### PR TITLE
add ability to invalidate a cookie that has domain set

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/cookie/CookieExtensions.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/cookie/CookieExtensions.kt
@@ -30,4 +30,4 @@ fun Response.cookies(): List<Cookie> = headerValues("set-cookie").filterNotNull(
 
 fun Cookie.invalidate(): Cookie = copy(value = "").maxAge(0).expires(LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC))
 
-fun Response.invalidateCookie(name: String): Response = replaceCookie(Cookie(name, "").invalidate())
+fun Response.invalidateCookie(name: String, domain: String? = null): Response = replaceCookie(Cookie(name, "", domain = domain).invalidate())

--- a/http4k-core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
@@ -141,9 +141,15 @@ class CookieTest {
     }
 
     @Test
-    fun `cookie can be invalidate at response level`() {
+    fun `cookie can be invalidated at response level`() {
         assertThat(Response(Status.OK).cookie(Cookie("foo", "bar").maxAge(10)).invalidateCookie("foo").cookies().first(),
             equalTo(Cookie("foo", "").invalidate()))
+    }
+
+    @Test
+    fun `cookie with domain can be invalidated at response level`() {
+        assertThat(Response(Status.OK).cookie(Cookie("foo", "bar", domain="foo.com").maxAge(10)).invalidateCookie("foo", "foo.com").cookies().first(),
+            equalTo(Cookie("foo", "", domain="foo.com").invalidate()))
     }
 
     @Test


### PR DESCRIPTION
This adds an optional parameter to set the domain when invalidating a cookie. When there's an existing cookie with a domain set, invalidating it with `Response.invalidateCookie(name: String)` won't work because the response cookie this adds doesn't include the domain.


