### PR TITLE
Http4kWebDriver follows redirects and sets cookies

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/ext.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ext.kt
@@ -1,0 +1,23 @@
+package org.http4k.core
+
+private fun Request.ensureValidMethod(): Request =
+    if (method == Method.GET || method == Method.HEAD) this else method(Method.GET)
+
+private fun Request.newLocation(location: String): Uri {
+    val locationUri = Uri.of(location)
+    return if (locationUri.host.isBlank()) {
+        locationUri.authority(uri.authority).scheme(uri.scheme)
+    } else locationUri
+}
+
+fun Request.toNewLocation(location: String) = ensureValidMethod().uri(newLocation(location))
+
+fun Response.location() = header("location")?.removeCharset().orEmpty()
+
+fun Response.assureBodyIsConsumed() = body.stream.close()
+
+fun Response.isRedirection(): Boolean {
+    return status.redirection && header("location")?.let(String::isNotBlank) == true
+}
+
+private fun String.removeCharset(): String = this.replace(";\\s*charset=.*$".toRegex(), "")

--- a/http4k-core/src/main/kotlin/org/http4k/core/ext.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ext.kt
@@ -1,6 +1,16 @@
 package org.http4k.core
 
-private fun Request.ensureValidMethod(): Request =
+fun Request.toNewLocation(location: String) = ensureValidMethodForRedirect().uri(newLocation(location))
+
+fun Response.location() = header("location")?.replace(";\\s*charset=.*$".toRegex(), "").orEmpty()
+
+fun Response.assureBodyIsConsumed() = body.stream.close()
+
+fun Response.isRedirection(): Boolean {
+    return status.redirection && header("location")?.let(String::isNotBlank) == true
+}
+
+private fun Request.ensureValidMethodForRedirect(): Request =
     if (method == Method.GET || method == Method.HEAD) this else method(Method.GET)
 
 private fun Request.newLocation(location: String): Uri {
@@ -10,14 +20,3 @@ private fun Request.newLocation(location: String): Uri {
     } else locationUri
 }
 
-fun Request.toNewLocation(location: String) = ensureValidMethod().uri(newLocation(location))
-
-fun Response.location() = header("location")?.removeCharset().orEmpty()
-
-fun Response.assureBodyIsConsumed() = body.stream.close()
-
-fun Response.isRedirection(): Boolean {
-    return status.redirection && header("location")?.let(String::isNotBlank) == true
-}
-
-private fun String.removeCharset(): String = this.replace(";\\s*charset=.*$".toRegex(), "")

--- a/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/Http4kWebDriver.kt
+++ b/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/Http4kWebDriver.kt
@@ -5,18 +5,12 @@ import org.http4k.core.*
 import org.http4k.core.Method.GET
 import org.http4k.core.cookie.cookie
 import org.http4k.core.cookie.cookies
-import org.http4k.filter.ClientFilters
-import org.openqa.selenium.Alert
-import org.openqa.selenium.By
-import org.openqa.selenium.Cookie
-import org.openqa.selenium.WebDriver
+import org.openqa.selenium.*
 import org.openqa.selenium.WebDriver.Navigation
-import org.openqa.selenium.WebElement
 import java.net.URL
 import java.nio.file.Paths
 import java.time.ZoneId
 import java.util.*
-import kotlin.NoSuchElementException
 import org.http4k.core.cookie.Cookie as HCookie
 
 
@@ -33,7 +27,7 @@ class Http4kWebDriver(private val handler: HttpHandler) : WebDriver {
         current = Page(response.status, this::navigateTo, UUID.randomUUID(), finalURI, response.bodyString(), current)
     }
 
-    private fun addCookiesToRequest(request: Request): Request{
+    private fun addCookiesToRequest(request: Request): Request {
         val normalizedPath = request.uri(request.uri.path(normalized(request.uri.path)))
         return siteCookies.entries.fold(normalizedPath) { memo, next -> memo.cookie(HCookie(next.key, next.value.value)) }
     }
@@ -41,19 +35,19 @@ class Http4kWebDriver(private val handler: HttpHandler) : WebDriver {
     private fun getResponseFollowingRedirects(request: Request, attempt: Int = 0): Pair<Response, String> {
 
         val res = handler(addCookiesToRequest(request))
-        res.cookies().forEach {
-            siteCookies.put(it.name, it.toWebDriver())
-        }
+        addCookies(res.cookies())
 
         return if (res.isRedirection()) {
             if (attempt == 10) throw IllegalStateException("Too many redirection")
             res.assureBodyIsConsumed()
-            val newRequest = request.toNewLocation(res.location())
-            getResponseFollowingRedirects(newRequest, attempt + 1)
+            getResponseFollowingRedirects(request.toNewLocation(res.location()), attempt + 1)
         } else {
             res to request.uri.toString()
         }
     }
+
+    private fun addCookies(cookies: List<org.http4k.core.cookie.Cookie>) =
+        cookies.forEach { siteCookies.put(it.name, it.toWebDriver()) }
 
     fun normalized(path: String): String {
         val newPath = if (path.startsWith("/")) Paths.get(path)

--- a/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/RedirectTest.kt
+++ b/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/RedirectTest.kt
@@ -27,7 +27,6 @@ class RedirectTest {
     private val driver = Http4kWebDriver(redirectingHandler)
 
     @Test
-    @Ignore
     fun `follows redirects and sets cookies`() {
         driver.get("/")
         assertThat(driver.currentUrl, equalTo("/final-destination"))

--- a/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/RedirectTest.kt
+++ b/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/RedirectTest.kt
@@ -12,6 +12,7 @@ import org.http4k.routing.bind
 import org.http4k.routing.routes
 import org.junit.Ignore
 import org.junit.Test
+import org.openqa.selenium.Cookie
 import org.http4k.core.cookie.Cookie as HCookie
 
 class RedirectTest {
@@ -30,6 +31,7 @@ class RedirectTest {
     fun `follows redirects and sets cookies`() {
         driver.get("/")
         assertThat(driver.currentUrl, equalTo("/final-destination"))
+        assertThat(driver.manage().cookies.contains(Cookie("http4k", "hello, cookie")), equalTo(true)) //todo: bleh
     }
 
 }

--- a/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/RedirectTest.kt
+++ b/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/RedirectTest.kt
@@ -1,0 +1,36 @@
+package org.http4k.webdriver
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.OK
+import org.http4k.core.Status.Companion.SEE_OTHER
+import org.http4k.core.cookie.cookie
+import org.http4k.routing.bind
+import org.http4k.routing.routes
+import org.junit.Ignore
+import org.junit.Test
+import org.http4k.core.cookie.Cookie as HCookie
+
+class RedirectTest {
+
+    private val redirectingHandler = routes(
+        "/final-destination" bind Method.GET to { _: Request -> Response(OK).body("You made it!") },
+        "/" bind Method.GET to { _: Request -> Response(SEE_OTHER)
+            .header("Location", "/final-destination")
+            .cookie(org.http4k.core.cookie.Cookie("http4k", "hello, cookie"))
+        }
+    )
+
+    private val driver = Http4kWebDriver(redirectingHandler)
+
+    @Test
+    @Ignore
+    fun `follows redirects and sets cookies`() {
+        driver.get("/")
+        assertThat(driver.currentUrl, equalTo("/final-destination"))
+    }
+
+}


### PR DESCRIPTION
This fixes a problem where `Http4kWebDriver` does not follow redirects. 

- Moved some code that is useful for this out of the ClientFilters into extension functions
- Ensure cookies get written between each redirected request