### PR TITLE
#13 Create extension methods for Response to add caching headers

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
@@ -1,11 +1,29 @@
 package org.http4k.core
 
-fun Response.noCache() = removeCachingHeaderIfSet().header("Cache-Control", "no-cache")
+fun Response.public() = addCachingHeader("public")
 
-fun Response.private() = removeCachingHeaderIfSet().header("Cache-Control", "private")
+fun Response.private() = addCachingHeader("private")
 
-fun Response.public() = removeCachingHeaderIfSet().header("Cache-Control", "public")
+fun Response.noCache() = addCachingHeader("no-cache")
 
-fun Response.onlyIfCached() = removeCachingHeaderIfSet().header("Cache-Control", "only-if-cached")
+fun Response.onlyIfCached() = addCachingHeader("only-if-cached")
 
-private fun Response.removeCachingHeaderIfSet(): Response = if(header("Cache-Control") != null) removeHeader("Cache-Control") else this
+fun Response.mustRevalidate() = addCachingHeader("must-revalidate")
+
+fun Response.noStore() = addCachingHeader("no-store")
+
+fun Response.noTransform() = addCachingHeader("no-transform")
+
+fun Response.proxyRevalidate() = addCachingHeader("proxy-revalidate")
+
+fun Response.maxAge(seconds: Int) = addCachingHeader("max-age=$seconds")
+
+fun Response.sMaxAge(seconds: Int) = addCachingHeader("s-maxage=$seconds")
+
+
+private fun Response.addCachingHeader(value: String) =
+        if(header("Cache-Control").isNullOrEmpty()) header("Cache-Control", value) else extendCachingHeader(value)
+
+private fun Response.extendCachingHeader(additionalValue: String) =
+        replaceHeader("Cache-Control", "${header("Cache-Control")}, $additionalValue")
+

--- a/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
@@ -1,0 +1,11 @@
+package org.http4k.core
+
+fun Response.noCache() = removeCachingHeaderIfSet().header("Cache-Control", "no-cache")
+
+fun Response.private() = removeCachingHeaderIfSet().header("Cache-Control", "private")
+
+fun Response.public() = removeCachingHeaderIfSet().header("Cache-Control", "public")
+
+fun Response.onlyIfCached() = removeCachingHeaderIfSet().header("Cache-Control", "only-if-cached")
+
+private fun Response.removeCachingHeaderIfSet(): Response = if(header("Cache-Control") != null) removeHeader("Cache-Control") else this

--- a/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
@@ -1,5 +1,8 @@
 package org.http4k.core
 
+import org.http4k.filter.MaxAgeTtl
+import java.time.Duration
+
 fun Response.public() = addCacheability(Cacheability.public)
 
 private fun Response.addCacheability(cacheability: Cacheability): Response =
@@ -16,7 +19,7 @@ fun Response.mustRevalidate() = addCachingHeader("must-revalidate")
 
 fun Response.noStore() = addCachingHeader("no-store")
 
-fun Response.maxAge(seconds: Int) = addCachingHeader("max-age=$seconds")
+fun Response.maxAge(duration: Duration) = replaceHeader("Cache-Control", MaxAgeTtl(duration).replaceIn(header("Cache-Control")))
 
 private fun Response.addCachingHeader(value: String) =
         if (header("Cache-Control").isNullOrEmpty()) header("Cache-Control", value) else extendCachingHeader(value)

--- a/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
@@ -1,6 +1,8 @@
 package org.http4k.core
 
 import org.http4k.filter.MaxAgeTtl
+import org.http4k.filter.StaleIfErrorTtl
+import org.http4k.filter.StaleWhenRevalidateTtl
 import java.time.Duration
 
 fun Response.public() = addCacheability(Cacheability.public)
@@ -14,12 +16,15 @@ fun Response.noCache() = addCacheability(Cacheability.`no-cache`)
 
 fun Response.onlyIfCached() = addCacheability(Cacheability.`only-if-cached`)
 
-
 fun Response.mustRevalidate() = addCachingHeader("must-revalidate")
 
 fun Response.noStore() = addCachingHeader("no-store")
 
 fun Response.maxAge(duration: Duration) = replaceHeader("Cache-Control", MaxAgeTtl(duration).replaceIn(header("Cache-Control")))
+
+fun Response.staleWhileRevalidate(duration: Duration) = replaceHeader("Cache-Control", StaleWhenRevalidateTtl(duration).replaceIn(header("Cache-Control")))
+
+fun Response.staleIfError(duration: Duration) = replaceHeader("Cache-Control", StaleIfErrorTtl(duration).replaceIn(header("Cache-Control")))
 
 private fun Response.addCachingHeader(value: String) =
         if (header("Cache-Control").isNullOrEmpty()) header("Cache-Control", value) else extendCachingHeader(value)

--- a/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
@@ -7,18 +7,15 @@ import java.time.Duration
 
 fun Response.public() = addCacheability(Cacheability.public)
 
-private fun Response.addCacheability(cacheability: Cacheability): Response =
-        replaceHeader("Cache-Control", cacheability(header("Cache-Control")))
-
 fun Response.private() = addCacheability(Cacheability.private)
 
-fun Response.noCache() = addCacheability(Cacheability.`no-cache`)
+fun Response.noCache() = addCacheability("no-cache")
 
-fun Response.onlyIfCached() = addCacheability(Cacheability.`only-if-cached`)
+fun Response.onlyIfCached() = addCacheability("only-if-cached")
 
-fun Response.mustRevalidate() = addCachingHeader("must-revalidate")
+fun Response.mustRevalidate() = addCacheability("must-revalidate")
 
-fun Response.noStore() = addCachingHeader("no-store")
+fun Response.noStore() = addCacheability("no-store")
 
 fun Response.maxAge(duration: Duration) = replaceHeader("Cache-Control", MaxAgeTtl(duration).replaceIn(header("Cache-Control")))
 
@@ -26,23 +23,24 @@ fun Response.staleWhileRevalidate(duration: Duration) = replaceHeader("Cache-Con
 
 fun Response.staleIfError(duration: Duration) = replaceHeader("Cache-Control", StaleIfErrorTtl(duration).replaceIn(header("Cache-Control")))
 
-private fun Response.addCachingHeader(value: String) =
-        if (header("Cache-Control").isNullOrEmpty()) header("Cache-Control", value) else extendCachingHeader(value)
+private fun Response.addCacheability(value: String): Response =
+        replaceHeader("Cache-Control", value.ensureOnlyOnceIn(header("Cache-Control")))
 
-private fun Response.extendCachingHeader(additionalValue: String) =
-        replaceHeader("Cache-Control", "${header("Cache-Control")}, $additionalValue")
+private fun Response.addCacheability(cacheability: Cacheability): Response =
+        replaceHeader("Cache-Control", cacheability(header("Cache-Control")))
 
 private enum class Cacheability {
     public,
-    `no-cache`,
-    private,
-    `only-if-cached`;
+    private;
 
     operator fun invoke(currentValue: String?): String =
             currentValue?.let {
                 val split = currentValue.split(",")
                 (listOf(name) + split
-                        .map { it.trim() }
+                        .map(String::trim)
                         .filterNot { values().map { it.name }.contains(it) }).joinToString(", ")
             } ?: name
 }
+
+private fun String.ensureOnlyOnceIn(currentValue: String?): String =
+        currentValue?.split(",")?.map(String::trim)?.toSet()?.plus(this)?.joinToString(", ") ?: this

--- a/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
@@ -1,29 +1,40 @@
 package org.http4k.core
 
-fun Response.public() = addCachingHeader("public")
+fun Response.public() = addCacheability(Cacheability.public)
 
-fun Response.private() = addCachingHeader("private")
+private fun Response.addCacheability(cacheability: Cacheability): Response =
+        replaceHeader("Cache-Control", cacheability(header("Cache-Control")))
 
-fun Response.noCache() = addCachingHeader("no-cache")
+fun Response.private() = addCacheability(Cacheability.private)
 
-fun Response.onlyIfCached() = addCachingHeader("only-if-cached")
+fun Response.noCache() = addCacheability(Cacheability.`no-cache`)
+
+fun Response.onlyIfCached() = addCacheability(Cacheability.`only-if-cached`)
+
 
 fun Response.mustRevalidate() = addCachingHeader("must-revalidate")
 
 fun Response.noStore() = addCachingHeader("no-store")
 
-fun Response.noTransform() = addCachingHeader("no-transform")
-
-fun Response.proxyRevalidate() = addCachingHeader("proxy-revalidate")
-
 fun Response.maxAge(seconds: Int) = addCachingHeader("max-age=$seconds")
 
-fun Response.sMaxAge(seconds: Int) = addCachingHeader("s-maxage=$seconds")
-
-
 private fun Response.addCachingHeader(value: String) =
-        if(header("Cache-Control").isNullOrEmpty()) header("Cache-Control", value) else extendCachingHeader(value)
+        if (header("Cache-Control").isNullOrEmpty()) header("Cache-Control", value) else extendCachingHeader(value)
 
 private fun Response.extendCachingHeader(additionalValue: String) =
         replaceHeader("Cache-Control", "${header("Cache-Control")}, $additionalValue")
 
+private enum class Cacheability {
+    public,
+    `no-cache`,
+    private,
+    `only-if-cached`;
+
+    operator fun invoke(currentValue: String?): String =
+            currentValue?.let {
+                val split = currentValue.split(",")
+                (listOf(name) + split
+                        .map { it.trim() }
+                        .filterNot { values().map { it.name }.contains(it) }).joinToString(", ")
+            } ?: name
+}

--- a/http4k-core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
@@ -13,6 +13,12 @@ import java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME
 
 open class CacheControlHeaderPart(open val name: String, val value: Duration) {
     fun toHeaderValue(): String = if (value.seconds > 0) "$name=${value.seconds}" else ""
+    fun replaceIn(header: String?): String? = header?.let {
+        header.split(",")
+                .map { it.trim() }
+                .filterNot { it.startsWith(name)} .plusElement(toHeaderValue())
+                .joinToString(", ")
+    } ?: toHeaderValue()
 }
 
 data class StaleWhenRevalidateTtl(private val valueD: Duration) : CacheControlHeaderPart("stale-while-revalidate", valueD)

--- a/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
@@ -79,8 +79,13 @@ class ResponseCacheExtTest {
 
     @Test
     fun `should overwrite existing headers with new values`() {
-        val chainedResponse = Response(Status.OK).public().private()
+        val chainedResponse = Response(Status.OK)
+                .public().private()
+                .noCache().noCache()
+                .noStore().noStore()
+                .maxAge(Duration.ofMinutes(1)).maxAge(Duration.ofMinutes(2))
+                .staleIfError(Duration.ofMinutes(2)).staleIfError(Duration.ofMinutes(2))
 
-        assertThat(chainedResponse.header("Cache-Control"), equalTo("private"))
+        assertThat(chainedResponse.header("Cache-Control"), equalTo("private, no-cache, no-store, max-age=120, stale-if-error=120"))
     }
 }

--- a/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
@@ -7,6 +7,20 @@ import org.junit.Test
 class ResponseCacheExtTest {
 
     @Test
+    fun `adds public to response Cache-Control header`() {
+        val publicResponse = Response(Status.OK).public()
+
+        assertThat(publicResponse.header("Cache-Control"), equalTo("public"))
+    }
+
+    @Test
+    fun `adds private to response Cache-Control header`() {
+        val privateResponse = Response(Status.OK).private()
+
+        assertThat(privateResponse.header("Cache-Control"), equalTo("private"))
+    }
+
+    @Test
     fun `adds no-cache to response Cache-Control header`() {
         val noCacheResponse = Response(Status.OK).noCache()
 
@@ -14,32 +28,58 @@ class ResponseCacheExtTest {
     }
 
     @Test
-    fun `adds private to response Cache-Control header`() {
-        val maxAgeResponse = Response(Status.OK).private()
-
-        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("private"))
-    }
-
-    @Test
-    fun `adds public to response Cache-Control header`() {
-        val maxAgeResponse = Response(Status.OK).public()
-
-        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("public"))
-    }
-
-    @Test
     fun `adds only-if-cached to response Cache-Control header`() {
-        val maxAgeResponse = Response(Status.OK).onlyIfCached()
+        val onlyIfCachedResponse = Response(Status.OK).onlyIfCached()
 
-        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("only-if-cached"))
+        assertThat(onlyIfCachedResponse.header("Cache-Control"), equalTo("only-if-cached"))
     }
 
     @Test
-    fun `overrides previous value if the header is already set`() {
-        val cacheControlAlreadySet = Response(Status.OK).header("Cache-Control", "max-age=100")
+    fun `adds must-revalidate to response Cache-Control header`() {
+        val mustRevalidateResponse = Response(Status.OK).mustRevalidate()
 
-        val noCacheResponse = cacheControlAlreadySet.noCache()
+        assertThat(mustRevalidateResponse.header("Cache-Control"), equalTo("must-revalidate"))
+    }
 
-        assertThat(noCacheResponse.header("Cache-Control"), equalTo("no-cache"))
+    @Test
+    fun `adds no-store to response Cache-Control header`() {
+        val noStoreResponse = Response(Status.OK).noStore()
+
+        assertThat(noStoreResponse.header("Cache-Control"), equalTo("no-store"))
+    }
+
+    @Test
+    fun `adds no-transform to response Cache-Control header`() {
+        val noTransformResponse = Response(Status.OK).noTransform()
+
+        assertThat(noTransformResponse.header("Cache-Control"), equalTo("no-transform"))
+    }
+
+    @Test
+    fun `adds proxy-revalidate to response Cache-Control header`() {
+        val proxyRevalidateResp = Response(Status.OK).proxyRevalidate()
+
+        assertThat(proxyRevalidateResp.header("Cache-Control"), equalTo("proxy-revalidate"))
+    }
+
+    @Test
+    fun `adds max-age to response Cache-Control header`() {
+        val maxAgeResponse = Response(Status.OK).maxAge(360)
+
+        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("max-age=360"))
+    }
+
+    @Test
+    fun `adds s-maxage to response Cache-Control header`() {
+        val sMaxAgeResponse = Response(Status.OK).sMaxAge(100)
+
+        assertThat(sMaxAgeResponse.header("Cache-Control"), equalTo("s-maxage=100"))
+    }
+
+    @Test
+    fun `can chain together multiple calls to add to the header`() {
+        val chainedResponse = Response(Status.OK).public().maxAge(60)
+
+        assertThat(chainedResponse.header("Cache-Control"), equalTo("public, max-age=60"))
     }
 }

--- a/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
@@ -57,10 +57,24 @@ class ResponseCacheExtTest {
     }
 
     @Test
-    fun `can chain together multiple calls to add to the header`() {
-        val chainedResponse = Response(Status.OK).public().maxAge(Duration.ofMinutes(1))
+    fun `adds stale-while-revalidate to response Cache-Control header`() {
+        val maxAgeResponse = Response(Status.OK).staleWhileRevalidate(Duration.ofMinutes(1))
 
-        assertThat(chainedResponse.header("Cache-Control"), equalTo("public, max-age=60"))
+        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("stale-while-revalidate=60"))
+    }
+
+    @Test
+    fun `adds stale-if-error to response Cache-Control header`() {
+        val maxAgeResponse = Response(Status.OK).staleIfError(Duration.ofMinutes(1))
+
+        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("stale-if-error=60"))
+    }
+
+    @Test
+    fun `can chain together multiple calls to add to the header`() {
+        val chainedResponse = Response(Status.OK).public().private().maxAge(Duration.ofMinutes(1)).maxAge(Duration.ofMinutes(2))
+
+        assertThat(chainedResponse.header("Cache-Control"), equalTo("private, max-age=120"))
     }
 
     @Test

--- a/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
@@ -3,6 +3,7 @@ package org.http4k.core
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.junit.Test
+import java.time.Duration
 
 class ResponseCacheExtTest {
 
@@ -50,14 +51,14 @@ class ResponseCacheExtTest {
 
     @Test
     fun `adds max-age to response Cache-Control header`() {
-        val maxAgeResponse = Response(Status.OK).maxAge(360)
+        val maxAgeResponse = Response(Status.OK).maxAge(Duration.ofMinutes(1))
 
-        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("max-age=360"))
+        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("max-age=60"))
     }
 
     @Test
     fun `can chain together multiple calls to add to the header`() {
-        val chainedResponse = Response(Status.OK).public().maxAge(60)
+        val chainedResponse = Response(Status.OK).public().maxAge(Duration.ofMinutes(1))
 
         assertThat(chainedResponse.header("Cache-Control"), equalTo("public, max-age=60"))
     }

--- a/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
@@ -1,0 +1,45 @@
+package org.http4k.core
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.Test
+
+class ResponseCacheExtTest {
+
+    @Test
+    fun `adds no-cache to response Cache-Control header`() {
+        val noCacheResponse = Response(Status.OK).noCache()
+
+        assertThat(noCacheResponse.header("Cache-Control"), equalTo("no-cache"))
+    }
+
+    @Test
+    fun `adds private to response Cache-Control header`() {
+        val maxAgeResponse = Response(Status.OK).private()
+
+        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("private"))
+    }
+
+    @Test
+    fun `adds public to response Cache-Control header`() {
+        val maxAgeResponse = Response(Status.OK).public()
+
+        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("public"))
+    }
+
+    @Test
+    fun `adds only-if-cached to response Cache-Control header`() {
+        val maxAgeResponse = Response(Status.OK).onlyIfCached()
+
+        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("only-if-cached"))
+    }
+
+    @Test
+    fun `overrides previous value if the header is already set`() {
+        val cacheControlAlreadySet = Response(Status.OK).header("Cache-Control", "max-age=100")
+
+        val noCacheResponse = cacheControlAlreadySet.noCache()
+
+        assertThat(noCacheResponse.header("Cache-Control"), equalTo("no-cache"))
+    }
+}

--- a/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
@@ -49,20 +49,6 @@ class ResponseCacheExtTest {
     }
 
     @Test
-    fun `adds no-transform to response Cache-Control header`() {
-        val noTransformResponse = Response(Status.OK).noTransform()
-
-        assertThat(noTransformResponse.header("Cache-Control"), equalTo("no-transform"))
-    }
-
-    @Test
-    fun `adds proxy-revalidate to response Cache-Control header`() {
-        val proxyRevalidateResp = Response(Status.OK).proxyRevalidate()
-
-        assertThat(proxyRevalidateResp.header("Cache-Control"), equalTo("proxy-revalidate"))
-    }
-
-    @Test
     fun `adds max-age to response Cache-Control header`() {
         val maxAgeResponse = Response(Status.OK).maxAge(360)
 
@@ -70,16 +56,16 @@ class ResponseCacheExtTest {
     }
 
     @Test
-    fun `adds s-maxage to response Cache-Control header`() {
-        val sMaxAgeResponse = Response(Status.OK).sMaxAge(100)
-
-        assertThat(sMaxAgeResponse.header("Cache-Control"), equalTo("s-maxage=100"))
-    }
-
-    @Test
     fun `can chain together multiple calls to add to the header`() {
         val chainedResponse = Response(Status.OK).public().maxAge(60)
 
         assertThat(chainedResponse.header("Cache-Control"), equalTo("public, max-age=60"))
+    }
+
+    @Test
+    fun `should overwrite existing headers with new values`() {
+        val chainedResponse = Response(Status.OK).public().private()
+
+        assertThat(chainedResponse.header("Cache-Control"), equalTo("private"))
     }
 }


### PR DESCRIPTION
Hey,

Saw you had an Hacktoberfest issue so thought i'd give it a punt.  Not sure if the location/filename of the ResponseCacheExt.kt is where you'd like it to be.  Also not sure if you'd want to allow the chaining conflicting headers (e.g. Response(OK).public().private() etc.) but left that up to the user.

Let me know what you think

Andy