### PR TITLE
Contract API reimplementation

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
@@ -16,7 +16,7 @@ class ContractRoute internal constructor(internal val method: Method,
                                          internal val toHandler: (ExtractedParts) -> HttpHandler,
                                          internal val meta: RouteMeta = RouteMeta()) {
 
-    internal val nonBodyParams = spec.requestParams.plus(spec.pathLenses).flatMap { it }
+    internal val nonBodyParams = spec.routeMeta.requestParams.plus(spec.pathLenses).flatMap { it }
 
     internal val jsonRequest: Request? = meta.request?.let { if (CONTENT_TYPE(it) == APPLICATION_JSON) it else null }
 

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
@@ -14,10 +14,10 @@ import org.http4k.routing.Router
 
 class ContractRoute internal constructor(internal val method: Method,
                                          internal val spec: ContractRouteSpec,
-                                         internal val toHandler: (ExtractedParts) -> HttpHandler,
-                                         internal val meta: RouteMeta = RouteMeta()) {
+                                         internal val meta: RouteMeta,
+                                         internal val toHandler: (ExtractedParts) -> HttpHandler) {
 
-    internal val nonBodyParams = spec.routeMeta.requestParams.plus(spec.pathLenses).flatMap { it }
+    internal val nonBodyParams = meta.requestParams.plus(spec.pathLenses).flatMap { it }
 
     internal val jsonRequest: Request? = meta.request?.let { if (CONTENT_TYPE(it) == APPLICATION_JSON) it else null }
 

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
@@ -1,60 +1,16 @@
 package org.http4k.contract
 
 
-import org.http4k.core.ContentType
 import org.http4k.core.ContentType.Companion.APPLICATION_JSON
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
-import org.http4k.core.Response
-import org.http4k.core.Status
 import org.http4k.core.Uri
 import org.http4k.core.then
-import org.http4k.core.with
-import org.http4k.lens.BiDiBodyLens
-import org.http4k.lens.BodyLens
-import org.http4k.lens.Header
 import org.http4k.lens.Header.Common.CONTENT_TYPE
-import org.http4k.lens.Lens
 import org.http4k.lens.LensFailure
 import org.http4k.lens.PathLens
 import org.http4k.routing.Router
-import org.http4k.util.Appendable
-
-class ContractRouteDsl internal constructor() {
-    var summary: String = "<unknown>"
-    var description: String? = null
-    var request: Request? = null
-    val tags = Appendable<Tag>()
-    val produces = Appendable<ContentType>()
-    val consumes = Appendable<ContentType>()
-    internal val responses = Appendable<Pair<Status, Pair<String, Response>>>()
-    var headers = Appendable<Lens<Request, *>>()
-    var queries = Appendable<Lens<Request, *>>()
-    var body: BodyLens<*>? = null
-
-    @JvmName("returningResponse")
-    fun returning(new: Pair<String, Response>) {
-        produces += (Header.Common.CONTENT_TYPE(new.second)?.let { listOf(it) } ?: emptyList())
-        responses += new.second.status to new
-    }
-
-    @JvmName("returningStatus")
-    fun returning(new: Pair<String, Status>) = returning(new.first to Response(new.second))
-
-    @JvmName("returningStatus")
-    fun returning(new: Status) = returning("" to Response(new))
-
-    fun <T> receiving(new: Pair<BiDiBodyLens<T>, T>) {
-        request = Request(Method.GET, "").with(new.first of new.second)
-    }
-}
-
-fun contractRoute(fn: ContractRouteDsl.() -> Unit = {}) = ContractRouteDsl().apply(fn).run {
-    ContractRouteSpec0({ it }, RouteMeta(
-        summary, description, request, tags.all.toSet(), body, produces.all.toSet(), consumes.all.toSet(), queries.all.plus(headers.all), responses.all.toMap()
-    ))
-}
 
 class ContractRoute internal constructor(internal val method: Method,
                                          internal val spec: ContractRouteSpec,

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoutingHttpHandler.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoutingHttpHandler.kt
@@ -27,7 +27,7 @@ data class ContractRoutingHttpHandler(private val renderer: ContractRenderer,
 
     override fun invoke(request: Request): Response = handler(request)
 
-    private val descriptionRoute = ContractRouteSpec0({ PathSegments("$it$descriptionPath") }, emptyList(), null) bindContract GET to { renderer.description(contractRoot, security, routes) }
+    private val descriptionRoute = ContractRouteSpec0({ PathSegments("$it$descriptionPath") }, emptyList(), null, RouteMeta()) bindContract GET to { renderer.description(contractRoot, security, routes) }
 
     private val routers = routes
         .map { it.toRouter(contractRoot) to CatchLensFailure.then(security.filter).then(identify(it)).then(filter) }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoutingHttpHandler.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoutingHttpHandler.kt
@@ -27,7 +27,7 @@ data class ContractRoutingHttpHandler(private val renderer: ContractRenderer,
 
     override fun invoke(request: Request): Response = handler(request)
 
-    private val descriptionRoute = ContractRouteSpec0({ PathSegments("$it$descriptionPath") }, emptyList(), null, RouteMeta()) bindContract GET to { renderer.description(contractRoot, security, routes) }
+    private val descriptionRoute = ContractRouteSpec0({ PathSegments("$it$descriptionPath") }, RouteMeta()) bindContract GET to { renderer.description(contractRoot, security, routes) }
 
     private val routers = routes
         .map { it.toRouter(contractRoot) to CatchLensFailure.then(security.filter).then(identify(it)).then(filter) }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/OpenApi.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/OpenApi.kt
@@ -58,12 +58,12 @@ class OpenApi<ROOT : NODE, out NODE : Any>(private val apiInfo: ApiInfo, private
 
         val schema = route.jsonRequest?.asSchema()
 
-        val bodyParamNodes = route.spec.body?.metas?.map { renderMeta(it, schema) } ?: emptyList()
+        val bodyParamNodes = route.spec.routeMeta.body?.metas?.map { renderMeta(it, schema) } ?: emptyList()
 
         val nonBodyParamNodes = route.nonBodyParams.flatMap { it.asList() }.map { renderMeta(it) }
 
         val routeTags = if (route.tags.isEmpty()) listOf(json.string(pathSegments.toString())) else route.tagsAsJson()
-        val consumes = route.meta.consumes.plus(route.spec.body?.let { listOf(it.contentType) } ?: emptyList())
+        val consumes = route.meta.consumes.plus(route.spec.routeMeta.body?.let { listOf(it.contentType) } ?: emptyList())
 
         val pathJson = json.obj(
             "tags" to json.array(routeTags),

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/deprecated.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/deprecated.kt
@@ -59,4 +59,4 @@ infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.header(new: HeaderLens<*>)
 infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.body(new: BodyLens<*>) = ContractRouteSpec4(pathFn, routeMeta + new, a, b, c, d)
 
 @Deprecated("use ContractRouteSpec.meta instead to define contract")
-infix fun ContractRoute.meta(new: RouteMeta) = ContractRoute(method, spec, toHandler, new)
+infix fun ContractRoute.meta(new: RouteMeta) = ContractRoute(method, spec, new, toHandler)

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/deprecated.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/deprecated.kt
@@ -60,5 +60,3 @@ infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.body(new: BodyLens<*>) = C
 
 @Deprecated("use ContractRouteSpec.meta instead to define contract")
 infix fun ContractRoute.meta(new: RouteMeta) = ContractRoute(method, spec, toHandler, new)
-
-private fun toBaseFn(path: String): (PathSegments) -> PathSegments = PathSegments(path).let { { old: PathSegments -> old / it } }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/deprecated.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/deprecated.kt
@@ -1,0 +1,64 @@
+package org.http4k.contract
+
+import org.http4k.lens.BodyLens
+import org.http4k.lens.HeaderLens
+import org.http4k.lens.QueryLens
+
+@Deprecated("use String.meta instead to define contract")
+infix fun String.query(new: QueryLens<*>) = ContractRouteSpec0(toBaseFn(this), RouteMeta(requestParams = listOf(new)))
+
+@Deprecated("use String.meta instead to define contract")
+infix fun String.header(new: HeaderLens<*>) = ContractRouteSpec0(toBaseFn(this), RouteMeta(requestParams = listOf(new)))
+
+@Deprecated("use String.meta instead to define contract")
+infix fun String.body(new: BodyLens<*>) = ContractRouteSpec0(toBaseFn(this), RouteMeta(body = new))
+
+@Deprecated("use ContractRouteSpec0.meta instead to define contract")
+infix fun ContractRouteSpec0.query(new: QueryLens<*>) = ContractRouteSpec0(pathFn, routeMeta + new)
+
+@Deprecated("use ContractRouteSpec0.meta instead to define contract")
+infix fun ContractRouteSpec0.header(new: HeaderLens<*>) = ContractRouteSpec0(pathFn, routeMeta + new)
+
+@Deprecated("use ContractRouteSpec0.meta instead to define contract")
+infix fun ContractRouteSpec0.body(new: BodyLens<*>) = ContractRouteSpec0(pathFn, routeMeta.copy(body = new))
+
+@Deprecated("use ContractRouteSpec1.meta instead to define contract")
+infix fun <A> ContractRouteSpec1<A>.query(new: QueryLens<*>) = ContractRouteSpec1(pathFn, routeMeta + new, a)
+
+@Deprecated("use ContractRouteSpec1.meta instead to define contract")
+infix fun <A> ContractRouteSpec1<A>.header(new: HeaderLens<*>) = ContractRouteSpec1(pathFn, routeMeta + new, a)
+
+@Deprecated("use ContractRouteSpec1.meta instead to define contract")
+infix fun <A> ContractRouteSpec1<A>.body(new: BodyLens<*>) = ContractRouteSpec1(pathFn, routeMeta + new, a)
+
+@Deprecated("use ContractRouteSpec2.meta instead to define contract")
+infix fun <A, B> ContractRouteSpec2<A, B>.query(new: QueryLens<*>) = ContractRouteSpec2(pathFn, routeMeta + new, a, b)
+
+@Deprecated("use ContractRouteSpec2.meta instead to define contract")
+infix fun <A, B> ContractRouteSpec2<A, B>.header(new: HeaderLens<*>) = ContractRouteSpec2(pathFn, routeMeta + new, a, b)
+
+@Deprecated("use ContractRouteSpec2.meta instead to define contract")
+infix fun <A, B> ContractRouteSpec2<A, B>.body(new: BodyLens<*>) = ContractRouteSpec2(pathFn, routeMeta + new, a, b)
+
+@Deprecated("use ContractRouteSpec3.meta instead to define contract")
+infix fun <A, B, C> ContractRouteSpec3<A, B, C>.query(new: QueryLens<*>) = ContractRouteSpec3(pathFn, routeMeta + new, a, b, c)
+
+@Deprecated("use ContractRouteSpec3.meta instead to define contract")
+infix fun <A, B, C> ContractRouteSpec3<A, B, C>.header(new: HeaderLens<*>) = ContractRouteSpec3(pathFn, routeMeta + new, a, b, c)
+
+@Deprecated("use ContractRouteSpec3.meta instead to define contract")
+infix fun <A, B, C> ContractRouteSpec3<A, B, C>.body(new: BodyLens<*>) = ContractRouteSpec3(pathFn, routeMeta + new, a, b, c)
+
+@Deprecated("use ContractRouteSpec4.meta instead to define contract")
+infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.query(new: QueryLens<*>) = ContractRouteSpec4(pathFn, routeMeta + new, a, b, c, d)
+
+@Deprecated("use ContractRouteSpec4.meta instead to define contract")
+infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.header(new: HeaderLens<*>) = ContractRouteSpec4(pathFn, routeMeta + new, a, b, c, d)
+
+@Deprecated("use ContractRouteSpec4.meta instead to define contract")
+infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.body(new: BodyLens<*>) = ContractRouteSpec4(pathFn, routeMeta + new, a, b, c, d)
+
+@Deprecated("use ContractRouteSpec.meta instead to define contract")
+infix fun ContractRoute.meta(new: RouteMeta) = ContractRoute(method, spec, toHandler, new)
+
+private fun toBaseFn(path: String): (PathSegments) -> PathSegments = PathSegments(path).let { { old: PathSegments -> old / it } }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
@@ -67,13 +67,13 @@ infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.bindContract(method: Metho
     }
 }
 
-// TODO deprecate or remove??
-@JvmName("handler0String")
-infix fun Pair<String, Method>.bind(handler: HttpHandler) = ContractRouteSpec0(toBaseFn(first), RouteMeta()).bindContract(second) to handler
-
-// TODO deprecate or remove??
-@JvmName("handler1Path")
-infix fun <A> Pair<PathLens<A>, Method>.bind(fn: (A) -> HttpHandler) = ContractRouteSpec1({ it }, RouteMeta(), first).bindContract(second) to fn
+//// TODO deprecate or remove??
+//@JvmName("handler0String")
+//infix fun Pair<String, Method>.bind(handler: HttpHandler) = ContractRouteSpec0(toBaseFn(first), RouteMeta()).bindContract(second) to handler
+//
+//// TODO deprecate or remove??
+//@JvmName("handler1Path")
+//infix fun <A> Pair<PathLens<A>, Method>.bind(fn: (A) -> HttpHandler) = ContractRouteSpec1({ it }, RouteMeta(), first).bindContract(second) to fn
 
 infix fun String.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec0(toBaseFn(this), metaDsl(new))
 infix fun ContractRouteSpec0.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec0(pathFn, metaDsl(new))
@@ -82,4 +82,4 @@ infix fun <A, B> ContractRouteSpec2<A, B>.meta(new: RouteMetaDsl.() -> Unit) = C
 infix fun <A, B, C> ContractRouteSpec3<A, B, C>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec3(pathFn, metaDsl(new), a, b, c)
 infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec4(pathFn, metaDsl(new), a, b, c, d)
 
-private fun toBaseFn(path: String): (PathSegments) -> PathSegments = PathSegments(path).let { { old: PathSegments -> old / it } }
+internal fun toBaseFn(path: String): (PathSegments) -> PathSegments = PathSegments(path).let { { old: PathSegments -> old / it } }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
@@ -6,10 +6,7 @@ import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
 import org.http4k.core.Uri
-import org.http4k.lens.BodyLens
-import org.http4k.lens.HeaderLens
 import org.http4k.lens.PathLens
-import org.http4k.lens.QueryLens
 
 fun contract(vararg serverRoutes: ContractRoute) = contract(NoRenderer, "", NoSecurity, *serverRoutes)
 fun contract(renderer: ContractRenderer, vararg serverRoutes: ContractRoute) = contract(renderer, "", NoSecurity, *serverRoutes)
@@ -78,30 +75,11 @@ infix fun Pair<String, Method>.bind(handler: HttpHandler) = ContractRouteSpec0(t
 @JvmName("handler1Path")
 infix fun <A> Pair<PathLens<A>, Method>.bind(fn: (A) -> HttpHandler) = ContractRouteSpec1({ it }, RouteMeta(), first).bindContract(second) to fn
 
-infix fun String.query(new: QueryLens<*>) = ContractRouteSpec0(toBaseFn(this), RouteMeta(requestParams = listOf(new)))
-infix fun String.header(new: HeaderLens<*>) = ContractRouteSpec0(toBaseFn(this), RouteMeta(requestParams = listOf(new)))
-infix fun String.body(new: BodyLens<*>) = ContractRouteSpec0(toBaseFn(this), RouteMeta(body = new))
-
-infix fun ContractRouteSpec0.query(new: QueryLens<*>) = ContractRouteSpec0(pathFn, routeMeta + new)
-infix fun ContractRouteSpec0.header(new: HeaderLens<*>) = ContractRouteSpec0(pathFn, routeMeta + new)
-infix fun ContractRouteSpec0.body(new: BodyLens<*>) = ContractRouteSpec0(pathFn, routeMeta.copy(body = new))
-
-infix fun <A> ContractRouteSpec1<A>.query(new: QueryLens<*>) = ContractRouteSpec1(pathFn, routeMeta + new, a)
-infix fun <A> ContractRouteSpec1<A>.header(new: HeaderLens<*>) = ContractRouteSpec1(pathFn, routeMeta + new, a)
-infix fun <A> ContractRouteSpec1<A>.body(new: BodyLens<*>) = ContractRouteSpec1(pathFn, routeMeta + new, a)
-
-infix fun <A, B> ContractRouteSpec2<A, B>.query(new: QueryLens<*>) = ContractRouteSpec2(pathFn, routeMeta + new, a, b)
-infix fun <A, B> ContractRouteSpec2<A, B>.header(new: HeaderLens<*>) = ContractRouteSpec2(pathFn, routeMeta + new, a, b)
-infix fun <A, B> ContractRouteSpec2<A, B>.body(new: BodyLens<*>) = ContractRouteSpec2(pathFn, routeMeta + new, a, b)
-
-infix fun <A, B, C> ContractRouteSpec3<A, B, C>.query(new: QueryLens<*>) = ContractRouteSpec3(pathFn, routeMeta + new, a, b, c)
-infix fun <A, B, C> ContractRouteSpec3<A, B, C>.header(new: HeaderLens<*>) = ContractRouteSpec3(pathFn, routeMeta + new, a, b, c)
-infix fun <A, B, C> ContractRouteSpec3<A, B, C>.body(new: BodyLens<*>) = ContractRouteSpec3(pathFn, routeMeta + new, a, b, c)
-
-infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.query(new: QueryLens<*>) = ContractRouteSpec4(pathFn, routeMeta + new, a, b, c, d)
-infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.header(new: HeaderLens<*>) = ContractRouteSpec4(pathFn, routeMeta + new, a, b, c, d)
-infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.body(new: BodyLens<*>) = ContractRouteSpec4(pathFn, routeMeta + new, a, b, c, d)
-
-infix fun ContractRoute.meta(new: RouteMeta) = ContractRoute(method, spec, toHandler, new)
+infix fun String.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec0(toBaseFn(this), metaDsl(new))
+infix fun ContractRouteSpec0.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec0(pathFn, metaDsl(new))
+infix fun <A> ContractRouteSpec1<A>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec1(pathFn, metaDsl(new), a)
+infix fun <A, B> ContractRouteSpec2<A, B>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec2(pathFn, metaDsl(new), a, b)
+infix fun <A, B, C> ContractRouteSpec3<A, B, C>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec3(pathFn, metaDsl(new), a, b, c)
+infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec4(pathFn, metaDsl(new), a, b, c, d)
 
 private fun toBaseFn(path: String): (PathSegments) -> PathSegments = PathSegments(path).let { { old: PathSegments -> old / it } }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
@@ -17,9 +17,9 @@ fun contract(renderer: ContractRenderer, descriptionPath: String, vararg serverR
 fun contract(renderer: ContractRenderer = NoRenderer, descriptionPath: String = "", security: Security = NoSecurity, vararg serverRoutes: ContractRoute) =
     ContractRoutingHttpHandler(renderer, security, descriptionPath, "", serverRoutes.map { it }, Filter { { req -> it(req) } })
 
-operator fun <A> String.div(next: PathLens<A>): ContractRouteSpec1<A> = ContractRouteSpec0(toBaseFn(this), emptyList(), null) / next
+operator fun <A> String.div(next: PathLens<A>): ContractRouteSpec1<A> = ContractRouteSpec0(toBaseFn(this), emptyList(), null, RouteMeta()) / next
 
-operator fun <A, B> PathLens<A>.div(next: PathLens<B>): ContractRouteSpec2<A, B> = ContractRouteSpec1({ it }, emptyList(), null, this) / next
+operator fun <A, B> PathLens<A>.div(next: PathLens<B>): ContractRouteSpec2<A, B> = ContractRouteSpec1({ it }, emptyList(), null, RouteMeta(), this) / next
 
 infix fun String.bind(router: ContractRoutingHttpHandler): ContractRoutingHttpHandler = router.withBasePath(this)
 
@@ -28,10 +28,10 @@ interface RouteBinder<in T> {
     infix fun to(fn: T): ContractRoute
 }
 
-infix fun <A> PathLens<A>.bindContract(method: Method) = ContractRouteSpec1({ it }, emptyList(), null, this).bindContract(method)
+infix fun <A> PathLens<A>.bindContract(method: Method) = ContractRouteSpec1({ it }, emptyList(), null, RouteMeta(), this).bindContract(method)
 
 
-infix fun String.bindContract(method: Method): RouteBinder<HttpHandler> = ContractRouteSpec0(toBaseFn(this), emptyList(), null).bindContract(method)
+infix fun String.bindContract(method: Method): RouteBinder<HttpHandler> = ContractRouteSpec0(toBaseFn(this), emptyList(), null, RouteMeta()).bindContract(method)
 
 infix fun ContractRouteSpec0.bindContract(method: Method) = let { spec ->
     object : RouteBinder<HttpHandler> {
@@ -72,35 +72,35 @@ infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.bindContract(method: Metho
 
 // TODO deprecate or remove??
 @JvmName("handler0String")
-infix fun Pair<String, Method>.bind(handler: HttpHandler) = ContractRouteSpec0(toBaseFn(first), emptyList(), null).bindContract(second) to handler
+infix fun Pair<String, Method>.bind(handler: HttpHandler) = ContractRouteSpec0(toBaseFn(first), emptyList(), null, RouteMeta()).bindContract(second) to handler
 
 // TODO deprecate or remove??
 @JvmName("handler1Path")
-infix fun <A> Pair<PathLens<A>, Method>.bind(fn: (A) -> HttpHandler) = ContractRouteSpec1({ it }, emptyList(), null, first).bindContract(second) to fn
+infix fun <A> Pair<PathLens<A>, Method>.bind(fn: (A) -> HttpHandler) = ContractRouteSpec1({ it }, emptyList(), null, RouteMeta(), first).bindContract(second) to fn
 
-infix fun String.query(new: QueryLens<*>) = ContractRouteSpec0(toBaseFn(this), listOf(new), null)
-infix fun String.header(new: HeaderLens<*>) = ContractRouteSpec0(toBaseFn(this), listOf(new), null)
-infix fun String.body(new: BodyLens<*>) = ContractRouteSpec0(toBaseFn(this), emptyList(), new)
+infix fun String.query(new: QueryLens<*>) = ContractRouteSpec0(toBaseFn(this), listOf(new), null, RouteMeta())
+infix fun String.header(new: HeaderLens<*>) = ContractRouteSpec0(toBaseFn(this), listOf(new), null, RouteMeta())
+infix fun String.body(new: BodyLens<*>) = ContractRouteSpec0(toBaseFn(this), emptyList(), new, RouteMeta())
 
-infix fun ContractRouteSpec0.query(new: QueryLens<*>) = ContractRouteSpec0(pathFn, requestParams.plus(listOf(new)), body)
-infix fun ContractRouteSpec0.header(new: HeaderLens<*>) = ContractRouteSpec0(pathFn, requestParams.plus(listOf(new)), body)
-infix fun ContractRouteSpec0.body(new: BodyLens<*>) = ContractRouteSpec0(pathFn, requestParams, new)
+infix fun ContractRouteSpec0.query(new: QueryLens<*>) = ContractRouteSpec0(pathFn, requestParams.plus(listOf(new)), body, routeMeta)
+infix fun ContractRouteSpec0.header(new: HeaderLens<*>) = ContractRouteSpec0(pathFn, requestParams.plus(listOf(new)), body, routeMeta)
+infix fun ContractRouteSpec0.body(new: BodyLens<*>) = ContractRouteSpec0(pathFn, requestParams, new, routeMeta)
 
-infix fun <A> ContractRouteSpec1<A>.query(new: QueryLens<*>) = ContractRouteSpec1(pathFn, requestParams.plus(listOf(new)), body, a)
-infix fun <A> ContractRouteSpec1<A>.header(new: HeaderLens<*>) = ContractRouteSpec1(pathFn, requestParams.plus(listOf(new)), body, a)
-infix fun <A> ContractRouteSpec1<A>.body(new: BodyLens<*>) = ContractRouteSpec1(pathFn, requestParams, new, a)
+infix fun <A> ContractRouteSpec1<A>.query(new: QueryLens<*>) = ContractRouteSpec1(pathFn, requestParams.plus(listOf(new)), body, routeMeta, a)
+infix fun <A> ContractRouteSpec1<A>.header(new: HeaderLens<*>) = ContractRouteSpec1(pathFn, requestParams.plus(listOf(new)), body, routeMeta, a)
+infix fun <A> ContractRouteSpec1<A>.body(new: BodyLens<*>) = ContractRouteSpec1(pathFn, requestParams, new, routeMeta, a)
 
-infix fun <A, B> ContractRouteSpec2<A, B>.query(new: QueryLens<*>) = ContractRouteSpec2(pathFn, requestParams.plus(listOf(new)), body, a, b)
-infix fun <A, B> ContractRouteSpec2<A, B>.header(new: HeaderLens<*>) = ContractRouteSpec2(pathFn, requestParams.plus(listOf(new)), body, a, b)
-infix fun <A, B> ContractRouteSpec2<A, B>.body(new: BodyLens<*>) = ContractRouteSpec2(pathFn, requestParams, new, a, b)
+infix fun <A, B> ContractRouteSpec2<A, B>.query(new: QueryLens<*>) = ContractRouteSpec2(pathFn, requestParams.plus(listOf(new)), body, routeMeta, a, b)
+infix fun <A, B> ContractRouteSpec2<A, B>.header(new: HeaderLens<*>) = ContractRouteSpec2(pathFn, requestParams.plus(listOf(new)), body, routeMeta, a, b)
+infix fun <A, B> ContractRouteSpec2<A, B>.body(new: BodyLens<*>) = ContractRouteSpec2(pathFn, requestParams, new, routeMeta, a, b)
 
-infix fun <A, B, C> ContractRouteSpec3<A, B, C>.query(new: QueryLens<*>) = ContractRouteSpec3(pathFn, requestParams.plus(listOf(new)), body, a, b, c)
-infix fun <A, B, C> ContractRouteSpec3<A, B, C>.header(new: HeaderLens<*>) = ContractRouteSpec3(pathFn, requestParams.plus(listOf(new)), body, a, b, c)
-infix fun <A, B, C> ContractRouteSpec3<A, B, C>.body(new: BodyLens<*>) = ContractRouteSpec3(pathFn, requestParams, new, a, b, c)
+infix fun <A, B, C> ContractRouteSpec3<A, B, C>.query(new: QueryLens<*>) = ContractRouteSpec3(pathFn, requestParams.plus(listOf(new)), body, routeMeta, a, b, c)
+infix fun <A, B, C> ContractRouteSpec3<A, B, C>.header(new: HeaderLens<*>) = ContractRouteSpec3(pathFn, requestParams.plus(listOf(new)), body, routeMeta, a, b, c)
+infix fun <A, B, C> ContractRouteSpec3<A, B, C>.body(new: BodyLens<*>) = ContractRouteSpec3(pathFn, requestParams, new, routeMeta, a, b, c)
 
-infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.query(new: QueryLens<*>) = ContractRouteSpec4(pathFn, requestParams.plus(listOf(new)), body, a, b, c, d)
-infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.header(new: HeaderLens<*>) = ContractRouteSpec4(pathFn, requestParams.plus(listOf(new)), body, a, b, c, d)
-infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.body(new: BodyLens<*>) = ContractRouteSpec4(pathFn, requestParams, new, a, b, c, d)
+infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.query(new: QueryLens<*>) = ContractRouteSpec4(pathFn, requestParams.plus(listOf(new)), body, routeMeta, a, b, c, d)
+infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.header(new: HeaderLens<*>) = ContractRouteSpec4(pathFn, requestParams.plus(listOf(new)), body, routeMeta, a, b, c, d)
+infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.body(new: BodyLens<*>) = ContractRouteSpec4(pathFn, requestParams, new, routeMeta, a, b, c, d)
 
 infix fun ContractRoute.meta(new: RouteMeta) = ContractRoute(method, spec, toHandler, new)
 

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
@@ -34,7 +34,7 @@ infix fun ContractRouteSpec0.bindContract(method: Method) = let { spec ->
     object : RouteBinder<HttpHandler> {
         override fun newRequest(baseUri: Uri) = Request(method, "").uri(baseUri.path(spec.describe(Root)))
 
-        override fun to(fn: HttpHandler): ContractRoute = ContractRoute(method, spec, { fn })
+        override fun to(fn: HttpHandler): ContractRoute = ContractRoute(method, spec, spec.routeMeta, { fn })
     }
 }
 
@@ -42,44 +42,36 @@ infix fun <A> ContractRouteSpec1<A>.bindContract(method: Method) = let { spec ->
     object : RouteBinder<(A) -> HttpHandler> {
         override fun newRequest(baseUri: Uri) = Request(method, "").uri(baseUri.path(spec.describe(Root)))
 
-        override fun to(fn: (A) -> HttpHandler): ContractRoute = ContractRoute(method, spec, { fn(it[spec.a]) })
+        override fun to(fn: (A) -> HttpHandler): ContractRoute = ContractRoute(method, spec, spec.routeMeta, { fn(it[spec.a]) })
     }
 }
 
 infix fun <A, B> ContractRouteSpec2<A, B>.bindContract(method: Method) = let { spec ->
     object : RouteBinder<(A, B) -> HttpHandler> {
         override fun newRequest(baseUri: Uri) = Request(method, "").uri(baseUri.path(spec.describe(Root)))
-        override fun to(fn: (A, B) -> HttpHandler): ContractRoute = ContractRoute(method, spec, { fn(it[spec.a], it[spec.b]) })
+        override fun to(fn: (A, B) -> HttpHandler): ContractRoute = ContractRoute(method, spec, spec.routeMeta, { fn(it[spec.a], it[spec.b]) })
     }
 }
 
 infix fun <A, B, C> ContractRouteSpec3<A, B, C>.bindContract(method: Method) = let { spec ->
     object : RouteBinder<(A, B, C) -> HttpHandler> {
         override fun newRequest(baseUri: Uri) = Request(method, "").uri(baseUri.path(spec.describe(Root)))
-        override fun to(fn: (A, B, C) -> HttpHandler): ContractRoute = ContractRoute(method, spec, { fn(it[spec.a], it[spec.b], it[spec.c]) })
+        override fun to(fn: (A, B, C) -> HttpHandler): ContractRoute = ContractRoute(method, spec, spec.routeMeta, { fn(it[spec.a], it[spec.b], it[spec.c]) })
     }
 }
 
 infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.bindContract(method: Method) = let { spec ->
     object : RouteBinder<(A, B, C, D) -> HttpHandler> {
         override fun newRequest(baseUri: Uri): Request = Request(method, "").uri(baseUri.path(spec.describe(Root)))
-        override fun to(fn: (A, B, C, D) -> HttpHandler): ContractRoute = ContractRoute(method, spec, { fn(it[spec.a], it[spec.b], it[spec.c], it[spec.d]) })
+        override fun to(fn: (A, B, C, D) -> HttpHandler): ContractRoute = ContractRoute(method, spec, spec.routeMeta, { fn(it[spec.a], it[spec.b], it[spec.c], it[spec.d]) })
     }
 }
 
-//// TODO deprecate or remove??
-//@JvmName("handler0String")
-//infix fun Pair<String, Method>.bind(handler: HttpHandler) = ContractRouteSpec0(toBaseFn(first), RouteMeta()).bindContract(second) to handler
-//
-//// TODO deprecate or remove??
-//@JvmName("handler1Path")
-//infix fun <A> Pair<PathLens<A>, Method>.bind(fn: (A) -> HttpHandler) = ContractRouteSpec1({ it }, RouteMeta(), first).bindContract(second) to fn
-
-infix fun String.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec0(toBaseFn(this), metaDsl(new))
-infix fun ContractRouteSpec0.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec0(pathFn, metaDsl(new))
-infix fun <A> ContractRouteSpec1<A>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec1(pathFn, metaDsl(new), a)
-infix fun <A, B> ContractRouteSpec2<A, B>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec2(pathFn, metaDsl(new), a, b)
-infix fun <A, B, C> ContractRouteSpec3<A, B, C>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec3(pathFn, metaDsl(new), a, b, c)
-infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec4(pathFn, metaDsl(new), a, b, c, d)
+infix fun String.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec0(toBaseFn(this), routeMetaDsl(new))
+infix fun ContractRouteSpec0.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec0(pathFn, routeMetaDsl(new))
+infix fun <A> ContractRouteSpec1<A>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec1(pathFn, routeMetaDsl(new), a)
+infix fun <A, B> ContractRouteSpec2<A, B>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec2(pathFn, routeMetaDsl(new), a, b)
+infix fun <A, B, C> ContractRouteSpec3<A, B, C>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec3(pathFn, routeMetaDsl(new), a, b, c)
+infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec4(pathFn, routeMetaDsl(new), a, b, c, d)
 
 internal fun toBaseFn(path: String): (PathSegments) -> PathSegments = PathSegments(path).let { { old: PathSegments -> old / it } }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
@@ -1,6 +1,7 @@
 package org.http4k.contract
 
 import org.http4k.core.ContentType
+import org.http4k.core.Method
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Response
@@ -10,7 +11,42 @@ import org.http4k.lens.BiDiBodyLens
 import org.http4k.lens.BodyLens
 import org.http4k.lens.Header
 import org.http4k.lens.Lens
+import org.http4k.util.Appendable
 
+class RouteMetaDsl internal constructor() {
+    var summary: String = "<unknown>"
+    var description: String? = null
+    var request: Request? = null
+    val tags = Appendable<Tag>()
+    val produces = Appendable<ContentType>()
+    val consumes = Appendable<ContentType>()
+    internal val responses = Appendable<Pair<Status, Pair<String, Response>>>()
+    var headers = Appendable<Lens<Request, *>>()
+    var queries = Appendable<Lens<Request, *>>()
+    var body: BodyLens<*>? = null
+
+    @JvmName("returningResponse")
+    fun returning(new: Pair<String, Response>) {
+        produces += (Header.Common.CONTENT_TYPE(new.second)?.let { listOf(it) } ?: emptyList())
+        responses += new.second.status to new
+    }
+
+    @JvmName("returningStatus")
+    fun returning(new: Pair<String, Status>) = returning(new.first to Response(new.second))
+
+    @JvmName("returningStatus")
+    fun returning(new: Status) = returning("" to Response(new))
+
+    fun <T> receiving(new: Pair<BiDiBodyLens<T>, T>) {
+        request = Request(Method.GET, "").with(new.first of new.second)
+    }
+}
+
+fun metaDsl(fn: RouteMetaDsl.() -> Unit = {}) = RouteMetaDsl().apply(fn).run {
+    RouteMeta(
+        summary, description, request, tags.all.toSet(), body, produces.all.toSet(), consumes.all.toSet(), queries.all + headers.all, responses.all.toMap()
+    )
+}
 data class Tag(val name: String, val description: String? = null)
 
 data class RouteMeta(val summary: String = "<unknown>",

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
@@ -44,39 +44,4 @@ data class RouteMeta(val summary: String = "<unknown>",
 
     fun producing(vararg new: ContentType) = copy(produces = produces.plus(new))
     fun consuming(vararg new: ContentType) = copy(consumes = consumes.plus(new))
-
-
-}
-
-class MetaDsl {
-    var summary: String = "<unknown>"
-    var description: String? = null
-    var request: Request? = null
-    var body: BodyLens<*>? = null
-    val tags: MutableSet<Tag> = mutableSetOf()
-    val produces: MutableSet<ContentType> = mutableSetOf()
-    val consumes: MutableSet<ContentType> = mutableSetOf()
-    val queries: List<Lens<Request, *>> = mutableListOf()
-    val headers: List<Lens<Request, *>> = mutableListOf()
-    internal val responses: MutableMap<Status, Pair<String, Response>> = mutableMapOf()
-
-    @JvmName("returningResponse")
-    fun returning(new: Pair<String, Response>) {
-        produces.plus(Header.Common.CONTENT_TYPE(new.second)?.let { listOf(it) } ?: emptyList())
-        responses += responses.plus(new.second.status to new)
-    }
-
-    @JvmName("returningStatus")
-    fun returning(new: Pair<String, Status>) = returning(new.first to Response(new.second))
-
-    @JvmName("returningStatus")
-    fun returning(new: Status) = returning("" to Response(new))
-
-    fun <T> receiving(new: Pair<BiDiBodyLens<T>, T>) {
-        request = Request(GET, "").with(new.first of new.second)
-    }
-}
-
-fun meta(fn: MetaDsl.() -> Unit): RouteMeta = MetaDsl().apply(fn).run {
-    RouteMeta(summary, description, request, tags, body, produces, consumes, queries.plus(headers), responses)
 }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
@@ -1,6 +1,9 @@
 package org.http4k.contract
 
+import org.http4k.core.Body
 import org.http4k.core.ContentType
+import org.http4k.core.ContentType.Companion.APPLICATION_XML
+import org.http4k.core.ContentType.Companion.TEXT_PLAIN
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Response
@@ -8,6 +11,7 @@ import org.http4k.core.Status
 import org.http4k.core.with
 import org.http4k.lens.BiDiBodyLens
 import org.http4k.lens.Header
+import org.http4k.lens.string
 
 data class Tag(val name: String, val description: String? = null)
 
@@ -38,4 +42,47 @@ data class RouteMeta(val summary: String,
     fun producing(vararg new: ContentType) = copy(produces = produces.plus(new))
     fun consuming(vararg new: ContentType) = copy(consumes = consumes.plus(new))
 
+}
+
+class MetaDsl {
+    var summary: String = "<unknown>"
+    var description: String? = null
+    var request: Request? = null
+    val tags: MutableSet<Tag> = mutableSetOf()
+    val produces: MutableSet<ContentType> = mutableSetOf()
+    val consumes: MutableSet<ContentType> = mutableSetOf()
+    internal val responses: MutableMap<Status, Pair<String, Response>> = mutableMapOf()
+
+    @JvmName("returningResponse")
+    fun returning(new: Pair<String, Response>) {
+        produces.plus(Header.Common.CONTENT_TYPE(new.second)?.let { listOf(it) } ?: emptyList())
+        responses += responses.plus(new.second.status to new)
+    }
+
+    @JvmName("returningStatus")
+    fun returning(new: Pair<String, Status>) = returning(new.first to Response(new.second))
+
+    @JvmName("returningStatus")
+    fun returning(new: Status) = returning("" to Response(new))
+
+    fun <T> receiving(new: Pair<BiDiBodyLens<T>, T>) {
+        request = Request(GET, "").with(new.first of new.second)
+    }
+}
+
+fun meta(fn: MetaDsl.() -> Unit): MetaDsl = MetaDsl().apply(fn).apply {
+    RouteMeta(summary, description, request, tags, produces, consumes, responses)
+}
+
+fun main(args: Array<String>) {
+    meta {
+        summary = "summary"
+        description = "description"
+        request = Request(GET, "")
+        produces += APPLICATION_XML
+        tags += Tag("name", "description")
+        consumes += ContentType.TEXT_PLAIN
+        returning("ok" to Status.OK)
+        receiving(Body.string(TEXT_PLAIN).toLens() to "")
+    }
 }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
@@ -42,7 +42,7 @@ class RouteMetaDsl internal constructor() {
     }
 }
 
-fun metaDsl(fn: RouteMetaDsl.() -> Unit = {}) = RouteMetaDsl().apply(fn).run {
+fun routeMetaDsl(fn: RouteMetaDsl.() -> Unit = {}) = RouteMetaDsl().apply(fn).run {
     RouteMeta(
         summary, description, request, tags.all.toSet(), body, produces.all.toSet(), consumes.all.toSet(), queries.all + headers.all, responses.all.toMap()
     )

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
@@ -13,8 +13,8 @@ import org.http4k.lens.Lens
 
 data class Tag(val name: String, val description: String? = null)
 
-data class RouteMeta(val summary: String,
-                     val description: String?,
+data class RouteMeta(val summary: String = "<unknown>",
+                     val description: String? = null,
                      val request: Request? = null,
                      val tags: Set<Tag> = emptySet(),
                      val body: BodyLens<*>? = null,
@@ -27,6 +27,9 @@ data class RouteMeta(val summary: String,
 
     fun taggedWith(tag: String) = taggedWith(Tag(tag))
     fun taggedWith(vararg new: Tag) = copy(tags = tags.plus(new))
+
+    operator fun plus(new: Lens<Request, *>): RouteMeta = copy(requestParams = requestParams.plus(listOf(new)))
+    operator fun plus(new: BodyLens<*>): RouteMeta = copy(body = new)
 
     @JvmName("returningResponse")
     fun returning(new: Pair<String, Response>) =
@@ -41,6 +44,7 @@ data class RouteMeta(val summary: String,
 
     fun producing(vararg new: ContentType) = copy(produces = produces.plus(new))
     fun consuming(vararg new: ContentType) = copy(consumes = consumes.plus(new))
+
 
 }
 

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
@@ -61,23 +61,29 @@ data class RouteMeta(val summary: String = "<unknown>",
 
     constructor(summary: String = "<unknown>", description: String? = null) : this(summary, description, null)
 
-    fun taggedWith(tag: String) = taggedWith(Tag(tag))
-    fun taggedWith(vararg new: Tag) = copy(tags = tags.plus(new))
-
     operator fun plus(new: Lens<Request, *>): RouteMeta = copy(requestParams = requestParams.plus(listOf(new)))
     operator fun plus(new: BodyLens<*>): RouteMeta = copy(body = new)
 
     @JvmName("returningResponse")
-    fun returning(new: Pair<String, Response>) =
+    @Deprecated("use meta builder instead")
+    fun RouteMeta.returning(new: Pair<String, Response>) =
         copy(
             produces = produces.plus(Header.Common.CONTENT_TYPE(new.second)?.let { listOf(it) } ?: emptyList()),
             responses = responses.plus(new.second.status to new))
 
     @JvmName("returningStatus")
-    fun returning(new: Pair<String, Status>) = returning(new.first to Response(new.second))
+    @Deprecated("use meta builder instead")
+    fun RouteMeta.returning(new: Pair<String, Status>) = returning(new.first to Response(new.second))
 
-    fun <T> receiving(new: Pair<BiDiBodyLens<T>, T>): RouteMeta = copy(request = Request(GET, "").with(new.first of new.second))
+    @Deprecated("use meta builder instead")
+    fun <T> RouteMeta.receiving(new: Pair<BiDiBodyLens<T>, T>): RouteMeta = copy(request = Request(GET, "").with(new.first of new.second))
 
-    fun producing(vararg new: ContentType) = copy(produces = produces.plus(new))
-    fun consuming(vararg new: ContentType) = copy(consumes = consumes.plus(new))
+    @Deprecated("use meta builder instead")
+    fun RouteMeta.producing(vararg new: ContentType) = copy(produces = produces.plus(new))
+    @Deprecated("use meta builder instead")
+    fun RouteMeta.consuming(vararg new: ContentType) = copy(consumes = consumes.plus(new))
+    @Deprecated("use meta builder instead")
+    fun RouteMeta.taggedWith(tag: String) = taggedWith(Tag(tag))
+    @Deprecated("use meta builder instead")
+    fun RouteMeta.taggedWith(vararg new: Tag) = copy(tags = tags.plus(new))
 }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
@@ -1,9 +1,6 @@
 package org.http4k.contract
 
-import org.http4k.core.Body
 import org.http4k.core.ContentType
-import org.http4k.core.ContentType.Companion.APPLICATION_XML
-import org.http4k.core.ContentType.Companion.TEXT_PLAIN
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Response
@@ -11,7 +8,6 @@ import org.http4k.core.Status
 import org.http4k.core.with
 import org.http4k.lens.BiDiBodyLens
 import org.http4k.lens.Header
-import org.http4k.lens.string
 
 data class Tag(val name: String, val description: String? = null)
 
@@ -72,17 +68,4 @@ class MetaDsl {
 
 fun meta(fn: MetaDsl.() -> Unit): RouteMeta = MetaDsl().apply(fn).run {
     RouteMeta(summary, description, request, tags, produces, consumes, responses)
-}
-
-fun main(args: Array<String>) {
-    meta {
-        summary = "summary"
-        description = "description"
-        request = Request(GET, "")
-        produces += APPLICATION_XML
-        tags += Tag("name", "description")
-        consumes += ContentType.TEXT_PLAIN
-        returning("ok" to Status.OK)
-        receiving(Body.string(TEXT_PLAIN).toLens() to "")
-    }
 }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
@@ -70,7 +70,7 @@ class MetaDsl {
     }
 }
 
-fun meta(fn: MetaDsl.() -> Unit): MetaDsl = MetaDsl().apply(fn).apply {
+fun meta(fn: MetaDsl.() -> Unit): RouteMeta = MetaDsl().apply(fn).run {
     RouteMeta(summary, description, request, tags, produces, consumes, responses)
 }
 

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
@@ -7,7 +7,9 @@ import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.with
 import org.http4k.lens.BiDiBodyLens
+import org.http4k.lens.BodyLens
 import org.http4k.lens.Header
+import org.http4k.lens.Lens
 
 data class Tag(val name: String, val description: String? = null)
 
@@ -15,11 +17,13 @@ data class RouteMeta(val summary: String,
                      val description: String?,
                      val request: Request? = null,
                      val tags: Set<Tag> = emptySet(),
+                     val body: BodyLens<*>? = null,
                      val produces: Set<ContentType> = emptySet(),
                      val consumes: Set<ContentType> = emptySet(),
+                     val requestParams: List<Lens<Request, *>> = emptyList(),
                      val responses: Map<Status, Pair<String, Response>> = emptyMap()) {
 
-    constructor(name: String = "<unknown>", description: String? = null) : this(name, description, null)
+    constructor(summary: String = "<unknown>", description: String? = null) : this(summary, description, null)
 
     fun taggedWith(tag: String) = taggedWith(Tag(tag))
     fun taggedWith(vararg new: Tag) = copy(tags = tags.plus(new))
@@ -44,9 +48,12 @@ class MetaDsl {
     var summary: String = "<unknown>"
     var description: String? = null
     var request: Request? = null
+    var body: BodyLens<*>? = null
     val tags: MutableSet<Tag> = mutableSetOf()
     val produces: MutableSet<ContentType> = mutableSetOf()
     val consumes: MutableSet<ContentType> = mutableSetOf()
+    val queries: List<Lens<Request, *>> = mutableListOf()
+    val headers: List<Lens<Request, *>> = mutableListOf()
     internal val responses: MutableMap<Status, Pair<String, Response>> = mutableMapOf()
 
     @JvmName("returningResponse")
@@ -67,5 +74,5 @@ class MetaDsl {
 }
 
 fun meta(fn: MetaDsl.() -> Unit): RouteMeta = MetaDsl().apply(fn).run {
-    RouteMeta(summary, description, request, tags, produces, consumes, responses)
+    RouteMeta(summary, description, request, tags, body, produces, consumes, queries.plus(headers), responses)
 }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeSpec.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeSpec.kt
@@ -3,16 +3,12 @@ package org.http4k.contract
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
 import org.http4k.core.Request
-import org.http4k.lens.BodyLens
 import org.http4k.lens.Failure
-import org.http4k.lens.Lens
 import org.http4k.lens.LensFailure
 import org.http4k.lens.Path
 import org.http4k.lens.PathLens
 
 abstract class ContractRouteSpec internal constructor(val pathFn: (PathSegments) -> PathSegments,
-                                                      val requestParams: List<Lens<Request, *>>,
-                                                      val body: BodyLens<*>?,
                                                       val routeMeta: RouteMeta,
                                                       vararg val pathLenses: PathLens<*>) : Filter {
 
@@ -22,8 +18,8 @@ abstract class ContractRouteSpec internal constructor(val pathFn: (PathSegments)
 
     override fun invoke(nextHandler: HttpHandler): HttpHandler =
         { req ->
-            val body = body?.let { listOf(it::invoke) } ?: emptyList<(Request) -> Any?>()
-            val errors = body.plus(requestParams).fold(emptyList<Failure>()) { memo, next ->
+            val body = routeMeta.body?.let { listOf(it::invoke) } ?: emptyList<(Request) -> Any?>()
+            val errors = body.plus(routeMeta.requestParams).fold(emptyList<Failure>()) { memo, next ->
                 try {
                     next(req)
                     memo
@@ -37,33 +33,33 @@ abstract class ContractRouteSpec internal constructor(val pathFn: (PathSegments)
     internal fun describe(contractRoot: PathSegments): String = "${pathFn(contractRoot)}${if (pathLenses.isNotEmpty()) "/${pathLenses.joinToString("/")}" else ""}"
 }
 
-class ContractRouteSpec0 internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, routeMeta: RouteMeta) : ContractRouteSpec(pathFn, requestParams, body, routeMeta) {
-    override infix operator fun div(next: String) = ContractRouteSpec0({ it / next }, emptyList(), body, routeMeta)
+class ContractRouteSpec0 internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta) : ContractRouteSpec(pathFn, routeMeta) {
+    override infix operator fun div(next: String) = ContractRouteSpec0({ it / next }, routeMeta)
 
-    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec1(pathFn, requestParams, body, routeMeta, next)
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec1(pathFn, routeMeta, next)
 }
 
-class ContractRouteSpec1<out A> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, routeMeta: RouteMeta, val a: PathLens<A>) : ContractRouteSpec(pathFn, requestParams, body, routeMeta, a) {
+class ContractRouteSpec1<out A> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta, val a: PathLens<A>) : ContractRouteSpec(pathFn, routeMeta, a) {
     override infix operator fun div(next: String) = div(Path.fixed(next))
 
-    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec2(pathFn, requestParams, body, routeMeta, a, next)
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec2(pathFn, routeMeta, a, next)
 }
 
-class ContractRouteSpec2<out A, out B> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, routeMeta: RouteMeta, val a: PathLens<A>, val b: PathLens<B>) : ContractRouteSpec(pathFn, requestParams, body, routeMeta, a, b) {
+class ContractRouteSpec2<out A, out B> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta, val a: PathLens<A>, val b: PathLens<B>) : ContractRouteSpec(pathFn, routeMeta, a, b) {
     override infix operator fun div(next: String) = div(Path.fixed(next))
 
-    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec3(pathFn, requestParams, body, routeMeta, a, b, next)
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec3(pathFn, routeMeta, a, b, next)
 }
 
-class ContractRouteSpec3<out A, out B, out C> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, routeMeta: RouteMeta,
-                                                                   val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>) : ContractRouteSpec(pathFn, requestParams, body, routeMeta, a, b, c) {
+class ContractRouteSpec3<out A, out B, out C> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta,
+                                                                   val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>) : ContractRouteSpec(pathFn, routeMeta, a, b, c) {
     override infix operator fun div(next: String) = div(Path.fixed(next))
 
-    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec4(pathFn, requestParams, body, routeMeta, a, b, c, next)
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec4(pathFn, routeMeta, a, b, c, next)
 }
 
-class ContractRouteSpec4<out A, out B, out C, out D> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, routeMeta: RouteMeta,
-                                                                          val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>, val d: PathLens<D>) : ContractRouteSpec(pathFn, requestParams, body, routeMeta, a, b, c, d) {
+class ContractRouteSpec4<out A, out B, out C, out D> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta,
+                                                                          val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>, val d: PathLens<D>) : ContractRouteSpec(pathFn, routeMeta, a, b, c, d) {
     override infix operator fun div(next: String) = throw UnsupportedOperationException("no longer paths!")
 
     override infix operator fun <NEXT> div(next: PathLens<NEXT>) = throw UnsupportedOperationException("no longer paths!")

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeSpec.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeSpec.kt
@@ -13,6 +13,7 @@ import org.http4k.lens.PathLens
 abstract class ContractRouteSpec internal constructor(val pathFn: (PathSegments) -> PathSegments,
                                                       val requestParams: List<Lens<Request, *>>,
                                                       val body: BodyLens<*>?,
+                                                      val routeMeta: RouteMeta,
                                                       vararg val pathLenses: PathLens<*>) : Filter {
 
     abstract infix operator fun <T> div(next: PathLens<T>): ContractRouteSpec
@@ -36,33 +37,33 @@ abstract class ContractRouteSpec internal constructor(val pathFn: (PathSegments)
     internal fun describe(contractRoot: PathSegments): String = "${pathFn(contractRoot)}${if (pathLenses.isNotEmpty()) "/${pathLenses.joinToString("/")}" else ""}"
 }
 
-class ContractRouteSpec0 internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?) : ContractRouteSpec(pathFn, requestParams, body) {
-    override infix operator fun div(next: String) = ContractRouteSpec0({ it / next }, emptyList(), body)
+class ContractRouteSpec0 internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, routeMeta: RouteMeta) : ContractRouteSpec(pathFn, requestParams, body, routeMeta) {
+    override infix operator fun div(next: String) = ContractRouteSpec0({ it / next }, emptyList(), body, routeMeta)
 
-    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec1(pathFn, requestParams, body, next)
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec1(pathFn, requestParams, body, routeMeta, next)
 }
 
-class ContractRouteSpec1<out A> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, val a: PathLens<A>) : ContractRouteSpec(pathFn, requestParams, body, a) {
+class ContractRouteSpec1<out A> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, routeMeta: RouteMeta, val a: PathLens<A>) : ContractRouteSpec(pathFn, requestParams, body, routeMeta, a) {
     override infix operator fun div(next: String) = div(Path.fixed(next))
 
-    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec2(pathFn, requestParams, body, a, next)
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec2(pathFn, requestParams, body, routeMeta, a, next)
 }
 
-class ContractRouteSpec2<out A, out B> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, val a: PathLens<A>, val b: PathLens<B>) : ContractRouteSpec(pathFn, requestParams, body, a, b) {
+class ContractRouteSpec2<out A, out B> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, routeMeta: RouteMeta, val a: PathLens<A>, val b: PathLens<B>) : ContractRouteSpec(pathFn, requestParams, body, routeMeta, a, b) {
     override infix operator fun div(next: String) = div(Path.fixed(next))
 
-    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec3(pathFn, requestParams, body, a, b, next)
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec3(pathFn, requestParams, body, routeMeta, a, b, next)
 }
 
-class ContractRouteSpec3<out A, out B, out C> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?,
-                                                                   val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>) : ContractRouteSpec(pathFn, requestParams, body, a, b, c) {
+class ContractRouteSpec3<out A, out B, out C> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, routeMeta: RouteMeta,
+                                                                   val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>) : ContractRouteSpec(pathFn, requestParams, body, routeMeta, a, b, c) {
     override infix operator fun div(next: String) = div(Path.fixed(next))
 
-    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec4(pathFn, requestParams, body, a, b, c, next)
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec4(pathFn, requestParams, body, routeMeta, a, b, c, next)
 }
 
-class ContractRouteSpec4<out A, out B, out C, out D> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?,
-                                                                          val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>, val d: PathLens<D>) : ContractRouteSpec(pathFn, requestParams, body, a, b, c, d) {
+class ContractRouteSpec4<out A, out B, out C, out D> internal constructor(pathFn: (PathSegments) -> PathSegments, requestParams: List<Lens<Request, *>>, body: BodyLens<*>?, routeMeta: RouteMeta,
+                                                                          val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>, val d: PathLens<D>) : ContractRouteSpec(pathFn, requestParams, body, routeMeta, a, b, c, d) {
     override infix operator fun div(next: String) = throw UnsupportedOperationException("no longer paths!")
 
     override infix operator fun <NEXT> div(next: PathLens<NEXT>) = throw UnsupportedOperationException("no longer paths!")

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeSpec.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeSpec.kt
@@ -12,6 +12,7 @@ abstract class ContractRouteSpec internal constructor(val pathFn: (PathSegments)
                                                       val routeMeta: RouteMeta,
                                                       vararg val pathLenses: PathLens<*>) : Filter {
 
+    abstract fun with(new: RouteMeta): ContractRouteSpec
     abstract infix operator fun <T> div(next: PathLens<T>): ContractRouteSpec
 
     open infix operator fun div(next: String) = div(Path.fixed(next))
@@ -34,18 +35,24 @@ abstract class ContractRouteSpec internal constructor(val pathFn: (PathSegments)
 }
 
 class ContractRouteSpec0 internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta) : ContractRouteSpec(pathFn, routeMeta) {
+    override fun with(new: RouteMeta): ContractRouteSpec0 = ContractRouteSpec0(pathFn, new)
+
     override infix operator fun div(next: String) = ContractRouteSpec0({ it / next }, routeMeta)
 
     override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec1(pathFn, routeMeta, next)
 }
 
 class ContractRouteSpec1<out A> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta, val a: PathLens<A>) : ContractRouteSpec(pathFn, routeMeta, a) {
+    override fun with(new: RouteMeta): ContractRouteSpec1<A> = ContractRouteSpec1(pathFn, new, a)
+
     override infix operator fun div(next: String) = div(Path.fixed(next))
 
     override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec2(pathFn, routeMeta, a, next)
 }
 
 class ContractRouteSpec2<out A, out B> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta, val a: PathLens<A>, val b: PathLens<B>) : ContractRouteSpec(pathFn, routeMeta, a, b) {
+    override fun with(new: RouteMeta): ContractRouteSpec2<A, B> = ContractRouteSpec2(pathFn, new, a, b)
+
     override infix operator fun div(next: String) = div(Path.fixed(next))
 
     override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec3(pathFn, routeMeta, a, b, next)
@@ -53,6 +60,8 @@ class ContractRouteSpec2<out A, out B> internal constructor(pathFn: (PathSegment
 
 class ContractRouteSpec3<out A, out B, out C> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta,
                                                                    val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>) : ContractRouteSpec(pathFn, routeMeta, a, b, c) {
+    override fun with(new: RouteMeta): ContractRouteSpec3<A, B, C> = ContractRouteSpec3(pathFn, new, a, b, c)
+
     override infix operator fun div(next: String) = div(Path.fixed(next))
 
     override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec4(pathFn, routeMeta, a, b, c, next)
@@ -60,6 +69,9 @@ class ContractRouteSpec3<out A, out B, out C> internal constructor(pathFn: (Path
 
 class ContractRouteSpec4<out A, out B, out C, out D> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta,
                                                                           val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>, val d: PathLens<D>) : ContractRouteSpec(pathFn, routeMeta, a, b, c, d) {
+
+    override fun with(new: RouteMeta): ContractRouteSpec4<A, B, C, D> = ContractRouteSpec4(pathFn, new, a, b, c, d)
+
     override infix operator fun div(next: String) = throw UnsupportedOperationException("no longer paths!")
 
     override infix operator fun <NEXT> div(next: PathLens<NEXT>) = throw UnsupportedOperationException("no longer paths!")

--- a/http4k-contract/src/main/kotlin/org/http4k/util/Appendable.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/util/Appendable.kt
@@ -1,0 +1,11 @@
+package org.http4k.util
+
+class Appendable<T>(val all: MutableList<T> = mutableListOf()) {
+    operator fun plusAssign(t: T) {
+        all += t
+    }
+
+    operator fun plusAssign(t: Collection<T>) {
+        all += t
+    }
+}

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -61,7 +61,6 @@ abstract class ContractRendererContract(private val renderer: ContractRenderer) 
                 summary = "summary of this route"
                 description = "some rambling description of what this thing actually does"
                 headers += Header.optional("header", "description of the header")
-                body = customBody
                 produces += APPLICATION_JSON
                 returning("peachy" to Response(OK).with(customBody of Argo.obj("anAnotherObject" to Argo.obj("aNumberField" to Argo.number(123)))))
                 returning("peachy" to Response(Status.ACCEPTED).with(customBody of Argo.obj("anAnotherObject" to Argo.obj("aNumberField" to Argo.number(123)))))
@@ -93,7 +92,7 @@ abstract class ContractRendererContract(private val renderer: ContractRenderer) 
 
         val expected = String(this.javaClass.getResourceAsStream("${this.javaClass.simpleName}.json").readBytes())
         val actual = router(Request(Method.GET, "/basepath?the_api_key=somevalue")).bodyString()
-        println(actual)
+//        println(actual)
         assertThat(parse(actual), equalTo(parse(expected)))
     }
 }

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -60,37 +60,31 @@ abstract class ContractRendererContract(private val renderer: ContractRenderer) 
             "/echo" / Path.of("message")
                 header Header.optional("header", "description of the header")
                 bindContract GET to { msg -> { Response(OK).body(msg) } }
-                meta meta {
-                summary = "summary of this route"
-                description = "some rambling description of what this thing actually does"
-                produces += APPLICATION_JSON
-                tags += Tag("tag3")
-                tags += Tag("tag1")
-                returning("peachy" to Response(OK).with(customBody of Argo.obj("anAnotherObject" to Argo.obj("aNumberField" to Argo.number(123)))))
-                returning("peachy" to Response(ACCEPTED).with(customBody of Argo.obj("anAnotherObject" to Argo.obj("aNumberField" to Argo.number(123)))))
-                returning("no way jose" to FORBIDDEN)
-            },
+                meta RouteMeta("summary of this route", "some rambling description of what this thing actually does")
+                .producing(APPLICATION_JSON)
+                .returning("peachy" to Response(OK).with(customBody of Argo.obj("anAnotherObject" to Argo.obj("aNumberField" to Argo.number(123)))))
+                .returning("peachy" to Response(ACCEPTED).with(customBody of Argo.obj("anAnotherObject" to Argo.obj("aNumberField" to Argo.number(123)))))
+                .returning("no way jose" to FORBIDDEN)
+                .taggedWith("tag3")
+                .taggedWith("tag1"),
+
             "/echo" / Path.of("message")
                 query Query.int().required("query")
                 body customBody
                 bindContract POST to { msg -> { Response(OK).body(msg) } }
-                meta meta {
-                summary = "a post endpoint"
-                consumes += ContentType.APPLICATION_XML
-                consumes += ContentType.APPLICATION_JSON
-                produces += ContentType.APPLICATION_JSON
-                tags += Tag("tag1")
-                tags += Tag("tag2", "description of tag")
-                tags += Tag("tag2", "description of tag")
-                returning("no way jose" to Response(FORBIDDEN).with(customBody of Argo.obj("aString" to Argo.string("a message of some kind"))))
-                receiving(customBody to Argo.obj("anObject" to Argo.obj("notAStringField" to Argo.number(123))))
-            },
+                meta RouteMeta("a post endpoint")
+                .consuming(ContentType.APPLICATION_XML, APPLICATION_JSON)
+                .producing(APPLICATION_JSON)
+                .returning("no way jose" to Response(FORBIDDEN).with(customBody of Argo.obj("aString" to Argo.string("a message of some kind"))))
+                .taggedWith("tag1")
+                .taggedWith(Tag("tag2", "description of tag"), Tag("tag2", "description of tag"))
+                .receiving(customBody to Argo.obj("anObject" to Argo.obj("notAStringField" to Argo.number(123)))),
 
             "/welcome" / Path.of("firstName") / "bertrand" / Path.of("secondName")
                 query Query.boolean().required("query", "description of the query")
                 body Body.webForm(Validator.Strict, FormField.int().required("form", "description of the form")).toLens()
                 bindContract GET to { a, _, _ -> { Response(OK).body(a) } }
-                meta meta { summary = "a friendly endpoint" },
+                meta RouteMeta("a friendly endpoint"),
 
             "/simples" bindContract GET to { Response(OK) } meta RouteMeta("a simple endpoint")
         )

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -60,31 +60,37 @@ abstract class ContractRendererContract(private val renderer: ContractRenderer) 
             "/echo" / Path.of("message")
                 header Header.optional("header", "description of the header")
                 bindContract GET to { msg -> { Response(OK).body(msg) } }
-                meta RouteMeta("summary of this route", "some rambling description of what this thing actually does")
-                .producing(APPLICATION_JSON)
-                .returning("peachy" to Response(OK).with(customBody of Argo.obj("anAnotherObject" to Argo.obj("aNumberField" to Argo.number(123)))))
-                .returning("peachy" to Response(ACCEPTED).with(customBody of Argo.obj("anAnotherObject" to Argo.obj("aNumberField" to Argo.number(123)))))
-                .returning("no way jose" to FORBIDDEN)
-                .taggedWith("tag3")
-                .taggedWith("tag1"),
-
+                meta meta {
+                summary = "summary of this route"
+                description = "some rambling description of what this thing actually does"
+                produces += APPLICATION_JSON
+                tags += Tag("tag3")
+                tags += Tag("tag1")
+                returning("peachy" to Response(OK).with(customBody of Argo.obj("anAnotherObject" to Argo.obj("aNumberField" to Argo.number(123)))))
+                returning("peachy" to Response(ACCEPTED).with(customBody of Argo.obj("anAnotherObject" to Argo.obj("aNumberField" to Argo.number(123)))))
+                returning("no way jose" to FORBIDDEN)
+            },
             "/echo" / Path.of("message")
                 query Query.int().required("query")
                 body customBody
                 bindContract POST to { msg -> { Response(OK).body(msg) } }
-                meta RouteMeta("a post endpoint")
-                .consuming(ContentType.APPLICATION_XML, APPLICATION_JSON)
-                .producing(APPLICATION_JSON)
-                .returning("no way jose" to Response(FORBIDDEN).with(customBody of Argo.obj("aString" to Argo.string("a message of some kind"))))
-                .taggedWith("tag1")
-                .taggedWith(Tag("tag2", "description of tag"), Tag("tag2", "description of tag"))
-                .receiving(customBody to Argo.obj("anObject" to Argo.obj("notAStringField" to Argo.number(123)))),
+                meta meta {
+                summary = "a post endpoint"
+                consumes += ContentType.APPLICATION_XML
+                consumes += ContentType.APPLICATION_JSON
+                produces += ContentType.APPLICATION_JSON
+                tags += Tag("tag1")
+                tags += Tag("tag2", "description of tag")
+                tags += Tag("tag2", "description of tag")
+                returning("no way jose" to Response(FORBIDDEN).with(customBody of Argo.obj("aString" to Argo.string("a message of some kind"))))
+                receiving(customBody to Argo.obj("anObject" to Argo.obj("notAStringField" to Argo.number(123))))
+            },
 
             "/welcome" / Path.of("firstName") / "bertrand" / Path.of("secondName")
                 query Query.boolean().required("query", "description of the query")
                 body Body.webForm(Validator.Strict, FormField.int().required("form", "description of the form")).toLens()
                 bindContract GET to { a, _, _ -> { Response(OK).body(a) } }
-                meta RouteMeta("a friendly endpoint"),
+                meta meta { summary = "a friendly endpoint" },
 
             "/simples" bindContract GET to { Response(OK) } meta RouteMeta("a simple endpoint")
         )

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
@@ -32,7 +32,11 @@ class ContractRouteTest {
         val headerLens = Header.required("header")
         val queryLens = Query.required("query")
         val bodyLens = Body.string(TEXT_PLAIN).toLens()
-        val route = "/" header headerLens query queryLens body bodyLens bindContract GET to { _: Request -> Response(OK) }
+        val route = "/" meta {
+            headers += headerLens
+            queries += queryLens
+            body = bodyLens
+        } bindContract GET to { _: Request -> Response(OK) }
 
         assertThat(route.toRouter(Root).match(Request(GET, "").with(headerLens of "value", queryLens of "value", bodyLens of "hello")), present())
     }
@@ -42,7 +46,11 @@ class ContractRouteTest {
         val headerLens = Header.required("header")
         val queryLens = Query.required("query")
         val bodyLens = Body.string(TEXT_PLAIN).toLens()
-        val route = "/" header headerLens query queryLens body bodyLens bindContract GET to { _: Request -> Response(OK) }
+        val route = "/" meta {
+            headers += headerLens
+            queries += queryLens
+            body = bodyLens
+        } bindContract GET to { _: Request -> Response(OK) }
 
         val invalidRequest = Request(GET, "").with(headerLens of "value", bodyLens of "hello")
         val actual = route.toRouter(Root).match(invalidRequest)
@@ -55,8 +63,11 @@ class ContractRouteTest {
     fun `can build a request from a route`() {
         val path1 = Path.int().of("sue")
         val path2 = Path.string().of("bob")
-        val pair = path1 / path2 query Query.required("") bindContract GET
-        val route = pair to { _, _ -> { _: Request -> Response(OK) } } meta RouteMeta("")
+        val pair = path1 / path2 meta {
+            summary = ""
+            queries += Query.required("")
+        } bindContract GET
+        val route = pair to { _, _ -> { _: Request -> Response(OK) } }
         val request = route.newRequest(Uri.of("http://rita.com"))
 
         request.with(path1 of 123, path2 of "hello world") shouldMatch equalTo(Request(GET, "http://rita.com/123/hello+world"))
@@ -76,7 +87,9 @@ class ContractRouteTest {
     fun `can build a request from a routespec`() {
         val path1 = Path.int().of("sue")
         val path2 = Path.string().of("bob")
-        val request = (path1 / path2 query Query.required("") bindContract GET).newRequest(Uri.of("http://rita.com"))
+        val request = (path1 / path2 meta {
+            queries += Query.required("")
+        } bindContract GET).newRequest(Uri.of("http://rita.com"))
 
         request.with(path1 of 123, path2 of "hello world") shouldMatch equalTo(Request(GET, "http://rita.com/123/hello+world"))
     }

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/test.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/test.kt
@@ -25,7 +25,7 @@ class Appendable<T>(val all: MutableList<T> = mutableListOf()) {
         all += t
     }
 
-    operator fun plusAssign(t: List<T>) {
+    operator fun plusAssign(t: Collection<T>) {
         all += t
     }
 }
@@ -71,8 +71,7 @@ val b = contractRoute {
     summary = "summary of this route"
     description = "some rambling description of what this thing actually does"
     produces += ContentType.APPLICATION_JSON
-    tags += Tag("tag3")
-    tags += Tag("tag1")
+    tags += listOf(Tag("tag3"), Tag("tag1"))
     headers += Header.optional("header", "description of the header")
     queries += Query.optional("header", "description of the header")
 } //"/echo" / Path.of("message")

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/test.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/test.kt
@@ -1,17 +1,14 @@
 package org.http4k.contract
 
 import org.http4k.core.ContentType
-import org.http4k.core.Method
-import org.http4k.core.Request
+import org.http4k.core.Method.GET
 import org.http4k.core.Response
 import org.http4k.core.Status
-import org.http4k.core.with
 import org.http4k.format.Argo
-import org.http4k.lens.BiDiBodyLens
-import org.http4k.lens.BodyLens
 import org.http4k.lens.Header
-import org.http4k.lens.Lens
+import org.http4k.lens.Path
 import org.http4k.lens.Query
+import org.http4k.lens.int
 
 class ContractDsl {
     var renderer: ContractRenderer = NoRenderer
@@ -19,53 +16,12 @@ class ContractDsl {
     var descriptionPath = ""
     var summary: String = "<unknown>"
 }
-
-class Appendable<T>(val all: MutableList<T> = mutableListOf()) {
-    operator fun plusAssign(t: T) {
-        all += t
-    }
-
-    operator fun plusAssign(t: Collection<T>) {
-        all += t
-    }
-}
-
-class ContractRouteDsl {
-    var summary: String = "<unknown>"
-    var description: String? = null
-    var request: Request? = null
-    val tags = Appendable<Tag>()
-    val produces = Appendable<ContentType>()
-    val consumes = Appendable<ContentType>()
-    internal val responses = Appendable<Pair<Status, Pair<String, Response>>>()
-    var headers = Appendable<Lens<Request, *>>()
-    var queries = Appendable<Lens<Request, *>>()
-    var body: BodyLens<*>? = null
-
-    @JvmName("returningResponse")
-    fun returning(new: Pair<String, Response>) {
-        produces += (Header.Common.CONTENT_TYPE(new.second)?.let { listOf(it) } ?: emptyList())
-        responses += new.second.status to new
-    }
-
-    @JvmName("returningStatus")
-    fun returning(new: Pair<String, Status>) = returning(new.first to Response(new.second))
-
-    @JvmName("returningStatus")
-    fun returning(new: Status) = returning("" to Response(new))
-
-    fun <T> receiving(new: Pair<BiDiBodyLens<T>, T>) {
-        request = Request(Method.GET, "").with(new.first of new.second)
-    }
-}
-
-fun contractRoute(fn: ContractRouteDsl.() -> Unit): Any = ContractRouteDsl().apply(fn).run {
-    this
-}
-
 fun contractDsl(fn: ContractDsl.() -> Unit): Any = ContractDsl().apply(fn).run {
     this
 }
+
+val asd = contractRoute {} / "asd" / Path.int().of("hey") bindContract GET to { { Response(Status.OK) } }
+
 
 val b = contractRoute {
     summary = "summary of this route"

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/test.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/test.kt
@@ -1,14 +1,7 @@
 package org.http4k.contract
 
-import org.http4k.core.ContentType
-import org.http4k.core.Method.GET
-import org.http4k.core.Response
-import org.http4k.core.Status
 import org.http4k.format.Argo
-import org.http4k.lens.Header
-import org.http4k.lens.Path
 import org.http4k.lens.Query
-import org.http4k.lens.int
 
 class ContractDsl {
     var renderer: ContractRenderer = NoRenderer
@@ -19,18 +12,6 @@ class ContractDsl {
 fun contractDsl(fn: ContractDsl.() -> Unit): Any = ContractDsl().apply(fn).run {
     this
 }
-
-val asd = contractRoute {} / "asd" / Path.int().of("hey") bindContract GET to { { Response(Status.OK) } }
-
-
-val b = contractRoute {
-    summary = "summary of this route"
-    description = "some rambling description of what this thing actually does"
-    produces += ContentType.APPLICATION_JSON
-    tags += listOf(Tag("tag3"), Tag("tag1"))
-    headers += Header.optional("header", "description of the header")
-    queries += Query.optional("header", "description of the header")
-} //"/echo" / Path.of("message")
 
 val a = contractDsl {
     renderer = OpenApi(ApiInfo("foo", "bbb", "asd"), Argo)

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/test.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/test.kt
@@ -1,0 +1,97 @@
+package org.http4k.contract
+
+import org.http4k.core.ContentType
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.core.with
+import org.http4k.format.Argo
+import org.http4k.lens.BiDiBodyLens
+import org.http4k.lens.BodyLens
+import org.http4k.lens.Header
+import org.http4k.lens.Lens
+import org.http4k.lens.Query
+
+class ContractDsl {
+    var renderer: ContractRenderer = NoRenderer
+    var security: Security = NoSecurity
+    var descriptionPath = ""
+    var summary: String = "<unknown>"
+}
+
+class Appendable<T>(val all: MutableList<T> = mutableListOf()) {
+    operator fun plusAssign(t: T) {
+        all += t
+    }
+
+    operator fun plusAssign(t: List<T>) {
+        all += t
+    }
+}
+
+class ContractRouteDsl {
+    var summary: String = "<unknown>"
+    var description: String? = null
+    var request: Request? = null
+    val tags = Appendable<Tag>()
+    val produces = Appendable<ContentType>()
+    val consumes = Appendable<ContentType>()
+    internal val responses = Appendable<Pair<Status, Pair<String, Response>>>()
+    var headers = Appendable<Lens<Request, *>>()
+    var queries = Appendable<Lens<Request, *>>()
+    var body: BodyLens<*>? = null
+
+    @JvmName("returningResponse")
+    fun returning(new: Pair<String, Response>) {
+        produces += (Header.Common.CONTENT_TYPE(new.second)?.let { listOf(it) } ?: emptyList())
+        responses += new.second.status to new
+    }
+
+    @JvmName("returningStatus")
+    fun returning(new: Pair<String, Status>) = returning(new.first to Response(new.second))
+
+    @JvmName("returningStatus")
+    fun returning(new: Status) = returning("" to Response(new))
+
+    fun <T> receiving(new: Pair<BiDiBodyLens<T>, T>) {
+        request = Request(Method.GET, "").with(new.first of new.second)
+    }
+}
+
+fun contractRoute(fn: ContractRouteDsl.() -> Unit): Any = ContractRouteDsl().apply(fn).run {
+    this
+}
+
+fun contractDsl(fn: ContractDsl.() -> Unit): Any = ContractDsl().apply(fn).run {
+    this
+}
+
+val b = contractRoute {
+    summary = "summary of this route"
+    description = "some rambling description of what this thing actually does"
+    produces += ContentType.APPLICATION_JSON
+    tags += Tag("tag3")
+    tags += Tag("tag1")
+    headers += Header.optional("header", "description of the header")
+    queries += Query.optional("header", "description of the header")
+} //"/echo" / Path.of("message")
+
+val a = contractDsl {
+    renderer = OpenApi(ApiInfo("foo", "bbb", "asd"), Argo)
+    security = ApiKey(Query.required("the_api_key"), { true })
+//        routes += contractRoute"/echo" / Path.of("message")
+//    header Header . optional ("header", "description of the header")
+//    bindContract Method . GET to { msg -> { Response(Status.OK).body(msg) } }
+//    meta meta {
+//        summary = "summary of this route"
+//        description = "some rambling description of what this thing actually does"
+//        produces += ContentType.APPLICATION_JSON
+//        tags += Tag("tag3")
+//        tags += Tag("tag1")
+//        returning("no way jose" to Status.FORBIDDEN)
+//    },
+//
+//    "/simples" bindContract Method.GET to { Response(Status.OK) } meta RouteMeta("a simple endpoint")
+//    )
+}

--- a/src/docs/cookbook/typesafe_http_contracts/example.kt
+++ b/src/docs/cookbook/typesafe_http_contracts/example.kt
@@ -84,8 +84,7 @@ fun main(args: Array<String>) {
             "/echo" / Path.of("name") meta {
                 summary = "echo"
                 queries += ageQuery
-            }
-                bindContract GET to ::echo
+            } bindContract GET to ::echo
         )
     )
 

--- a/src/docs/cookbook/typesafe_http_contracts/example.kt
+++ b/src/docs/cookbook/typesafe_http_contracts/example.kt
@@ -3,13 +3,11 @@ package cookbook.typesafe_http_contracts
 import org.http4k.contract.ApiInfo
 import org.http4k.contract.ApiKey
 import org.http4k.contract.OpenApi
-import org.http4k.contract.RouteMeta
 import org.http4k.contract.bind
 import org.http4k.contract.bindContract
 import org.http4k.contract.contract
 import org.http4k.contract.div
 import org.http4k.contract.meta
-import org.http4k.contract.query
 import org.http4k.core.Body
 import org.http4k.core.ContentType.Companion.TEXT_PLAIN
 import org.http4k.core.Filter
@@ -62,28 +60,32 @@ fun main(args: Array<String>) {
     })
 
     val contract = contract(OpenApi(ApiInfo("my great api", "v1.0"), Argo), "/docs/swagger.json", security,
-        "/ping"
-            bindContract GET
-            to { Response(OK).body("pong")}
-            meta RouteMeta("add", "Adds 2 numbers together").returning("The result" to OK),
-        "/add" / Path.int().of("value1") / Path.int().of("value2")
-            bindContract GET
-            to ::add
-            meta RouteMeta("add", "Adds 2 numbers together").returning("The result" to OK),
-        "/echo" / Path.of("name")
-            query ageQuery
-            bindContract GET to ::echo
-            meta RouteMeta("echo")
+        "/ping" meta {
+            summary = "add"
+            description = "Adds 2 numbers together"
+            returning("The result" to OK)
+        } bindContract GET to { Response(OK).body("pong") },
+        "/add" / Path.int().of("value1") / Path.int().of("value2") meta {
+            summary = "add"
+            description = "Adds 2 numbers together"
+            returning("The result" to OK)
+        } bindContract GET
+            to ::add,
+        "/echo" / Path.of("name") meta {
+            summary = "echo"
+            queries += ageQuery
+        } bindContract GET to ::echo
     )
 
     val handler = routes(
         "/context" bind filter.then(contract),
         "/static" bind NoCache().then(static(Classpath("cookbook"))),
         "/" bind contract(OpenApi(ApiInfo("my great super api", "v1.0"), Argo),
-            "/echo" / Path.of("name")
-                query ageQuery
+            "/echo" / Path.of("name") meta {
+                summary = "echo"
+                queries += ageQuery
+            }
                 bindContract GET to ::echo
-                meta RouteMeta("echo")
         )
     )
 

--- a/src/docs/guide/modules/contracts/example.kt
+++ b/src/docs/guide/modules/contracts/example.kt
@@ -3,14 +3,11 @@ package guide.modules.contracts
 import org.http4k.contract.ApiInfo
 import org.http4k.contract.ApiKey
 import org.http4k.contract.OpenApi
-import org.http4k.contract.RouteMeta
 import org.http4k.contract.bind
 import org.http4k.contract.bindContract
-import org.http4k.contract.body
 import org.http4k.contract.contract
 import org.http4k.contract.div
 import org.http4k.contract.meta
-import org.http4k.contract.query
 import org.http4k.core.Body
 import org.http4k.core.ContentType.Companion.TEXT_PLAIN
 import org.http4k.core.HttpHandler
@@ -31,10 +28,11 @@ import org.http4k.routing.routes
 val ageQuery = Query.int().required("age")
 val stringBody = Body.string(TEXT_PLAIN).toLens()
 
-val route = ("/echo" / Path.of("name")
-    query ageQuery
-    body stringBody
-    bindContract Method.GET)
+val route = ("/echo" / Path.of("name") meta {
+    summary = "echo"
+    queries += ageQuery
+    body = stringBody
+} bindContract Method.GET)
 
 //2. Dynamic binding of calls to an HttpHandler
 //Next, bind this route to a function which creates an `HttpHandler` for each invocation, which receives the dynamic path elements from the path:
@@ -50,7 +48,7 @@ fun echo(nameFromPath: String): HttpHandler = { request: Request ->
 //3. Combining Routes into a contract and bind to a context
 //Finally, the `ContractRoutes` are added into a reusable `Contract` in the standard way, defining a renderer (in this example OpenApi/Swagger) and a security model (in this case an API-Key):
 
-val routeWithBindings = route to ::echo meta RouteMeta("echo")
+val routeWithBindings = route to ::echo
 
 val security = ApiKey(Query.int().required("api"), { it == 42 })
 


### PR DESCRIPTION
The current version of the contracts API involves quite a lot of infix functions and this isn't very good in terms of discoverability, since the various calls are split. This PR reimplements the "meta" section of the API, so now instead of declaring:

```Path -> Service Constructor Fn (-> optional Meta block)```

... the new call chain is:
```Path -> (optional Meta block ->) Service Constructor Fn```

The new API also uses a Groovy-style DSL builder, which you can see examples of at: https://kotlinlang.org/docs/reference/type-safe-builders.html

Overall this change makes the API much more consistent with the rest of http4k. The old API is still present, but deprecated.