### PR TITLE
Request/Response equality does not depend on header order

### DIFF
--- a/http4k-core/src/test/kotlin/org/http4k/core/RequestTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/RequestTest.kt
@@ -7,12 +7,43 @@ import org.http4k.core.Method.GET
 import org.junit.Test
 
 class RequestTest {
-
     @Test
     fun extracts_query_parameters() {
         assertThat(requestWithQuery("foo=one&foo=two").queries("foo"), equalTo(listOf<String?>("one", "two")))
         assertThat(requestWithQuery("foo=one&foo=two").query("foo")!!, equalTo("one"))
         assertThat(requestWithQuery("foo=one&foo&foo=two").queries("foo"), equalTo(listOf("one", null, "two")))
+    }
+
+    @Test
+    fun `differences in header order do not invalidate equality`() {
+        val requestOne = Request(GET, "http://ignore").header("foo", "bar").header("fizz", "buzz")
+        val requestTwo = Request(GET, "http://ignore").header("fizz", "buzz").header("foo", "bar")
+        assertThat(requestOne, equalTo(requestTwo))
+    }
+
+    @Test
+    fun `if multiple headers with the same key exist in two headers, they must be in the same order for the headers to be equal`() {
+        val requestOne = Request(GET, "http://ignore")
+            .header("foo", "bar")
+            .header("foo", "buzz")
+            .header("fizz", "bar")
+            .header("fizz", "buzz")
+            .header("Content-Type", "application/json")
+        val requestTwo = Request(GET, "http://ignore")
+            .header("foo", "buzz")
+            .header("foo", "bar")
+            .header("fizz", "bar")
+            .header("fizz", "buzz")
+            .header("Content-Type", "application/json")
+        val requestThree = Request(GET, "http://ignore")
+            .header("Content-Type", "application/json")
+            .header("fizz", "bar")
+            .header("fizz", "buzz")
+            .header("foo", "buzz")
+            .header("foo", "bar")
+
+        assertThat(requestOne, !equalTo(requestTwo))
+        assertThat(requestTwo, equalTo(requestThree))
     }
 
     private fun requestWithQuery(query: String) = Request(GET, Uri.of("http://ignore/?$query"))

--- a/http4k-core/src/test/kotlin/org/http4k/core/ResponseTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/ResponseTest.kt
@@ -1,0 +1,43 @@
+package org.http4k.core
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.core.Status.Companion.OK
+import org.junit.Test
+
+class ResponseTest {
+    @Test
+    fun `differences in header order do not invalidate equality`() {
+        val responseOne = Response(OK).header("foo", "bar").header("fizz", "buzz")
+        val responseTwo = Response(OK).header("fizz", "buzz").header("foo", "bar")
+        assertThat(responseOne, equalTo(responseTwo))
+    }
+
+    @Test
+    fun `if multiple headers with the same key exist in two headers, they must be in the same order for the headers to be equal`() {
+        val responseOne = Response(OK)
+            .header("foo", "bar")
+            .header("foo", "buzz")
+            .header("fizz", "bar")
+            .header("fizz", "buzz")
+            .header("Content-Type", "application/json")
+        val responseTwo = Response(OK)
+            .header("foo", "buzz")
+            .header("foo", "bar")
+            .header("fizz", "bar")
+            .header("fizz", "buzz")
+            .header("Content-Type", "application/json")
+        val responseThree = Response(OK)
+            .header("Content-Type", "application/json")
+            .header("fizz", "bar")
+            .header("fizz", "buzz")
+            .header("foo", "buzz")
+            .header("foo", "bar")
+
+        assertThat(responseOne, !equalTo(responseTwo))
+        assertThat(responseTwo, equalTo(responseThree))
+    }
+}
+
+
+


### PR DESCRIPTION
I've had a crack at making equality for Requests and Responses less dependent upon the order of headers.

Now header order is unimportant, unless header field names are repeated, in which case headers with the same field name should be declared in the same order in for equality to hold. As per https://tools.ietf.org/html/rfc7230#section-3.2.2 if I'm reading it right 😄 .