### PR TITLE
Add support for operationId to Swagger

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
@@ -24,6 +24,7 @@ class RouteMetaDsl internal constructor() {
     var headers = Appendable<Lens<Request, *>>()
     var queries = Appendable<Lens<Request, *>>()
     var body: BodyLens<*>? = null
+    var operationId: String? = null
 
     @JvmName("returningResponse")
     fun returning(new: Pair<String, Response>) {
@@ -44,7 +45,7 @@ class RouteMetaDsl internal constructor() {
 
 fun routeMetaDsl(fn: RouteMetaDsl.() -> Unit = {}) = RouteMetaDsl().apply(fn).run {
     RouteMeta(
-        summary, description, request, tags.all.toSet(), body, produces.all.toSet(), consumes.all.toSet(), queries.all + headers.all, responses.all.toMap()
+        summary, description, request, tags.all.toSet(), body, produces.all.toSet(), consumes.all.toSet(), queries.all + headers.all, responses.all.toMap(), operationId
     )
 }
 data class Tag(val name: String, val description: String? = null)
@@ -57,7 +58,8 @@ data class RouteMeta(val summary: String = "<unknown>",
                      val produces: Set<ContentType> = emptySet(),
                      val consumes: Set<ContentType> = emptySet(),
                      val requestParams: List<Lens<Request, *>> = emptyList(),
-                     val responses: Map<Status, Pair<String, Response>> = emptyMap()) {
+                     val responses: Map<Status, Pair<String, Response>> = emptyMap(),
+                     val operationId: String? = null) {
 
     constructor(summary: String = "<unknown>", description: String? = null) : this(summary, description, null)
 

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -60,6 +60,7 @@ abstract class ContractRendererContract(private val renderer: ContractRenderer) 
             "/echo" / Path.of("message") meta {
                 summary = "summary of this route"
                 description = "some rambling description of what this thing actually does"
+                operationId = "echoMessage"
                 headers += Header.optional("header", "description of the header")
                 produces += APPLICATION_JSON
                 returning("peachy" to Response(OK).with(customBody of Argo.obj("anAnotherObject" to Argo.obj("aNumberField" to Argo.number(123)))))

--- a/http4k-contract/src/test/resources/org/http4k/contract/OpenApiTest.json
+++ b/http4k-contract/src/test/resources/org/http4k/contract/OpenApiTest.json
@@ -27,6 +27,7 @@
         ],
         "summary": "summary of this route",
         "description": "some rambling description of what this thing actually does",
+        "operationId": "echoMessage",
         "produces": [
           "application/json"
         ],


### PR DESCRIPTION
This adds support for adding an `operationId` field to paths for Swagger definitions. This field allows developers to customize the naming of methods when auto-generating API clients in Swagger. For example, if an endpoint `GET /echo/{message}` has an operationId `echoMessage`, the method name in Swagger's client will be `echoMessage` vs `getEchoMessage`