### PR TITLE
Updated to handle up to 10 path parameters in a contract route.

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
@@ -66,11 +66,64 @@ infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.bindContract(method: Metho
     }
 }
 
+infix fun <A, B, C, D, E> ContractRouteSpec5<A, B, C, D, E>.bindContract(method: Method) = let { spec ->
+    object : RouteBinder<(A, B, C, D, E) -> HttpHandler> {
+        override fun newRequest(baseUri: Uri): Request = Request(method, "").uri(baseUri.path(spec.describe(Root)))
+        override fun to(fn: (A, B, C, D, E) -> HttpHandler): ContractRoute = ContractRoute(method, spec, spec.routeMeta, { fn(it[spec.a], it[spec.b], it[spec.c], it[spec.d], it[spec.e]) })
+    }
+}
+
+infix fun <A, B, C, D, E, F> ContractRouteSpec6<A, B, C, D, E, F>.bindContract(method: Method) = let { spec ->
+    object : RouteBinder<(A, B, C, D, E, F) -> HttpHandler> {
+        override fun newRequest(baseUri: Uri): Request = Request(method, "").uri(baseUri.path(spec.describe(Root)))
+        override fun to(fn: (A, B, C, D, E, F) -> HttpHandler): ContractRoute = ContractRoute(method, spec, spec.routeMeta,
+                { fn(it[spec.a], it[spec.b], it[spec.c], it[spec.d], it[spec.e], it[spec.f]) })
+    }
+}
+
+infix fun <A, B, C, D, E, F, G> ContractRouteSpec7<A, B, C, D, E, F, G>.bindContract(method: Method) = let { spec ->
+    object : RouteBinder<(A, B, C, D, E, F, G) -> HttpHandler> {
+        override fun newRequest(baseUri: Uri): Request = Request(method, "").uri(baseUri.path(spec.describe(Root)))
+        override fun to(fn: (A, B, C, D, E, F, G) -> HttpHandler): ContractRoute = ContractRoute(method, spec, spec.routeMeta,
+                { fn(it[spec.a], it[spec.b], it[spec.c], it[spec.d], it[spec.e], it[spec.f], it[spec.g]) })
+    }
+}
+
+infix fun <A, B, C, D, E, F, G, H> ContractRouteSpec8<A, B, C, D, E, F, G, H>.bindContract(method: Method) = let { spec ->
+    object : RouteBinder<(A, B, C, D, E, F, G, H) -> HttpHandler> {
+        override fun newRequest(baseUri: Uri): Request = Request(method, "").uri(baseUri.path(spec.describe(Root)))
+        override fun to(fn: (A, B, C, D, E, F, G, H) -> HttpHandler): ContractRoute = ContractRoute(method, spec, spec.routeMeta,
+                { fn(it[spec.a], it[spec.b], it[spec.c], it[spec.d], it[spec.e], it[spec.f], it[spec.g], it[spec.h]) })
+    }
+}
+
+infix fun <A, B, C, D, E, F, G, H, I> ContractRouteSpec9<A, B, C, D, E, F, G, H, I>.bindContract(method: Method) = let { spec ->
+    object : RouteBinder<(A, B, C, D, E, F, G, H, I) -> HttpHandler> {
+        override fun newRequest(baseUri: Uri): Request = Request(method, "").uri(baseUri.path(spec.describe(Root)))
+        override fun to(fn: (A, B, C, D, E, F, G, H, I) -> HttpHandler): ContractRoute = ContractRoute(method, spec, spec.routeMeta,
+                { fn(it[spec.a], it[spec.b], it[spec.c], it[spec.d], it[spec.e], it[spec.f], it[spec.g], it[spec.h], it[spec.i]) })
+    }
+}
+
+infix fun <A, B, C, D, E, F, G, H, I, J> ContractRouteSpec10<A, B, C, D, E, F, G, H, I, J>.bindContract(method: Method) = let { spec ->
+    object : RouteBinder<(A, B, C, D, E, F, G, H, I, J) -> HttpHandler> {
+        override fun newRequest(baseUri: Uri): Request = Request(method, "").uri(baseUri.path(spec.describe(Root)))
+        override fun to(fn: (A, B, C, D, E, F, G, H, I, J) -> HttpHandler): ContractRoute = ContractRoute(method, spec, spec.routeMeta,
+                { fn(it[spec.a], it[spec.b], it[spec.c], it[spec.d], it[spec.e], it[spec.f], it[spec.g], it[spec.h], it[spec.i], it[spec.j]) })
+    }
+}
+
 infix fun String.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec0(toBaseFn(this), routeMetaDsl(new))
 infix fun ContractRouteSpec0.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec0(pathFn, routeMetaDsl(new))
 infix fun <A> ContractRouteSpec1<A>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec1(pathFn, routeMetaDsl(new), a)
 infix fun <A, B> ContractRouteSpec2<A, B>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec2(pathFn, routeMetaDsl(new), a, b)
 infix fun <A, B, C> ContractRouteSpec3<A, B, C>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec3(pathFn, routeMetaDsl(new), a, b, c)
 infix fun <A, B, C, D> ContractRouteSpec4<A, B, C, D>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec4(pathFn, routeMetaDsl(new), a, b, c, d)
+infix fun <A, B, C, D, E> ContractRouteSpec5<A, B, C, D, E>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec5(pathFn, routeMetaDsl(new), a, b, c, d, e)
+infix fun <A, B, C, D, E, F> ContractRouteSpec6<A, B, C, D, E, F>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec6(pathFn, routeMetaDsl(new), a, b, c, d, e, f)
+infix fun <A, B, C, D, E, F, G> ContractRouteSpec7<A, B, C, D, E, F, G>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec7(pathFn, routeMetaDsl(new), a, b, c, d, e, f, g)
+infix fun <A, B, C, D, E, F, G, H> ContractRouteSpec8<A, B, C, D, E, F, G, H>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec8(pathFn, routeMetaDsl(new), a, b, c, d, e, f, g, h)
+infix fun <A, B, C, D, E, F, G, H, I> ContractRouteSpec9<A, B, C, D, E, F, G, H, I>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec9(pathFn, routeMetaDsl(new), a, b, c, d, e, f, g, h, i)
+infix fun <A, B, C, D, E, F, G, H, I, J> ContractRouteSpec10<A, B, C, D, E, F, G, H, I, J>.meta(new: RouteMetaDsl.() -> Unit) = ContractRouteSpec10(pathFn, routeMetaDsl(new), a, b, c, d, e, f, g, h, i, j)
 
 internal fun toBaseFn(path: String): (PathSegments) -> PathSegments = PathSegments(path).let { { old: PathSegments -> old / it } }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/routeSpec.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/routeSpec.kt
@@ -72,8 +72,68 @@ class ContractRouteSpec4<out A, out B, out C, out D> internal constructor(pathFn
 
     override fun with(new: RouteMeta): ContractRouteSpec4<A, B, C, D> = ContractRouteSpec4(pathFn, new, a, b, c, d)
 
+    override infix operator fun div(next: String) = div(Path.fixed(next))
+
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec5(pathFn, routeMeta, a, b, c, d, next)
+}
+
+class ContractRouteSpec5<out A, out B, out C, out D, out E> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta,
+                                                                                 val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>, val d: PathLens<D>, val e: PathLens<E>) : ContractRouteSpec(pathFn, routeMeta, a, b, c, d, e) {
+    override fun with(new: RouteMeta): ContractRouteSpec5<A, B, C, D, E> = ContractRouteSpec5(pathFn, new, a, b, c, d, e)
+
+    override infix operator fun div(next: String) = div(Path.fixed(next))
+
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec6(pathFn, routeMeta, a, b, c, d, e, next)
+}
+
+class ContractRouteSpec6<out A, out B, out C, out D, out E, out F> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta,
+                                     val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>, val d: PathLens<D>, val e: PathLens<E>, val f: PathLens<F>) : ContractRouteSpec(pathFn, routeMeta, a, b, c, d, e, f) {
+    override fun with(new: RouteMeta): ContractRouteSpec6<A, B, C, D, E, F> = ContractRouteSpec6(pathFn, new, a, b, c, d, e, f)
+
+    override infix operator fun div(next: String) = div(Path.fixed(next))
+
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec7(pathFn, routeMeta, a, b, c, d, e, f, next)
+}
+
+class ContractRouteSpec7<out A, out B, out C, out D, out E, out F, out G> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta,
+                                   val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>, val d: PathLens<D>, val e: PathLens<E>,
+                                   val f: PathLens<F>, val g: PathLens<G>) : ContractRouteSpec(pathFn, routeMeta, a, b, c, d, e, f, g) {
+    override fun with(new: RouteMeta): ContractRouteSpec7<A, B, C, D, E, F, G> = ContractRouteSpec7(pathFn, new, a, b, c, d, e, f, g)
+
+    override infix operator fun div(next: String) = div(Path.fixed(next))
+
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec8(pathFn, routeMeta, a, b, c, d, e, f, g, next)
+}
+
+class ContractRouteSpec8<out A, out B, out C, out D, out E, out F, out G, out H> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta,
+                                   val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>, val d: PathLens<D>, val e: PathLens<E>,
+                                   val f: PathLens<F>, val g: PathLens<G>, val h: PathLens<H>) : ContractRouteSpec(pathFn, routeMeta, a, b, c, d, e, f, g, h) {
+    override fun with(new: RouteMeta): ContractRouteSpec8<A, B, C, D, E, F, G, H> = ContractRouteSpec8(pathFn, new, a, b, c, d, e, f, g, h)
+
+    override infix operator fun div(next: String) = div(Path.fixed(next))
+
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec9(pathFn, routeMeta, a, b, c, d, e, f, g, h, next)
+}
+
+class ContractRouteSpec9<out A, out B, out C, out D, out E, out F, out G, out H, out I> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta,
+                                  val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>, val d: PathLens<D>, val e: PathLens<E>,
+                                  val f: PathLens<F>, val g: PathLens<G>, val h: PathLens<H>, val i: PathLens<I>) : ContractRouteSpec(pathFn, routeMeta, a, b, c, d, e, f, g, h, i) {
+    override fun with(new: RouteMeta): ContractRouteSpec9<A, B, C, D, E, F, G, H, I> = ContractRouteSpec9(pathFn, new, a, b, c, d, e, f, g, h, i)
+
+    override infix operator fun div(next: String) = div(Path.fixed(next))
+
+    override infix operator fun <NEXT> div(next: PathLens<NEXT>) = ContractRouteSpec10(pathFn, routeMeta, a, b, c, d, e, f, g, h, i, next)
+}
+
+class ContractRouteSpec10<out A, out B, out C, out D, out E, out F, out G, out H, out I, out J> internal constructor(pathFn: (PathSegments) -> PathSegments, routeMeta: RouteMeta,
+                                 val a: PathLens<A>, val b: PathLens<B>, val c: PathLens<C>, val d: PathLens<D>, val e: PathLens<E>,
+                                 val f: PathLens<F>, val g: PathLens<G>, val h: PathLens<H>, val i: PathLens<I>,
+                                 val j: PathLens<J>) : ContractRouteSpec(pathFn, routeMeta, a, b, c, d, e, f, g, h, i, j) {
+    override fun with(new: RouteMeta): ContractRouteSpec10<A, B, C, D, E, F, G, H, I, J> = ContractRouteSpec10(pathFn, new, a, b, c, d, e, f, g, h, i, j)
+
     override infix operator fun div(next: String) = throw UnsupportedOperationException("no longer paths!")
 
     override infix operator fun <NEXT> div(next: PathLens<NEXT>) = throw UnsupportedOperationException("no longer paths!")
 }
+
 

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
@@ -131,9 +131,81 @@ class ContractRouteTest {
         checkMatching(Path.of("value") / Path.of("value2") / Path.of("value3") / Path.of("value4") bindContract GET to ::matched, "/value1/value2/value3/value4", "value1value2value3value4")
     }
 
+    @Test
+    fun `5 parts - matches route`() {
+        fun matched(value1: String, value2: String, value3: String, value4: String, value5: String) =
+                { _: Request -> Response(OK).body(value1 + value2 + value3 + value4 + value5) }
+
+        checkMatching(Path.of("value") / Path.of("value2") / Path.of("value3") / Path.of("value4") / Path.of("value5")
+                bindContract GET to ::matched, "/value1/value2/value3/value4/value5", "value1value2value3value4value5")
+    }
+
+    @Test
+    fun `6 parts - matches route`() {
+        fun matched(value1: String, value2: String, value3: String, value4: String, value5: String, value6: String) =
+                { _: Request -> Response(OK).body(value1 + value2 + value3 + value4 + value5 + value6) }
+
+        checkMatching(Path.of("value") / Path.of("value2") / Path.of("value3") / Path.of("value4") /
+                Path.of("value5") / Path.of("value6")
+                bindContract GET to ::matched, "/value1/value2/value3/value4/value5/value6",
+                "value1value2value3value4value5value6")
+    }
+
+    @Test
+    fun `7 parts - matches route`() {
+        fun matched(value1: String, value2: String, value3: String, value4: String, value5: String, value6: String,
+                    value7: String) = { _: Request -> Response(OK).body(value1 + value2 + value3 + value4 +
+                value5 + value6 + value7) }
+
+        checkMatching(Path.of("value") / Path.of("value2") / Path.of("value3") / Path.of("value4") /
+                Path.of("value5") / Path.of("value6") / Path.of("value7")
+                bindContract GET to ::matched, "/value1/value2/value3/value4/value5/value6/value7",
+                "value1value2value3value4value5value6value7")
+    }
+
+    @Test
+    fun `8 parts - matches route`() {
+        fun matched(value1: String, value2: String, value3: String, value4: String, value5: String, value6: String,
+                    value7: String, value8: String) = { _: Request -> Response(OK).body(value1 + value2 +
+                value3 + value4 + value5 + value6 + value7 + value8) }
+
+        checkMatching(Path.of("value") / Path.of("value2") / Path.of("value3") / Path.of("value4") /
+                Path.of("value5") / Path.of("value6") / Path.of("value7") / Path.of("value8")
+                bindContract GET to ::matched, "/value1/value2/value3/value4/value5/value6/value7/value8",
+                "value1value2value3value4value5value6value7value8")
+    }
+
+    @Test
+    fun `9 parts - matches route`() {
+        fun matched(value1: String, value2: String, value3: String, value4: String, value5: String, value6: String,
+                    value7: String, value8: String, value9: String) = { _: Request -> Response(OK).body(value1 +
+                value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9) }
+
+        checkMatching(Path.of("value") / Path.of("value2") / Path.of("value3") / Path.of("value4") /
+                Path.of("value5") / Path.of("value6") / Path.of("value7") / Path.of("value8") /
+                Path.of("value9")
+                bindContract GET to ::matched, "/value1/value2/value3/value4/value5/value6/value7/value8/value9",
+                "value1value2value3value4value5value6value7value8value9")
+    }
+
+    @Test
+    fun `10 parts - matches route`() {
+        fun matched(value1: String, value2: String, value3: String, value4: String, value5: String, value6: String,
+                    value7: String, value8: String, value9: String, value10: String) = { _: Request -> Response(OK)
+                .body(value1 + value2 + value3 + value4 + value5 + value6 + value7 + value8 + value9 + value10) }
+
+        checkMatching(Path.of("value") / Path.of("value2") / Path.of("value3") / Path.of("value4") /
+                Path.of("value5") / Path.of("value6") / Path.of("value7") / Path.of("value8") /
+                Path.of("value9") / Path.of("value10")
+                bindContract GET to ::matched, "/value1/value2/value3/value4/value5/value6/value7/value8/value9/value10",
+                "value1value2value3value4value5value6value7value8value9value10")
+    }
+
     @Test(expected = UnsupportedOperationException::class)
-    fun `5 parts - unsupported`() {
-        Path.of("value") / Path.of("value2") / Path.of("value3") / Path.of("value4") / Path.of("value5")
+    fun `11 parts - unsupported`() {
+        Path.of("value") / Path.of("value2") / Path.of("value3") / Path.of("value4")/
+                Path.of("value5") / Path.of("value6") / Path.of("value7") / Path.of("value8") /
+                Path.of("value9") / Path.of("value10") / Path.of("value11")
     }
 
     private fun checkMatching(route: ContractRoute, valid: String, expected: String) {


### PR DESCRIPTION
I ran into this issue when I was trying to implement an api with HTTP4k and really need the support for at least 6 path parameters. I added 10 in the hopes of being more future proof. 