### PR TITLE
add extra escaping to URI_TEMPLATE_FORMAT to make router work on Android

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/UriTemplate.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/UriTemplate.kt
@@ -19,7 +19,7 @@ class UriTemplate private constructor(private val template: String) {
     }
 
     companion object {
-        private val URI_TEMPLATE_FORMAT = "\\{([^}]+?)(?::([^}]+))?}".toRegex()
+        private val URI_TEMPLATE_FORMAT = "\\{([^}]+?)(?::([^}]+))?\\}".toRegex()
         fun from(template: String) = UriTemplate(template.trimSlashes())
 
         fun String.trimSlashes() = "^(/)?(.*?)(/)?$".toRegex().replace(this, { result -> result.groupValues[2] })


### PR DESCRIPTION
When attempting to create a `router` on Android, we hit a fatal `java.util.regex.PatternSyntaxException`:

```
Process: org.example.test, PID: 17588
java.lang.ExceptionInInitializerError
    at org.http4k.routing.PathMethod.to(routing.kt:40)
    at org.example.test.MainActivity.onCreate(MainActivity.kt:25)
    at android.app.Activity.performCreate(Activity.java:6684)
    at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1119)
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2637)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2751)
    at android.app.ActivityThread.-wrap12(ActivityThread.java)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1496)
    at android.os.Handler.dispatchMessage(Handler.java:102)
    at android.os.Looper.loop(Looper.java:154)
    at android.app.ActivityThread.main(ActivityThread.java:6186)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
 Caused by: java.util.regex.PatternSyntaxException: Syntax error in regexp pattern near index 24
\{([^}]+?)(?::([^}]+))?}
                        ^
    at java.util.regex.Pattern.compileImpl(Native Method)
    at java.util.regex.Pattern.compile(Pattern.java:1340)
    at java.util.regex.Pattern.<init>(Pattern.java:1324)
    at java.util.regex.Pattern.compile(Pattern.java:946)
    at kotlin.text.Regex.<init>(Regex.kt:102)
    at org.http4k.core.UriTemplate.<clinit>(UriTemplate.kt:22)
     ... 14 more
```

This can be reproduced very easily with the following Activity:
```java
package org.example.test

import android.support.v7.app.AppCompatActivity
import android.os.Bundle
import org.http4k.core.Method
import org.http4k.core.Request
import org.http4k.core.Response
import org.http4k.core.Status.Companion.OK
import org.http4k.routing.bind
import org.http4k.routing.routes
import org.http4k.server.Http4kServer
import org.http4k.server.Netty
import org.http4k.server.asServer


class MainActivity : AppCompatActivity() {

    private lateinit var server: Http4kServer

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(R.layout.activity_main)

        val app = routes(
                "/" bind Method.GET to {
                    _: Request -> Response(OK).body("Hello World!")
                }
        )
        val netty = Netty(8080)
        server = app.asServer(netty).start()
    }

    override fun onDestroy() {
        this.server.stop()
        super.onDestroy()
    }
}
```

Resolution: The regular expression in question needs additional escaping to make it more portable.
Unfortunately I have no idea how to write an explicit test for this.