### PR TITLE
replacing x-uri-template header with RoutedResponse and RoutedRequest

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/HttpTransaction.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/HttpTransaction.kt
@@ -1,10 +1,15 @@
 package org.http4k.core
 
-import org.http4k.lens.Header
+import org.http4k.routing.RoutedRequest
+import org.http4k.routing.RoutedResponse
 import java.time.Duration
 
 data class HttpTransaction(val request: Request, val response: Response, val duration: Duration, val labels: Map<String, String> =
-Header.X_URI_TEMPLATE(request)?.let { it -> mapOf(ROUTING_GROUP_LABEL to it) } ?: emptyMap()) {
+    when {
+        response is RoutedResponse -> mapOf(ROUTING_GROUP_LABEL to response.xUriTemplate.toString())
+        request is RoutedRequest -> mapOf(ROUTING_GROUP_LABEL to request.xUriTemplate.toString())
+        else -> emptyMap()
+    }) {
     fun label(name: String, value: String) = copy(labels = labels + (name to value))
     fun label(name: String) = labels[name]
 

--- a/http4k-core/src/main/kotlin/org/http4k/core/UriTemplate.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/UriTemplate.kt
@@ -5,7 +5,7 @@ import java.net.URLEncoder
 import java.util.regex.Pattern
 
 
-class UriTemplate private constructor(private val template: String) {
+data class UriTemplate private constructor(private val template: String) {
     private val templateRegex: Regex
     private val matches: Sequence<MatchResult>
     private val parameterNames: List<String>

--- a/http4k-core/src/main/kotlin/org/http4k/lens/header.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/header.kt
@@ -22,6 +22,4 @@ object Header : BiDiLensSpec<HttpMessage, String>("header", StringParam,
             },
             ContentType::toHeaderValue).optional("content-type")
     }
-
-    val X_URI_TEMPLATE = optional("x-uri-template")
 }

--- a/http4k-core/src/test/kotlin/org/http4k/core/HttpTransactionTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/HttpTransactionTest.kt
@@ -4,18 +4,21 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.http4k.core.Method.GET
 import org.http4k.core.Status.Companion.OK
-import org.http4k.lens.Header
+import org.http4k.routing.RoutedResponse
 import org.junit.Test
 import java.time.Duration.ZERO
 
 class HttpTransactionTest {
 
     @Test
-    fun `can get the routing group`() {
+    fun `cannot get the routing group from a standard Response`() {
         assertThat(HttpTransaction(Request(GET, Uri.of("/")), Response(OK), ZERO).routingGroup, equalTo("UNMAPPED"))
+    }
 
-        assertThat(HttpTransaction(Request(GET, Uri.of("/"))
-            .with(Header.X_URI_TEMPLATE of "hello"), Response(OK), ZERO).routingGroup, equalTo("hello"))
+    @Test
+    fun `can get the routing group from a RoutedResponse`() {
+        val response = RoutedResponse(Response(OK), UriTemplate.from("hello"))
+        assertThat(HttpTransaction(Request(GET, Uri.of("/")), response, ZERO).routingGroup, equalTo("hello"))
     }
 
 }

--- a/http4k-core/src/test/kotlin/org/http4k/lens/PathTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/PathTest.kt
@@ -7,7 +7,9 @@ import org.http4k.core.Method
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Uri
+import org.http4k.core.UriTemplate
 import org.http4k.core.with
+import org.http4k.routing.RoutedRequest
 import org.junit.Test
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -41,7 +43,7 @@ class PathTest {
 
     @Test
     fun `value present in request when it has been pre-parsed`() {
-        val target = Request(Method.GET, "/some/world").header("x-uri-template", "/some/{hello}")
+        val target = RoutedRequest(Request(Method.GET, "/some/world"), UriTemplate.from("/some/{hello}"))
 
         assertThat(Path.of("hello")(target), equalTo("world"))
         assertThat(Path.of("hello").extract(target), equalTo("world"))

--- a/http4k-core/src/test/kotlin/org/http4k/routing/RoutingTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/routing/RoutingTest.kt
@@ -191,7 +191,7 @@ class RoutingTest {
             Request(GET, "/").path("abc")
             fail("Expected exception")
         } catch (e: IllegalStateException) {
-            assertThat(e.message, equalTo("x-uri-template header not present in the request"))
+            assertThat(e.message, equalTo("Request was not routed, so no uri-template not present"))
         }
     }
 


### PR DESCRIPTION
This solves the issue with setting and removing the header. We now use polymorphism.

The only thing I'm not sure about is if we should have a RoutedHttpMessage sealed class to sit over the top. This would abstract the xUriTemplate and remove a line in the HttpTransaction.