### PR TITLE
OpenApi example values

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/util/JsonSchema.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/util/JsonSchema.kt
@@ -1,5 +1,7 @@
 package org.http4k.util
 
+//import argo.jdom.JsonNode
+import argo.jdom.JsonNode
 import org.http4k.format.Json
 import org.http4k.format.JsonType
 import org.http4k.lens.ParamMeta
@@ -19,15 +21,18 @@ class JsonToJsonSchema<ROOT : NODE, NODE>(private val json: Json<ROOT, NODE>) {
         when (json.typeOf(node)) {
             JsonType.Object -> objectSchema(overrideDefinitionId)
             JsonType.Array -> arraySchema()
-            JsonType.String -> JsonSchema(StringParam.schema(), definitions)
+            JsonType.String -> JsonSchema(StringParam.schema(json.string(json.text(node))), definitions)
             JsonType.Number -> numberSchema()
-            JsonType.Boolean -> JsonSchema(BooleanParam.schema(), definitions)
+            JsonType.Boolean -> JsonSchema(BooleanParam.schema(json.boolean(json.bool(node))), definitions)
             JsonType.Null -> throw IllegalSchemaException("Cannot use a null value in a schema!")
             else -> throw IllegalSchemaException("unknown type")
         }
 
-    private fun JsonSchema<NODE>.numberSchema(): JsonSchema<NODE> =
-        JsonSchema((if (json.text(node).contains(".")) NumberParam else IntegerParam).schema(), definitions)
+    private fun JsonSchema<NODE>.numberSchema(): JsonSchema<NODE> {
+        val text = json.text(node)
+        val schema = if (text.contains(".")) NumberParam.schema(json.number(text.toBigDecimal())) else IntegerParam.schema(json.number(text.toBigInteger()))
+        return JsonSchema(schema, definitions)
+    }
 
     private fun JsonSchema<NODE>.arraySchema(): JsonSchema<NODE> {
         val (node, definitions) = json.elements(node).toList().firstOrNull()?.let {
@@ -47,6 +52,6 @@ class JsonToJsonSchema<ROOT : NODE, NODE>(private val json: Json<ROOT, NODE>) {
         return JsonSchema(json.obj("\$ref" to json.string("#/definitions/$definitionId")), allDefinitions)
     }
 
-    private fun ParamMeta.schema(): NODE = json.obj("type" to json.string(value))
+    private fun ParamMeta.schema(example: NODE): NODE = json.obj("type" to json.string(value), "example" to example)
 }
 

--- a/http4k-contract/src/main/kotlin/org/http4k/util/JsonSchema.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/util/JsonSchema.kt
@@ -1,7 +1,5 @@
 package org.http4k.util
 
-//import argo.jdom.JsonNode
-import argo.jdom.JsonNode
 import org.http4k.format.Json
 import org.http4k.format.JsonType
 import org.http4k.lens.ParamMeta

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -16,7 +16,6 @@ import org.http4k.core.Status.Companion.OK
 import org.http4k.core.with
 import org.http4k.format.Argo
 import org.http4k.format.Argo.json
-import org.http4k.format.Argo.parse
 import org.http4k.format.Argo.prettify
 import org.http4k.lens.FormField
 import org.http4k.lens.Header

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -17,6 +17,7 @@ import org.http4k.core.with
 import org.http4k.format.Argo
 import org.http4k.format.Argo.json
 import org.http4k.format.Argo.parse
+import org.http4k.format.Argo.prettify
 import org.http4k.lens.FormField
 import org.http4k.lens.Header
 import org.http4k.lens.Invalid
@@ -94,7 +95,6 @@ abstract class ContractRendererContract(private val renderer: ContractRenderer) 
 
         val expected = String(this.javaClass.getResourceAsStream("${this.javaClass.simpleName}.json").readBytes())
         val actual = router(Request(Method.GET, "/basepath?the_api_key=somevalue")).bodyString()
-        println(actual)
-        assertThat(parse(actual), equalTo(parse(expected)))
+        assertThat(prettify(actual), equalTo(prettify(expected)))
     }
 }

--- a/http4k-contract/src/test/kotlin/org/http4k/util/JsonToJsonSchemaTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/util/JsonToJsonSchemaTest.kt
@@ -19,7 +19,7 @@ class JsonToJsonSchemaTest {
     fun `renders all different types of json value as expected`() {
         val model = json.obj(
             "aString" to json.string("aStringValue"),
-            "aNumber" to json.number(BigDecimal(1.9)),
+            "aNumber" to json.number(BigDecimal("1.9")),
             "aBooleanTrue" to json.boolean(true),
             "aBooleanFalse" to json.boolean(false),
             "anArray" to json.array(listOf(json.obj("anotherString" to json.string("yetAnotherString")))),
@@ -32,6 +32,6 @@ class JsonToJsonSchemaTest {
         assertThat(actual.node, equalTo(expected))
         val expectedDefs = "JsonSchema_definitions.json".readResource().asJsonValue()
         println(json.pretty(obj(actual.definitions)))
-        assertThat(obj(actual.definitions), equalTo(expectedDefs))
+        assertThat(json.pretty(obj(actual.definitions)), equalTo(json.pretty(expectedDefs)))
     }
 }

--- a/http4k-contract/src/test/resources/org/http4k/contract/OpenApiTest.json
+++ b/http4k-contract/src/test/resources/org/http4k/contract/OpenApiTest.json
@@ -50,7 +50,7 @@
           "200": {
             "description": "peachy",
             "schema": {
-              "$ref": "#/definitions/object730441992"
+              "$ref": "#/definitions/object-1396932212"
             }
           },
           "202": {
@@ -110,7 +110,7 @@
           "403": {
             "description": "no way jose",
             "schema": {
-              "$ref": "#/definitions/object-610697972"
+              "$ref": "#/definitions/object1283926341"
             }
           }
         },
@@ -193,11 +193,12 @@
     }
   },
   "definitions": {
-    "object-126231440": {
+    "object-546230254": {
       "type": "object",
       "properties": {
         "notAStringField": {
-          "type": "integer"
+          "type": "integer",
+          "example": 123
         }
       }
     },
@@ -205,23 +206,25 @@
       "type": "object",
       "properties": {
         "anObject": {
-          "$ref": "#/definitions/object-126231440"
+          "$ref": "#/definitions/object-546230254"
         }
       }
     },
-    "object-610697972": {
+    "object1283926341": {
       "type": "object",
       "properties": {
         "aString": {
-          "type": "string"
+          "type": "string",
+          "example": "a message of some kind"
         }
       }
     },
-    "object-945612357": {
+    "object-1365611171": {
       "type": "object",
       "properties": {
         "aNumberField": {
-          "type": "integer"
+          "type": "integer",
+          "example": 123
         }
       }
     },
@@ -229,15 +232,15 @@
       "type": "object",
       "properties": {
         "anAnotherObject": {
-          "$ref": "#/definitions/object-945612357"
+          "$ref": "#/definitions/object-1365611171"
         }
       }
     },
-    "object730441992": {
+    "object-1396932212": {
       "type": "object",
       "properties": {
         "anAnotherObject": {
-          "$ref": "#/definitions/object-945612357"
+          "$ref": "#/definitions/object-1365611171"
         }
       }
     }

--- a/http4k-contract/src/test/resources/org/http4k/util/JsonSchema_definitions.json
+++ b/http4k-contract/src/test/resources/org/http4k/util/JsonSchema_definitions.json
@@ -3,7 +3,8 @@
     "type": "object",
     "properties": {
       "anotherString": {
-        "type": "string"
+        "type": "string",
+        "example": "yetAnotherString"
       }
     }
   },
@@ -11,7 +12,8 @@
     "type": "object",
     "properties": {
       "anInteger": {
-        "type": "integer"
+        "type": "integer",
+        "example": 1
       }
     }
   },
@@ -19,16 +21,20 @@
     "type": "object",
     "properties": {
       "aString": {
-        "type": "string"
+        "type": "string",
+        "example": "aStringValue"
       },
       "aNumber": {
-        "type": "number"
+        "type": "number",
+        "example": 1.9
       },
       "aBooleanTrue": {
-        "type": "boolean"
+        "type": "boolean",
+        "example": "true"
       },
       "aBooleanFalse": {
-        "type": "boolean"
+        "type": "boolean",
+        "example": "false"
       },
       "anArray": {
         "type": "array",

--- a/http4k-contract/src/test/resources/org/http4k/util/JsonSchema_definitions.json
+++ b/http4k-contract/src/test/resources/org/http4k/util/JsonSchema_definitions.json
@@ -1,5 +1,5 @@
 {
-  "object1566645290": {
+  "object1048897856": {
     "type": "object",
     "properties": {
       "anotherString": {
@@ -8,7 +8,7 @@
       }
     }
   },
-  "object-1591149158": {
+  "object-2011196613": {
     "type": "object",
     "properties": {
       "anInteger": {
@@ -30,23 +30,23 @@
       },
       "aBooleanTrue": {
         "type": "boolean",
-        "example": "true"
+        "example": true
       },
       "aBooleanFalse": {
         "type": "boolean",
-        "example": "false"
+        "example": false
       },
       "anArray": {
         "type": "array",
         "items": {
-          "$ref": "#/definitions/object1566645290"
+          "$ref": "#/definitions/object1048897856"
         }
       },
       "anObject": {
-        "$ref": "#/definitions/object-1591149158"
+        "$ref": "#/definitions/object-2011196613"
       },
       "anotherObject": {
-        "$ref": "#/definitions/object-1591149158"
+        "$ref": "#/definitions/object-2011196613"
       }
     }
   }

--- a/http4k-core/src/main/kotlin/org/http4k/format/Json.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/format/Json.kt
@@ -38,6 +38,7 @@ interface Json<ROOT : NODE, NODE> {
     fun fields(node: NODE): Iterable<Pair<String, NODE>>
     fun elements(value: NODE): Iterable<NODE>
     fun text(value: NODE): String
+    fun bool(value: NODE): Boolean
 
     fun compactify(s: String) = parse(s).asCompactJsonString()
 

--- a/http4k-core/src/test/kotlin/org/http4k/format/JsonContract.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/format/JsonContract.kt
@@ -77,6 +77,11 @@ abstract class JsonContract<ROOT : NODE, NODE>(open val j: Json<ROOT, NODE>) {
     }
 
     @Test
+    fun `get boolean`() {
+        assertThat(j.bool(j.boolean(true)), equalTo(true))
+    }
+
+    @Test
     fun `get elements`() {
         val fields = listOf(j.string("world"), j.string("world2"))
         val elements = j.elements(j.array(fields)).toList()

--- a/http4k-format-argo/src/main/kotlin/org/http4k/format/Argo.kt
+++ b/http4k-format-argo/src/main/kotlin/org/http4k/format/Argo.kt
@@ -44,6 +44,7 @@ object Argo : Json<JsonRootNode, JsonNode> {
     override fun fields(node: JsonNode): Iterable<Pair<String, JsonNode>> = node.fieldList.map { it.name.text to it.value }
     override fun elements(value: JsonNode): Iterable<JsonNode> = value.elements
     override fun text(value: JsonNode): String = value.text
+    override fun bool(value: JsonNode): Boolean = value.getBooleanValue()
 
     private fun field(name: String, value: JsonNode) = JsonNodeFactories.field(name, value)
 }

--- a/http4k-format-gson/src/main/kotlin/org/http4k/format/Gson.kt
+++ b/http4k-format-gson/src/main/kotlin/org/http4k/format/Gson.kt
@@ -1,6 +1,12 @@
 package org.http4k.format
 
-import com.google.gson.*
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.google.gson.JsonPrimitive
 import org.http4k.core.Body
 import org.http4k.lens.BiDiBodyLensSpec
 import org.http4k.lens.BiDiWsMessageLensSpec

--- a/http4k-format-gson/src/main/kotlin/org/http4k/format/Gson.kt
+++ b/http4k-format-gson/src/main/kotlin/org/http4k/format/Gson.kt
@@ -1,12 +1,6 @@
 package org.http4k.format
 
-import com.google.gson.GsonBuilder
-import com.google.gson.JsonArray
-import com.google.gson.JsonElement
-import com.google.gson.JsonNull
-import com.google.gson.JsonObject
-import com.google.gson.JsonParser
-import com.google.gson.JsonPrimitive
+import com.google.gson.*
 import org.http4k.core.Body
 import org.http4k.lens.BiDiBodyLensSpec
 import org.http4k.lens.BiDiWsMessageLensSpec
@@ -69,12 +63,12 @@ open class ConfigurableGson(builder: GsonBuilder) : JsonLibAutoMarshallingJson<J
 
     override fun elements(value: JsonElement): Iterable<JsonElement> = value.asJsonArray
     override fun text(value: JsonElement): String = value.asString
+    override fun bool(value: JsonElement): Boolean = value.asBoolean
 
     override fun asJsonObject(a: Any): JsonElement = compact.toJsonTree(a)
     override fun <T : Any> asA(s: String, c: KClass<T>): T = compact.fromJson(s, c.java)
     override fun <T : Any> asA(j: JsonElement, c: KClass<T>): T = compact.fromJson(j, c.java)
 
-    inline fun <reified T : Any> String.asA(): T = asA(this, T::class)
     inline fun <reified T : Any> JsonElement.asA(): T = asA(this, T::class)
 
     inline fun <reified T : Any> Body.Companion.auto(description: String? = null, contentNegotiation: ContentNegotiation = ContentNegotiation.None): BiDiBodyLensSpec<T> = Body.json(description, contentNegotiation).map({ it.asA<T>() }, { it.asJsonObject() })

--- a/http4k-format-jackson/src/main/kotlin/org/http4k/format/Jackson.kt
+++ b/http4k-format-jackson/src/main/kotlin/org/http4k/format/Jackson.kt
@@ -68,6 +68,7 @@ open class ConfigurableJackson(private val mapper: ObjectMapper) : JsonLibAutoMa
 
     override fun elements(value: JsonNode): Iterable<JsonNode> = value.elements().asSequence().asIterable()
     override fun text(value: JsonNode): String = value.asText()
+    override fun bool(value: JsonNode): Boolean = value.asBoolean()
 
     override fun asJsonObject(a: Any): JsonNode = mapper.convertValue(a, JsonNode::class.java)
     override fun <T : Any> asA(s: String, c: KClass<T>): T = mapper.convertValue(s.asJsonObject(), c.java)

--- a/http4k-format-jackson/src/main/kotlin/org/http4k/format/Jackson.kt
+++ b/http4k-format-jackson/src/main/kotlin/org/http4k/format/Jackson.kt
@@ -74,7 +74,6 @@ open class ConfigurableJackson(private val mapper: ObjectMapper) : JsonLibAutoMa
     override fun <T : Any> asA(s: String, c: KClass<T>): T = mapper.convertValue(s.asJsonObject(), c.java)
     override fun <T : Any> asA(j: JsonNode, c: KClass<T>): T = mapper.convertValue(j, c.java)
 
-    inline fun <reified T : Any> String.asA(): T = asA(this, T::class)
     inline fun <reified T : Any> JsonNode.asA(): T = asA(this, T::class)
 
     inline fun <reified T : Any> Body.Companion.auto(description: String? = null, contentNegotiation: ContentNegotiation = ContentNegotiation.None): BiDiBodyLensSpec<T> = Body.json(description, contentNegotiation).map({ it.asA<T>() }, { it.asJsonObject() })


### PR DESCRIPTION
For example objects in a schema, this PR will populate the example field of OpenAPI so that end users will see an example request rather than simply `"string"` or `0`.