### PR TITLE
Get rid of reflection netty factory

### DIFF
--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
@@ -4,12 +4,8 @@ package org.http4k.server
 import io.netty.bootstrap.ServerBootstrap
 import io.netty.buffer.ByteBufInputStream
 import io.netty.buffer.ByteBufOutputStream
-import io.netty.channel.ChannelFuture
+import io.netty.channel.*
 import io.netty.channel.ChannelFutureListener.CLOSE
-import io.netty.channel.ChannelHandlerContext
-import io.netty.channel.ChannelInitializer
-import io.netty.channel.ChannelOption
-import io.netty.channel.SimpleChannelInboundHandler
 import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioServerSocketChannel
@@ -71,7 +67,7 @@ data class Netty(val port: Int = 8000) : ServerConfig {
         override fun start(): Http4kServer = apply {
             val bootstrap = ServerBootstrap()
             bootstrap.group(masterGroup, workerGroup)
-                .channel(NioServerSocketChannel::class.java)
+                .channelFactory(ChannelFactory<ServerChannel> { NioServerSocketChannel() })
                 .childHandler(object : ChannelInitializer<SocketChannel>() {
                     public override fun initChannel(ch: SocketChannel) {
                         ch.pipeline().addLast("codec", HttpServerCodec())


### PR DESCRIPTION
This provides a specific factory for server channels rather than relying on the reflection one internally, this improves compatibility with GraalVM