### PR TITLE
Add support for propagation of the Zipkin x-b3-sampled header

### DIFF
--- a/http4k-core/src/test/kotlin/org/http4k/filter/ClientFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ClientFiltersTest.kt
@@ -90,7 +90,7 @@ class ClientFiltersTest {
 
     @Test
     fun `adds request tracing to outgoing request when already present`() {
-        val zipkinTraces = ZipkinTraces(TraceId("originalTraceId"), TraceId("originalSpanId"), TraceId("originalParentId"))
+        val zipkinTraces = ZipkinTraces(TraceId("originalTraceId"), TraceId("originalSpanId"), TraceId("originalParentId"), SamplingDecision.SAMPLE)
         ZipkinTraces.THREAD_LOCAL.set(zipkinTraces)
 
         var start: Pair<Request, ZipkinTraces>? = null
@@ -101,14 +101,14 @@ class ClientFiltersTest {
             { req, resp, trace -> end = Triple(req, resp, trace) }
         ).then { it ->
             val actual = ZipkinTraces(it)
-            assertThat(actual, equalTo(ZipkinTraces(TraceId("originalTraceId"), actual.spanId, TraceId("originalSpanId"))))
+            assertThat(actual, equalTo(ZipkinTraces(TraceId("originalTraceId"), actual.spanId, TraceId("originalSpanId"), SamplingDecision.SAMPLE)))
             assertThat(actual.spanId, !equalTo(zipkinTraces.spanId))
             Response(OK)
         }
 
         svc(Request(GET, "")) shouldMatch equalTo(Response(OK))
-        assertThat(start, equalTo(Request(GET, "") to ZipkinTraces(TraceId("originalTraceId"), end!!.third.spanId, TraceId("originalSpanId"))))
-        assertThat(end, equalTo(Triple(Request(GET, ""), Response(OK), ZipkinTraces(TraceId("originalTraceId"), end!!.third.spanId, TraceId("originalSpanId")))))
+        assertThat(start, equalTo(Request(GET, "") to ZipkinTraces(TraceId("originalTraceId"), end!!.third.spanId, TraceId("originalSpanId"), SamplingDecision.SAMPLE)))
+        assertThat(end, equalTo(Triple(Request(GET, ""), Response(OK), ZipkinTraces(TraceId("originalTraceId"), end!!.third.spanId, TraceId("originalSpanId"), SamplingDecision.SAMPLE))))
     }
 
     @Test

--- a/http4k-core/src/test/kotlin/org/http4k/filter/RequestTracingTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/RequestTracingTest.kt
@@ -10,6 +10,7 @@ import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.then
+import org.http4k.filter.SamplingDecision.Companion.DO_NOT_SAMPLE
 import org.junit.Before
 import org.junit.Test
 
@@ -25,7 +26,7 @@ class RequestTracingTest {
         val originalTraceId = TraceId("originalTrace")
         val originalSpanId = TraceId("originalSpan")
         val originalParentSpanId = TraceId("originalParentSpanId")
-        val traces = ZipkinTraces(originalTraceId, originalSpanId, originalParentSpanId)
+        val traces = ZipkinTraces(originalTraceId, originalSpanId, originalParentSpanId, DO_NOT_SAMPLE)
 
         val client: HttpHandler = ClientFilters.RequestTracing().then {
             val actual = ZipkinTraces(it)
@@ -33,6 +34,7 @@ class RequestTracingTest {
             actual.traceId shouldMatch equalTo(originalTraceId)
             actual.parentSpanId shouldMatch equalTo(originalSpanId)
             actual.spanId shouldMatch present()
+            actual.samplingDecision shouldMatch equalTo(DO_NOT_SAMPLE)
 
             Response(OK)
         }


### PR DESCRIPTION
As per the [Zipkin spec](https://github.com/openzipkin/b3-propagation) there's a standardised sampling decision header that can be used to inform clients as to whether they should sample the current request. This adds support for the capture and propagation of this header, allowing recording filters to decide whether or not to sample based on an upstream decision.

Note that we default to "sample" so as to maintain backwards compatibility.