### PR TITLE
SetHostFrom: Port should be added to header when non-null

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ClientFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ClientFilters.kt
@@ -45,7 +45,9 @@ object ClientFilters {
      */
     object SetHostFrom {
         operator fun invoke(uri: Uri): Filter = Filter { next ->
-            { next(it.uri(it.uri.scheme(uri.scheme).host(uri.host).port(uri.port)).replaceHeader("Host", uri.host)) }
+            { next(it.uri(it.uri.scheme(uri.scheme).host(uri.host).port(uri.port)).replaceHeader("Host", "${uri.host}${
+              uri.port?.let { port -> ":$port" } ?: ""
+            }")) }
         }
     }
 

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ClientFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ClientFiltersTest.kt
@@ -123,8 +123,14 @@ class ClientFiltersTest {
 
     @Test
     fun `set host on client`() {
-        val handler = ClientFilters.SetHostFrom(Uri.of("http://localhost:8080")).then { Response(OK).header("Host", it.header("Host")).body(it.uri.toString()) }
-        handler(Request(GET, "/loop")) shouldMatch hasBody("http://localhost:8080/loop").and(hasHeader("Host", "localhost"))
+        val handler = ClientFilters.SetHostFrom(Uri.of("http://localhost:123")).then { Response(OK).header("Host", it.header("Host")).body(it.uri.toString()) }
+        handler(Request(GET, "/loop")) shouldMatch hasBody("http://localhost:123/loop").and(hasHeader("Host", "localhost:123"))
+    }
+
+    @Test
+    fun `set host without port on client`() {
+        val handler = ClientFilters.SetHostFrom(Uri.of("http://localhost")).then { Response(OK).header("Host", it.header("Host")).body(it.uri.toString()) }
+        handler(Request(GET, "/loop")) shouldMatch hasBody("http://localhost/loop").and(hasHeader("Host", "localhost"))
     }
 
     @Test


### PR DESCRIPTION
When the port isn't null, it gets appended to the host name on the 'Host' header. Fixes #162