### PR TITLE
allow navigation to Uri objects

### DIFF
--- a/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/Http4kWebDriver.kt
+++ b/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/Http4kWebDriver.kt
@@ -28,6 +28,10 @@ import org.http4k.core.cookie.Cookie as HCookie
 
 typealias Navigate = (Request) -> Unit
 
+interface Http4KNavigation : Navigation {
+    fun to(uri: Uri)
+}
+
 class Http4kWebDriver(initialHandler: HttpHandler) : WebDriver {
     private val handler = ClientFilters.FollowRedirects()
             .then(ClientFilters.Cookies(storage = cookieStorage()))
@@ -68,6 +72,8 @@ class Http4kWebDriver(initialHandler: HttpHandler) : WebDriver {
     override fun get(url: String) {
         navigateTo(Request(GET, url).body(""))
     }
+
+    fun get(uri: Uri) = this.get(uri.toString())
 
     override fun getCurrentUrl(): String? = current?.url
 
@@ -113,7 +119,7 @@ class Http4kWebDriver(initialHandler: HttpHandler) : WebDriver {
         override fun defaultContent(): WebDriver = this@Http4kWebDriver
     }
 
-    override fun navigate(): Navigation = object : Navigation {
+    override fun navigate():Http4KNavigation = object : Http4KNavigation {
         override fun to(url: String) = get(url)
 
         override fun to(url: URL) = get(url.toString())
@@ -131,6 +137,8 @@ class Http4kWebDriver(initialHandler: HttpHandler) : WebDriver {
         override fun back() {
             current?.previous?.let { current = it.copy(next = current) }
         }
+
+        override fun to(uri: Uri) = get(uri.toString())
     }
 
     override fun manage() = object : WebDriver.Options {

--- a/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
+++ b/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
@@ -6,6 +6,7 @@ import com.natpryce.hamkrest.present
 import org.http4k.core.Method
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
+import org.http4k.core.Uri
 import org.http4k.core.cookie.cookie
 import org.http4k.core.cookie.cookies
 import org.junit.jupiter.api.Test
@@ -88,6 +89,11 @@ class Http4kWebDriverTest {
         driver.navigate().refresh()
         driver.assertOnPage("/bill")
         assertThat(driver.findElement(By.tagName("h2"))!!.text, !equalTo(preRefreshTime))
+        driver.get(Uri.of("https://localhost/rita"))
+        driver.assertOnPage("https://localhost/rita")
+        driver.get("/bill")
+        driver.assertOnPage("/bill")
+        driver.navigate().to(Uri.of("https://localhost/rita"))
     }
 
     @Test


### PR DESCRIPTION
In master if you do:

`driver.navigate().to(Uri.of("http://slashdot.org")) `

then you'll find that to is resolved to an extension method to construct pairs in the Kotlin standard library which will produce code with no effect, which could be confusing.