### PR TITLE
allow empty action items

### DIFF
--- a/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/Http4kWebDriver.kt
+++ b/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/Http4kWebDriver.kt
@@ -27,6 +27,7 @@ import org.http4k.core.cookie.Cookie as HCookie
 
 
 typealias Navigate = (Request) -> Unit
+typealias GetURL = () -> String?
 
 class Http4kWebDriver(initialHandler: HttpHandler) : WebDriver {
     private val handler = ClientFilters.FollowRedirects()
@@ -42,7 +43,7 @@ class Http4kWebDriver(initialHandler: HttpHandler) : WebDriver {
     private fun navigateTo(request: Request) {
         val normalizedPath = request.uri(request.uri.path(normalized(request.uri.path)))
         val response = handler(normalizedPath)
-        current = Page(response.status, this::navigateTo, UUID.randomUUID(), normalized(latestUri), response.bodyString(), current)
+        current = Page(response.status, this::navigateTo, { getCurrentUrl()}, UUID.randomUUID(), normalized(latestUri), response.bodyString(), current)
     }
 
     private fun normalized(path: String) = when {

--- a/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupElementFinder.kt
+++ b/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupElementFinder.kt
@@ -9,7 +9,7 @@ import org.openqa.selenium.internal.FindsByCssSelector
 import org.openqa.selenium.internal.FindsById
 import org.openqa.selenium.internal.FindsByTagName
 
-internal class JSoupElementFinder(private val navigate: Navigate, private val element: Element) :
+internal class JSoupElementFinder(private val navigate: Navigate, private val getURL: GetURL, private val element: Element) :
     FindsByCssSelector, FindsByTagName, FindsById, FindsByClassName, SearchContext {
     override fun findElementByClassName(className: String) = findElementsByClassName(className).firstOrNull()
 
@@ -25,7 +25,7 @@ internal class JSoupElementFinder(private val navigate: Navigate, private val el
 
     override fun findElementByCssSelector(selector: String) = findElementsByCssSelector(selector).firstOrNull()
 
-    override fun findElementsByCssSelector(selector: String): List<WebElement> = element.select(selector).map { JSoupWebElement(navigate, it) }
+    override fun findElementsByCssSelector(selector: String): List<WebElement> = element.select(selector).map { JSoupWebElement(navigate, getURL, it) }
 
     override fun findElement(by: By): WebElement? = by.findElement(this)
 

--- a/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
+++ b/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
@@ -52,8 +52,10 @@ data class JSoupWebElement(private val navigate: Navigate, private val getURL: G
                         .filter { it.isSelected }
                         .map { it.getAttribute("value") }
                 }
-
-            val form = WebForm(inputs.plus(textareas).plus(selects)
+            val buttons = it.findElements(By.tagName("button"))
+                    .filter { it.getAttribute("name") != "" && it == this}
+                    .map { it.getAttribute("name") to listOf(it.getAttribute("value")) }
+            val form = WebForm(inputs.plus(textareas).plus(selects).plus(buttons)
                 .groupBy { it.first }
                 .mapValues { it.value.map { it.second }.flatMap { it } })
 

--- a/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
+++ b/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
@@ -88,6 +88,8 @@ data class JSoupWebElement(private val navigate: Navigate, private val getURL: G
 
             if (oldValue && !currentSelectIsMultiple) clear()
             else element.attr("selected", "selected")
+        } else if (isA("button") && element.attr("type")?:"submit".toLowerCase() == "submit") {
+            submit()
         }
     }
 

--- a/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
+++ b/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
@@ -88,8 +88,10 @@ data class JSoupWebElement(private val navigate: Navigate, private val getURL: G
 
             if (oldValue && !currentSelectIsMultiple) clear()
             else element.attr("selected", "selected")
-        } else if (isA("button") && element.attr("type")?:"submit".toLowerCase() == "submit") {
-            submit()
+        } else if (isA("button")) {
+            val t = element.attr("type")
+            if (t == "" || t.toLowerCase() == "submit")
+                submit()
         }
     }
 

--- a/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
+++ b/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
@@ -17,7 +17,7 @@ import org.openqa.selenium.Point
 import org.openqa.selenium.Rectangle
 import org.openqa.selenium.WebElement
 
-data class JSoupWebElement(private val navigate: Navigate, private val element: Element) : WebElement {
+data class JSoupWebElement(private val navigate: Navigate, private val getURL: GetURL, private val element: Element) : WebElement {
 
     override fun getTagName(): String = element.tagName()
 
@@ -60,7 +60,7 @@ data class JSoupWebElement(private val navigate: Navigate, private val element: 
             val body = Body.webForm(Validator.Strict,
                 *(form.fields.map { FormField.multi.required(it.key) }.toTypedArray())).toLens()
 
-            val uri = it.element.attr("action") ?: "<unknown>"
+            val uri = (it.element.attr("action") ?: getURL()) ?: "<unknown>"
             val postRequest = Request(method, uri).with(body of form)
 
             if (method == Method.POST) navigate(postRequest)
@@ -120,13 +120,13 @@ data class JSoupWebElement(private val navigate: Navigate, private val element: 
 
     override fun hashCode(): Int = element.hashCode()
 
-    override fun findElement(by: By): WebElement? = JSoupElementFinder(navigate, element).findElement(by)
+    override fun findElement(by: By): WebElement? = JSoupElementFinder(navigate, getURL, element).findElement(by)
 
-    override fun findElements(by: By) = JSoupElementFinder(navigate, element).findElements(by)
+    override fun findElements(by: By) = JSoupElementFinder(navigate, getURL, element).findElements(by)
 
     private fun current(tag: String): JSoupWebElement? = if (isA(tag)) this else this.parent()?.current(tag)
 
-    private fun parent(): JSoupWebElement? = element.parent()?.let { JSoupWebElement(navigate, it) }
+    private fun parent(): JSoupWebElement? = element.parent()?.let { JSoupWebElement(navigate, getURL, it) }
 
     private fun isA(tag: String) = tagName.toLowerCase() == tag.toLowerCase()
 }

--- a/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/Page.kt
+++ b/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/Page.kt
@@ -6,15 +6,15 @@ import org.openqa.selenium.By
 import org.openqa.selenium.WebElement
 import java.util.UUID
 
-data class Page(val status: Status, private val navigate: Navigate, val handle: UUID, val url: String, val contents: String, val previous: Page? = null, val next: Page? = null) {
+data class Page(val status: Status, private val navigate: Navigate, private val getURL: GetURL, val handle: UUID, val url: String, val contents: String, val previous: Page? = null, val next: Page? = null) {
 
     private val parsed = Jsoup.parse(contents)
 
     fun findElement(by: By) = findElements(by).firstOrNull()
 
-    fun findElements(by: By): List<WebElement> = by.findElements(JSoupElementFinder(navigate, parsed))
+    fun findElements(by: By): List<WebElement> = by.findElements(JSoupElementFinder(navigate, getURL, parsed))
 
-    fun firstElement() = parsed.body().children().firstOrNull()?.let { JSoupWebElement(navigate, it) }
+    fun firstElement() = parsed.body().children().firstOrNull()?.let { JSoupWebElement(navigate, getURL, it) }
 
     val title: String = parsed.title()
 }

--- a/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
+++ b/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
@@ -50,6 +50,15 @@ class Http4kWebDriverTest {
     }
 
     @Test
+    fun `POST form via button click`() {
+        driver.get("/bob")
+        driver.findElement(By.id("button"))!!.click()
+        driver.assertOnPage("/form")
+        assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2"))
+        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+    }
+
+    @Test
     fun `POST form with empty action`() {
         var loadCount = 0
         val driver = Http4kWebDriver {

--- a/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
+++ b/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
@@ -52,6 +52,8 @@ class Http4kWebDriverTest {
     @Test
     fun `POST form via button click`() {
         driver.get("/bob")
+        driver.findElement(By.id("resetbutton"))!!.click()
+        driver.assertOnPage("/bob")
         driver.findElement(By.id("button"))!!.click()
         driver.assertOnPage("/form")
         assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2"))

--- a/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
+++ b/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
@@ -28,6 +28,7 @@ class Http4kWebDriverTest {
             .replace("THEBODY", req.bodyString())
             .replace("THEURL", req.uri.toString())
             .replace("THETIME", System.currentTimeMillis().toString())
+            .replace("ACTION", "action=\"/form\"")
         )
     }
 
@@ -49,6 +50,32 @@ class Http4kWebDriverTest {
     }
 
     @Test
+    fun `POST form with empty action`() {
+        var loadCount = 0
+        val driver = Http4kWebDriver {
+            req ->
+                loadCount++
+                val body = File("src/test/resources/test.html").readText()
+                Response(OK).body(body
+                        .replace("FORMMETHOD", Method.POST.name)
+                        .replace("THEMETHOD", req.method.name)
+                        .replace("THEBODY", req.bodyString())
+                        .replace("THEURL", req.uri.toString())
+                        .replace("THETIME", System.currentTimeMillis().toString())
+                        .replace("ACTION", "action")
+                )
+        }
+        val n0 = loadCount
+        driver.get("/bob")
+        driver.findElement(By.id("button"))!!.submit()
+        driver.assertOnPage("/bob")
+        assertThat(loadCount, equalTo(n0+2))
+        assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2"))
+        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+    }
+
+
+    @Test
     fun `GET form`() {
         val driver = Http4kWebDriver { req ->
             val body = File("src/test/resources/test.html").readText()
@@ -58,6 +85,7 @@ class Http4kWebDriverTest {
                 .replace("THEBODY", req.bodyString())
                 .replace("THEURL", req.uri.toString())
                 .replace("THETIME", System.currentTimeMillis().toString())
+                .replace("ACTION", "action=\"/form\"")
             )
         }
 

--- a/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
+++ b/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
@@ -45,7 +45,7 @@ class Http4kWebDriverTest {
         driver.get("/bob")
         driver.findElement(By.id("button"))!!.submit()
         driver.assertOnPage("/form")
-        assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2"))
+        assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes"))
         assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
     }
 
@@ -56,7 +56,7 @@ class Http4kWebDriverTest {
         driver.assertOnPage("/bob")
         driver.findElement(By.id("button"))!!.click()
         driver.assertOnPage("/form")
-        assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2"))
+        assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes"))
         assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
     }
 
@@ -81,7 +81,7 @@ class Http4kWebDriverTest {
         driver.findElement(By.id("button"))!!.submit()
         driver.assertOnPage("/bob")
         assertThat(loadCount, equalTo(n0+2))
-        assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2"))
+        assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes"))
         assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
     }
 
@@ -102,7 +102,7 @@ class Http4kWebDriverTest {
 
         driver.get("/bob")
         driver.findElement(By.id("button"))!!.submit()
-        driver.assertOnPage("/form?text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2")
+        driver.assertOnPage("/form?text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
         assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo(""))
         assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("GET"))
     }

--- a/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/JSoupElementFinderTest.kt
+++ b/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/JSoupElementFinderTest.kt
@@ -10,7 +10,7 @@ import java.io.File
 class JSoupElementFinderTest {
     private val contents = File("src/test/resources/test.html").readText()
 
-    private val state = JSoupElementFinder({}, Jsoup.parse(contents))
+    private val state = JSoupElementFinder({}, {null}, Jsoup.parse(contents))
 
     @Test
     fun `find element`() = assertThat(state.findElement(By.tagName("span"))!!.text, equalTo("this is a span"))

--- a/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/JSoupWebElementTest.kt
+++ b/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/JSoupWebElementTest.kt
@@ -18,23 +18,23 @@ class JSoupWebElementTest {
 
     private var newLocation: Pair<Method, String>? = null
     private val navigate: (Request) -> Unit = { it -> newLocation = it.method to it.uri.toString() }
-
-    private fun input(type: String): WebElement = JSoupWebElement(navigate, Jsoup.parse("""<input id="bob" value="someValue" type="$type">""")).findElement(By.tagName("input"))!!
+    private val getURL: () -> String? = { null }
+    private fun input(type: String): WebElement = JSoupWebElement(navigate, getURL, Jsoup.parse("""<input id="bob" value="someValue" type="$type">""")).findElement(By.tagName("input"))!!
 
     private fun select(multiple: Boolean): WebElement =
-        JSoupWebElement(navigate, Jsoup.parse("""<select name="bob" ${if (multiple) "multiple" else ""}>
+        JSoupWebElement(navigate, getURL, Jsoup.parse("""<select name="bob" ${if (multiple) "multiple" else ""}>
             <option>foo1</option>
             <option>foo2</option>
             </select>"""
         )).findElement(By.tagName("select"))!!
 
     private fun element(tag: String = "a"): WebElement =
-        JSoupWebElement(navigate, Jsoup.parse("""<$tag id="bob" href="/link">
+        JSoupWebElement(navigate, getURL, Jsoup.parse("""<$tag id="bob" href="/link">
         |<span>hello</span>
         |<disabled disabled>disabled</disabled>
         |</$tag>""".trimMargin())).findElement(By.tagName(tag))!!
 
-    private fun form(method: Method = POST) = JSoupWebElement(navigate, Jsoup.parse("""
+    private fun form(method: Method = POST) = JSoupWebElement(navigate, getURL, Jsoup.parse("""
         <form method="${method.name}" action="/posted">
             <input id="text" type="text"/>
             <textarea id="textarea"/>

--- a/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/PageTest.kt
+++ b/http4k-testing-webdriver/src/test/kotlin/org/http4k/webdriver/PageTest.kt
@@ -11,7 +11,7 @@ import java.util.UUID
 class PageTest {
     private val contents = File("src/test/resources/test.html").readText()
 
-    private val state = Page(Status.OK, {}, UUID.randomUUID(), "someUrl", contents)
+    private val state = Page(Status.OK, {}, {null}, UUID.randomUUID(), "someUrl", contents)
 
     @Test
     fun `title`() = assertThat(state.title, equalTo("Page title"))

--- a/http4k-testing-webdriver/src/test/resources/test.html
+++ b/http4k-testing-webdriver/src/test/resources/test.html
@@ -27,6 +27,7 @@
             <option value="option2" selected="selected"></option>
         </select>
         <button id="button" value="yes" name="button"/>
+        <button id="resetbutton" type="reset"/>
     </form>
     <a id="noPath" href=""></a>
     <a id="sameDirPath" href="bob"></a>

--- a/http4k-testing-webdriver/src/test/resources/test.html
+++ b/http4k-testing-webdriver/src/test/resources/test.html
@@ -26,7 +26,7 @@
             <option value="option1" selected="selected"></option>
             <option value="option2" selected="selected"></option>
         </select>
-        <button id="button"/>
+        <button id="button" value="yes" name="button"/>
     </form>
     <a id="noPath" href=""></a>
     <a id="sameDirPath" href="bob"></a>

--- a/http4k-testing-webdriver/src/test/resources/test.html
+++ b/http4k-testing-webdriver/src/test/resources/test.html
@@ -17,7 +17,7 @@
     <span>this is a span</span>
     <disabled disabled>this is a disabled item</disabled>
     <a href="/link">this is a link</a>
-    <form action="/form" method="FORMMETHOD">
+    <form ACTION method="FORMMETHOD">
         <input name="text1" type="text" value="textValue"/>
         <textarea name="textarea1">textarea</textarea>
         <input name="checkbox1" type="checkbox" value="checkbox" checked="checked"/>


### PR DESCRIPTION
I found a form in the wild which had an action attribute with no value. This change tests and handles that case in the WebDriver. I've followed the pattern of having callback parameters from the Element that can be used with the driver, rather than keep a WebDriver reference in all SoupElements. What's unfortunately touches more files than I'd like.

I can extend the pattern of counting the number of times the HTTPHandler gets called into the other test cases if you like.


