### PR TITLE
Fix type

### DIFF
--- a/http4k-incubator/src/main/kotlin/org/http4k/routing/experimental/StaticRoutingHttpHandler.kt
+++ b/http4k-incubator/src/main/kotlin/org/http4k/routing/experimental/StaticRoutingHttpHandler.kt
@@ -12,7 +12,7 @@ import org.http4k.core.then
 import org.http4k.routing.Router
 import org.http4k.routing.RoutingHttpHandler
 
-fun static(resourceLoader: ResourceLoading): RoutingHttpHandler = StaticRoutingHttpHandler("", resourceLoader)
+fun static(resourceLoader: Router): RoutingHttpHandler = StaticRoutingHttpHandler("", resourceLoader)
 
 internal data class StaticRoutingHttpHandler(
     private val pathSegments: String,


### PR DESCRIPTION
Dammit we were so close. 

We do want to be able to be able to compile `static(ResourceLoaders.ClassPath())`