### PR TITLE
Fixing problem where unchecked checkboxes are sent through

### DIFF
--- a/http4k-testing-webdriver/src/test/resources/test.html
+++ b/http4k-testing-webdriver/src/test/resources/test.html
@@ -21,6 +21,7 @@
         <input name="text1" type="text" value="textValue"/>
         <textarea name="textarea1">textarea</textarea>
         <input name="checkbox1" type="checkbox" value="checkbox" checked="checked"/>
+        <input name="checkbox1" type="checkbox" value="checkbox2"/>
         <input type="radio" value="radio" checked="checked"/>
         <select name="select1">
             <option value="option1" selected="selected"></option>


### PR DESCRIPTION
Hello! 

It seems there is a bug with the way WebDriver collects the form data to be submitted when using checkboxes.

If you look at the `test.html` you can see how I've changed it to reflect this. When you have more than one checkbox with the same `name` attribute it should submit just the ones that are checked (with the `value`s). 

When you try this with the real server it _does_ behave like this, but when you exercise the same server code with the WebDriver it sends all of the checkbox values, irrespective of whether they have been checked or not. 

By changing `test.html` to have another checkbox it does make some of the tests fail which i fixed by introducing `.filterNot(::isUncheckedInput)`. 

As an aside, it seems my editor is configured differently to yours. I couldn't find an editorconfig to use so I just kinda left it :p 

Hope this is all good.


Chris