### PR TITLE
WebDriver - checkboxes' 'checked' attribute does not require a value

### DIFF
--- a/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
+++ b/http4k-testing-webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
@@ -14,7 +14,13 @@ data class JSoupWebElement(private val navigate: Navigate, private val getURL: G
 
     override fun getText(): String = element.text()
 
-    override fun getAttribute(name: String): String? = element.attr(name)
+    override fun getAttribute(name: String): String? {
+        return when {
+            booleanAttributes.contains(name) && element.hasAttr(name) -> "true"
+            booleanAttributes.contains(name) && !element.hasAttr(name) -> null
+            else -> element.attr(name)
+        }
+    }
 
     override fun isDisplayed(): Boolean = throw FeatureNotImplementedYet
 
@@ -69,7 +75,7 @@ data class JSoupWebElement(private val navigate: Navigate, private val getURL: G
     }
 
     private fun isUncheckedInput(input: WebElement): Boolean =
-        (input.getAttribute("type") == "checkbox") && input.getAttribute("checked") != "checked"
+        (input.getAttribute("type") == "checkbox") && input.getAttribute("checked") == null
 
     override fun getLocation(): Point = throw FeatureNotImplementedYet
 
@@ -136,4 +142,49 @@ data class JSoupWebElement(private val navigate: Navigate, private val getURL: G
     private fun parent(): JSoupWebElement? = element.parent()?.let { JSoupWebElement(navigate, getURL, it) }
 
     private fun isA(tag: String) = tagName.toLowerCase() == tag.toLowerCase()
+
+    companion object {
+        private val booleanAttributes = listOf(
+            "async",
+            "autofocus",
+            "autoplay",
+            "checked",
+            "compact",
+            "complete",
+            "controls",
+            "declare",
+            "defaultchecked",
+            "defaultselected",
+            "defer",
+            "disabled",
+            "draggable",
+            "ended",
+            "formnovalidate",
+            "hidden",
+            "indeterminate",
+            "iscontenteditable",
+            "ismap",
+            "itemscope",
+            "loop",
+            "multiple",
+            "muted",
+            "nohref",
+            "noresize",
+            "noshade",
+            "novalidate",
+            "nowrap",
+            "open",
+            "paused",
+            "pubdate",
+            "readonly",
+            "required",
+            "reversed",
+            "scoped",
+            "seamless",
+            "seeking",
+            "selected",
+            "truespeed",
+            "willvalidate"
+        )
+    }
 }

--- a/http4k-testing-webdriver/src/test/resources/test.html
+++ b/http4k-testing-webdriver/src/test/resources/test.html
@@ -20,7 +20,7 @@
     <form ACTION method="FORMMETHOD">
         <input name="text1" type="text" value="textValue"/>
         <textarea name="textarea1">textarea</textarea>
-        <input name="checkbox1" type="checkbox" value="checkbox" checked="checked"/>
+        <input name="checkbox1" type="checkbox" value="checkbox" checked/>
         <input name="checkbox1" type="checkbox" value="checkbox2"/>
         <input type="radio" value="radio" checked="checked"/>
         <select name="select1">


### PR DESCRIPTION
Hey folks,

Noticed this small bug today: if a checkbox is `checked` without a value to the `checked` attribute then the webdriver thinks it's not checked.

So

```html
<input type="checkbox" checked="yup"</input>
```
is checked, but

```html
<input type="checkbox" checked</input>
```
isn't

Bit of digging discovered that `getAttribute` for "checked" should be returning "true" when there is a `checked` attribute and `null` otherwise - that's at least how I read the docs on the JSoup interface.

And so we've added a list of attributes which are 'boolean', and we've added that logic to `getAttribute`.

Hope that makes sense!

