### PR TITLE
Add filter allowing Gzipping based on an allowed set of content types

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
@@ -1,8 +1,6 @@
 package org.http4k.filter
 
-import org.http4k.core.Filter
-import org.http4k.core.HttpTransaction
-import org.http4k.core.Response
+import org.http4k.core.*
 import java.time.Clock
 import java.time.Duration
 import java.time.Duration.between
@@ -51,6 +49,36 @@ object ResponseFilters {
                     ".${tx.response.status.code / 100}xx" +
                     ".${tx.response.status.code}", tx.duration)
             }
+    }
+
+    /**
+     * GZipping of the response where the content-type (sans-charset) matches an allowed list of compressible types.
+     */
+    class GZipContentTypes(compressibleContentTypes: Set<ContentType>) : Filter {
+        private val compressibleMimeTypes = compressibleContentTypes
+                .map { it.value }
+                .map { it.split(";").first() }
+
+        override fun invoke(next: HttpHandler): HttpHandler {
+            return { request ->
+                next(request).let {
+                    if (requestAcceptsGzip(request) && isCompressible(it)) {
+                        it.body(it.body.gzipped()).replaceHeader("content-encoding", "gzip")
+                    } else {
+                        it
+                    }
+                }
+            }
+        }
+
+        private fun isCompressible(it: Response) =
+                compressibleMimeTypes.contains(mimeTypeOf(it))
+
+        private fun mimeTypeOf(it: Response) =
+                (it.header("content-type") ?: "").split(";").first().trim()
+
+        private fun requestAcceptsGzip(it: Request) =
+                (it.header("accept-encoding") ?: "").contains("gzip", true)
     }
 
     /**

--- a/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
@@ -54,7 +54,7 @@ object ResponseFilters {
     }
 
     /**
-     * Basic UnGZipping of Response. Does not currently support GZipping streams
+     * Basic GZipping of Response. Does not currently support GZipping streams
      */
     object GZip {
         operator fun invoke() = Filter { next ->

--- a/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
@@ -218,6 +218,19 @@ object ServerFilters {
     }
 
     /**
+     * Basic GZip and Gunzip support of Request/Response where the content-type is in the allowed list. Does not currently support GZipping streams.
+     * Only Gunzips requests which contain "transfer-encoding" header containing 'gzip'
+     * Only Gzips responses when request contains "accept-encoding" header containing 'gzip' and the content-type (sans-charset) is one of the compressible types.
+     */
+    class GZipContentTypes(private val compressibleContentTypes: Set<ContentType>): Filter {
+        override fun invoke(next: HttpHandler): HttpHandler {
+            return RequestFilters.GunZip()
+                    .then(ResponseFilters.GZipContentTypes(compressibleContentTypes))
+                    .invoke(next)
+        }
+    }
+
+    /**
      * Initialise a RequestContext for each request which passes through the Filter stack,
      */
     object InitialiseRequestContext {

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ResponseFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ResponseFiltersTest.kt
@@ -4,14 +4,10 @@ import com.natpryce.hamkrest.and
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.should.shouldMatch
-import org.http4k.core.Body
-import org.http4k.core.HttpTransaction
+import org.http4k.core.*
 import org.http4k.core.HttpTransaction.Companion.ROUTING_GROUP_LABEL
 import org.http4k.core.Method.GET
-import org.http4k.core.Request
-import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
-import org.http4k.core.then
 import org.http4k.filter.ResponseFilters.ReportHttpTransaction
 import org.http4k.hamkrest.hasBody
 import org.http4k.hamkrest.hasHeader
@@ -62,6 +58,42 @@ class ResponseFiltersTest {
         }
         assertSupportsZipping("foobar")
         assertSupportsZipping("")
+    }
+
+    @Test
+    fun `gzip response and adds gzip content encoding if the request has accept-encoding of gzip and content type is acceptable`() {
+        fun assertSupportsZipping(body: String) {
+            val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML)).then { Response(OK).header("content-type", "text/html").body(body) }
+            zipped(Request(Method.GET, "").header("accept-encoding", "gzip")) shouldMatch
+                    hasBody(equalTo(Body(body).gzipped())).and(hasHeader("content-encoding", "gzip"))
+        }
+        assertSupportsZipping("foobar")
+        assertSupportsZipping("")
+    }
+
+    @Test
+    fun `gzip response and adds gzip content encoding if the request has accept-encoding of gzip and content type with a charset is acceptable`() {
+        fun assertSupportsZipping(body: String) {
+            val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML)).then { Response(OK).header("content-type", "text/html;charset=utf-8").body(body) }
+            zipped(Request(Method.GET, "").header("accept-encoding", "gzip")) shouldMatch
+                    hasBody(equalTo(Body(body).gzipped())).and(hasHeader("content-encoding", "gzip"))
+        }
+        assertSupportsZipping("foobar")
+        assertSupportsZipping("")
+    }
+
+    @Test
+    fun `do not gzip response if content type is missing`() {
+        val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML)).then { Response(OK).body("unzipped") }
+        zipped(Request(Method.GET, "").header("accept-encoding", "gzip")) shouldMatch
+                hasBody(equalTo(Body("unzipped"))).and(!hasHeader("content-encoding", "gzip"))
+    }
+
+    @Test
+    fun `do not gzip response if content type is not acceptable`() {
+        val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML)).then { Response(OK).header("content-type", "image/png").body("unzipped") }
+        zipped(Request(Method.GET, "").header("accept-encoding", "gzip")) shouldMatch
+                hasBody(equalTo(Body("unzipped"))).and(!hasHeader("content-encoding", "gzip"))
     }
 
     @Test


### PR DESCRIPTION
The current GZip filter is an all-or-nothing affair. This extends it so that you can give it a set of content-types which will restrict the responses for which GZipping will be performed. This allows you to ensure that previously compressed content such as PNGs will not be recompressed.

I also fixed a Javadoc, as you lot are hacks who do too much copy & paste ;-)