### PR TITLE
handle multiple allow-origin values

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
@@ -38,10 +38,18 @@ object ServerFilters {
         operator fun invoke(policy: CorsPolicy) = Filter { next ->
             {
                 val response = if (it.method == OPTIONS) Response(OK) else next(it)
+
+                val origin = it.header("Origin")
+                val allowedOrigin = when {
+                    policy.origins.contains("*") -> "*"
+                    policy.origins.contains(origin) -> origin!!
+                    else -> "null"
+                }
+
                 response.with(
-                        Header.required("access-control-allow-origin") of policy.origins.joined(),
-                        Header.required("access-control-allow-headers") of policy.headers.joined(),
-                        Header.required("access-control-allow-methods") of policy.methods.map { it.name }.joined()
+                    Header.required("access-control-allow-origin") of allowedOrigin,
+                    Header.required("access-control-allow-headers") of policy.headers.joined(),
+                    Header.required("access-control-allow-methods") of policy.methods.map { it.name }.joined()
                 )
             }
         }

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
@@ -113,15 +113,37 @@ class ServerFiltersTest {
     }
 
     @Test
-    fun `OPTIONS - requests are intercepted and returned with expected headers`() {
-        val handler = ServerFilters.Cors(CorsPolicy(listOf("foo", "bar"), listOf("rita", "sue", "bob"), listOf(DELETE, POST))).then { Response(INTERNAL_SERVER_ERROR) }
-        val response = handler(Request(OPTIONS, "/"))
+     fun `OPTIONS - requests are intercepted and returned with expected headers`() {
+         val handler = ServerFilters.Cors(CorsPolicy(listOf("foo", "bar"), listOf("rita", "sue", "bob"), listOf(DELETE, POST))).then { Response(INTERNAL_SERVER_ERROR) }
+         val response = handler(Request(OPTIONS, "/").header("Origin", "foo"))
 
         response shouldMatch hasStatus(OK)
-            .and(hasHeader("access-control-allow-origin", "foo, bar"))
+            .and(hasHeader("access-control-allow-origin", "foo"))
             .and(hasHeader("access-control-allow-headers", "rita, sue, bob"))
             .and(hasHeader("access-control-allow-methods", "DELETE, POST"))
     }
+
+    @Test
+    fun `OPTIONS - requests are returned with expected headers when origin does not match`() {
+        val handler = ServerFilters.Cors(CorsPolicy(listOf("foo", "bar"), listOf("rita", "sue", "bob"), listOf(DELETE, POST))).then { Response(INTERNAL_SERVER_ERROR) }
+        val response = handler(Request(OPTIONS, "/").header("Origin", "baz"))
+
+        response shouldMatch hasStatus(OK)
+            .and(hasHeader("access-control-allow-origin", "null"))
+            .and(hasHeader("access-control-allow-headers", "rita, sue, bob"))
+            .and(hasHeader("access-control-allow-methods", "DELETE, POST"))
+    }
+
+    @Test
+    fun `OPTIONS - requests are returned with expected headers when origin is not set`() {
+        val handler = ServerFilters.Cors(CorsPolicy(listOf("foo", "bar"), listOf("rita", "sue", "bob"), listOf(DELETE, POST))).then { Response(INTERNAL_SERVER_ERROR) }
+        val response = handler(Request(OPTIONS, "/"))
+ 
+        response shouldMatch hasStatus(OK)
+            .and(hasHeader("access-control-allow-origin", "null"))
+            .and(hasHeader("access-control-allow-headers", "rita, sue, bob"))
+            .and(hasHeader("access-control-allow-methods", "DELETE, POST"))
+     }
 
     @Test
     fun `catch all exceptions`() {


### PR DESCRIPTION
As discussed with Ivan on Slack, we've noticed some issues with the way that CORS is handled in http4k when multiple values are involved for allow-origin header. This pull request hopefully fixes that issue.