### PR TITLE
Preventing FallbackCacheControl from duplicating existing headers

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
@@ -122,7 +122,7 @@ object CachingFilters {
             operator fun invoke(clock: Clock, defaultCacheTimings: DefaultCacheTimings, predicate: (org.http4k.core.Response) -> Boolean = { it.status.code < 400 }): Filter {
 
                 fun addDefaultHeaderIfAbsent(response: org.http4k.core.Response, header: String, defaultProducer: () -> String) =
-                    response.header(header, response.header(header) ?: defaultProducer())
+                    response.replaceHeader(header, response.header(header) ?: defaultProducer())
 
                 fun addDefaultCacheHeadersIfAbsent(response: org.http4k.core.Response) =
                     addDefaultHeaderIfAbsent(response, "Cache-Control") {

--- a/http4k-core/src/test/kotlin/org/http4k/filter/CachingFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/CachingFiltersTest.kt
@@ -65,9 +65,9 @@ class CachingFiltersTest {
         val responseWithHeaders = Response(OK).header("Cache-Control", "rita").header("Expires", "sue").header("Vary", "bob")
         val response = getResponseWith(timings, responseWithHeaders)
 
-        response shouldMatch hasHeader("Cache-Control", "rita")
-        response shouldMatch hasHeader("Expires", "sue")
-        response shouldMatch hasHeader("Vary", "bob")
+        response shouldMatch hasHeader("Cache-Control", listOf("rita"))
+        response shouldMatch hasHeader("Expires", listOf("sue"))
+        response shouldMatch hasHeader("Vary", listOf("bob"))
     }
 
     @Test


### PR DESCRIPTION
FallbackCacheControl claims it will include a default value for "Cache-Control", "Expires" and "Vary" headers when they are not present in the response. However it is actually duplicating the existing values when these headers are already present in the response. This PR fixes that.