### PR TITLE
Issue with prefixes in static routing

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/routing/internal.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/routing/internal.kt
@@ -37,7 +37,7 @@ internal class ResourceLoadingHandler(private val pathSegments: String,
     } else Response(NOT_FOUND)
 
     private fun convertPath(path: String): String {
-        val newPath = if (pathSegments == "/" || pathSegments == "") path else path.replace(pathSegments, "")
+        val newPath = if (pathSegments == "/" || pathSegments == "") path else path.replaceFirst(pathSegments, "")
         val resolved = if (newPath == "/" || newPath.isBlank()) "/index.html" else newPath
         return resolved.replaceFirst("/", "")
     }

--- a/http4k-core/src/test/kotlin/org/http4k/routing/StaticPrefixRoutingTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/routing/StaticPrefixRoutingTest.kt
@@ -1,0 +1,47 @@
+package org.http4k.routing
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.Status
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class StaticPrefixRoutingTest {
+    private lateinit var app: RoutingHttpHandler
+
+    @BeforeEach
+    fun before() {
+        app = routes("/bar" bind static(ResourceLoader.Classpath("bar")))
+    }
+
+    @Test
+    fun `test static resource bar`() {
+        val result = app(Request(GET, "/bar/"))
+        assertThat(result.status, equalTo(Status.OK))
+        assertThat(result.bodyString(), equalTo("contents of bar/index.html"))
+    }
+
+    @Test
+    fun `test static resource bar - index html`() {
+        val result = app(Request(GET, "/bar/index.html"))
+        assertThat(result.status, equalTo(Status.OK))
+        assertThat(result.bodyString(), equalTo("contents of bar/index.html"))
+    }
+
+    @Test
+    fun `test static resource bar - bar html`() {
+        val result = app(Request(GET, "/bar/bar.html"))
+        assertThat(result.status, equalTo(Status.OK))
+        assertThat(result.bodyString(), equalTo("contents of bar/bar.html"))
+    }
+
+    @Test
+    fun `test static resource bar - bar-xyz html`() {
+        val result = app(Request(GET, "/bar/bar-xyz.html"))
+        assertThat(result.status, equalTo(Status.OK))
+        assertThat(result.bodyString(), equalTo("contents of bar/bar-xyz.html"))
+    }
+
+}

--- a/http4k-core/src/test/kotlin/org/http4k/routing/StaticPrefixRoutingTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/routing/StaticPrefixRoutingTest.kt
@@ -5,6 +5,7 @@ import com.natpryce.hamkrest.equalTo
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Status
+import org.http4k.routing.ResourceLoader.Companion.Classpath
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -13,7 +14,7 @@ class StaticPrefixRoutingTest {
 
     @BeforeEach
     fun before() {
-        app = routes("/bar" bind static(ResourceLoader.Classpath("bar")))
+        app = routes("/bar" bind static(Classpath("bar")))
     }
 
     @Test
@@ -42,6 +43,33 @@ class StaticPrefixRoutingTest {
         val result = app(Request(GET, "/bar/bar-xyz.html"))
         assertThat(result.status, equalTo(Status.OK))
         assertThat(result.bodyString(), equalTo("contents of bar/bar-xyz.html"))
+    }
+
+    @Test
+    fun `test static resource bar - bar`() {
+        val result = app(Request(GET, "/bar/bar/"))
+        assertThat(result.status, equalTo(Status.NOT_FOUND)) // because index.html is read only for root
+    }
+
+    @Test
+    fun `test static resource bar - bar - index html`() {
+        val result = app(Request(GET, "/bar/bar/index.html"))
+        assertThat(result.status, equalTo(Status.OK))
+        assertThat(result.bodyString(), equalTo("contents of bar/bar/index.html"))
+    }
+
+    @Test
+    fun `test static resource bar - bar - bar html`() {
+        val result = app(Request(GET, "/bar/bar/bar.html"))
+        assertThat(result.status, equalTo(Status.OK))
+        assertThat(result.bodyString(), equalTo("contents of bar/bar/bar.html"))
+    }
+
+    @Test
+    fun `test static resource bar - bar - bar-xyz html`() {
+        val result = app(Request(GET, "/bar/bar/bar-xyz.html"))
+        assertThat(result.status, equalTo(Status.OK))
+        assertThat(result.bodyString(), equalTo("contents of bar/bar/bar-xyz.html"))
     }
 
 }

--- a/http4k-core/src/test/resources/bar/bar-xyz.html
+++ b/http4k-core/src/test/resources/bar/bar-xyz.html
@@ -1,0 +1,1 @@
+contents of bar/bar-xyz.html

--- a/http4k-core/src/test/resources/bar/bar.html
+++ b/http4k-core/src/test/resources/bar/bar.html
@@ -1,0 +1,1 @@
+contents of bar/bar.html

--- a/http4k-core/src/test/resources/bar/bar/bar-xyz.html
+++ b/http4k-core/src/test/resources/bar/bar/bar-xyz.html
@@ -1,0 +1,1 @@
+contents of bar/bar/bar-xyz.html

--- a/http4k-core/src/test/resources/bar/bar/bar.html
+++ b/http4k-core/src/test/resources/bar/bar/bar.html
@@ -1,0 +1,1 @@
+contents of bar/bar/bar.html

--- a/http4k-core/src/test/resources/bar/bar/index.html
+++ b/http4k-core/src/test/resources/bar/bar/index.html
@@ -1,0 +1,1 @@
+contents of bar/bar/index.html

--- a/http4k-core/src/test/resources/bar/index.html
+++ b/http4k-core/src/test/resources/bar/index.html
@@ -1,0 +1,1 @@
+contents of bar/index.html


### PR DESCRIPTION
Hello here

I found a case when paths are not translated properly

For example request `GET /bar/bar-xyz.html` to `routes("/bar" bind static(Classpath("bar")))` was translated into`/-xyz.html`