### PR TITLE
Allow null values in examples used for schema generation in contracts

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/util/JsonSchema.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/util/JsonSchema.kt
@@ -40,7 +40,9 @@ class JsonToJsonSchema<NODE>(private val json: Json<NODE>) {
     }
 
     private fun JsonSchema<NODE>.objectSchema(overrideDefinitionId: String?): JsonSchema<NODE> {
-        val (fields, subDefinitions) = json.fields(node).fold(listOf<Pair<String, NODE>>() to definitions) { (memoFields, memoDefinitions), (first, second) ->
+        val (fields, subDefinitions) = json.fields(node)
+                .filter { json.typeOf(it.second) != JsonType.Null } // filter out null fields for which type can't be inferred
+                .fold(listOf<Pair<String, NODE>>() to definitions) { (memoFields, memoDefinitions), (first, second) ->
             JsonSchema(second, memoDefinitions).toSchema().let { memoFields.plus(first to it.node) to it.definitions }
         }
 

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -85,7 +85,8 @@ abstract class ContractRendererContract(private val renderer: ContractRenderer) 
             }
                 bindContract POST to { Response(OK) },
             "/body_json_schema" meta {
-                receiving(Body.json("json").toLens() to Jackson { obj("anAnotherObject" to obj("aNumberField" to number(123))) }, "someDefinitionId")
+                receiving(Body.json("json").toLens() to Jackson {
+                    obj("anAnotherObject" to obj("aNullField" to nullNode(), "aNumberField" to number(123))) }, "someDefinitionId")
             }
                 bindContract POST to { Response(OK) },
             "/body_form" meta {


### PR DESCRIPTION
Fixes #212 