### PR TITLE
Handle null response stream in Java HTTP client

### DIFF
--- a/http4k-core/build.gradle
+++ b/http4k-core/build.gradle
@@ -8,5 +8,6 @@ dependencies {
     testCompile project(":http4k-client-apache")
     testCompile project(":http4k-client-websocket")
     testCompile project(":http4k-testing-hamkrest")
+    testCompile project(":http4k-server-jetty")
 }
 

--- a/http4k-core/src/main/kotlin/org/http4k/client/JavaHttpClient.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/client/JavaHttpClient.kt
@@ -7,6 +7,7 @@ import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.Status.Companion.CONNECTION_REFUSED
 import org.http4k.core.Status.Companion.UNKNOWN_HOST
+import java.io.ByteArrayInputStream
 import java.net.ConnectException
 import java.net.HttpURLConnection
 import java.net.URL
@@ -48,11 +49,13 @@ object JavaHttpClient {
 
     // Because HttpURLConnection closes the stream if a new request is made, we are forced to consume it straight away
     private fun HttpURLConnection.body(status: Status) =
-        resolveStream(status).readBytes().let { ByteBuffer.wrap(it) }.let { Body(it) }
+            Body(resolveStream(status).readBytes().let { ByteBuffer.wrap(it) })
 
     private fun HttpURLConnection.resolveStream(status: Status) =
         when {
             status.serverError || status.clientError -> errorStream
             else -> inputStream
-        }
+        } ?: EMPTY_STREAM
+
+    private val EMPTY_STREAM = ByteArrayInputStream(ByteArray(0))
 }

--- a/http4k-core/src/test/kotlin/org/http4k/client/AbstractHttpClientContract.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/client/AbstractHttpClientContract.kt
@@ -70,6 +70,10 @@ abstract class AbstractHttpClientContract(private val serverConfig: (Int) -> Ser
             "/status/{status}" bind GET to { r: Request ->
                 val status = Status(r.path("status")!!.toInt(), "")
                 Response(status).body("body for status ${status.code}")
+            },
+            "/status-no-body/{status}" bind GET to { r: Request ->
+                val status = Status(r.path("status")!!.toInt(), "")
+                Response(status)
             })
         server = app.asServer(serverConfig(0)).start()
     }

--- a/http4k-core/src/test/kotlin/org/http4k/client/HttpClientContract.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/client/HttpClientContract.kt
@@ -169,11 +169,20 @@ abstract class HttpClientContract(serverConfig: (Int) -> ServerConfig,
     }
 
     @Test
-    fun `can retrieve body for diffMoshierent statuses`() {
+    fun `can retrieve body for different statuses`() {
         listOf(200, 301, 404, 500).forEach { statusCode ->
             val response = client(Request(GET, "http://localhost:$port/status/$statusCode"))
             assertThat(response.status, equalTo(Status(statusCode, "")))
             assertThat(response.bodyString(), equalTo("body for status $statusCode"))
+        }
+    }
+
+    @Test
+    fun `handles empty response body for different statuses`() {
+        listOf(200, 301, 400, 404, 500).forEach { statusCode ->
+            val response = client(Request(GET, "http://localhost:$port/status-no-body/$statusCode"))
+            assertThat(response.status, equalTo(Status(statusCode, "")))
+            assertThat(response.bodyString(), equalTo(""))
         }
     }
 

--- a/http4k-core/src/test/kotlin/org/http4k/client/JavaHttpClientTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/client/JavaHttpClientTest.kt
@@ -3,9 +3,9 @@ package org.http4k.client
 import org.apache.http.config.SocketConfig
 import org.apache.http.impl.client.HttpClients
 import org.http4k.core.BodyMode
-import org.http4k.server.SunHttp
+import org.http4k.server.Jetty
 
-class JavaHttpClientTest : HttpClientContract({ SunHttp(it) }, JavaHttpClient(),
+class JavaHttpClientTest : HttpClientContract({ Jetty(it) }, JavaHttpClient(),
     ApacheClient(HttpClients.custom()
         .setDefaultSocketConfig(
             SocketConfig.custom()


### PR DESCRIPTION
This fixes an issue where a null pointer exception is thrown when an empty body is returned for error responses, using the JavaHttpClient calling a server backed by Jetty.
Specifically, the error stream can be null, which means the code extracting the body will fail with a null pointer exception.
This change will handle that case by returning an empty input stream if the underlying stream is null.