### PR TITLE
serverless - Allow handlers to be called locally

### DIFF
--- a/http4k-serverless-lambda/src/main/java/org/http4k/serverless/lambda/ApiGatewayProxyRequest.java
+++ b/http4k-serverless-lambda/src/main/java/org/http4k/serverless/lambda/ApiGatewayProxyRequest.java
@@ -9,4 +9,44 @@ public class ApiGatewayProxyRequest {
     public Map<String, String> headers = Collections.emptyMap();
     public Map<String, String> queryStringParameters = Collections.emptyMap();
     public String body = "";
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public void setHttpMethod(String httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public Map<String, String> getQueryStringParameters() {
+        return queryStringParameters;
+    }
+
+    public void setQueryStringParameters(Map<String, String> queryStringParameters) {
+        this.queryStringParameters = queryStringParameters;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
 }


### PR DESCRIPTION
## What solves?
Trying to invoke a lambda locally using serverless throws this exception:
```
java.lang.reflect.InvocationTargetException

        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
        at java.lang.reflect.Method.invoke(Unknown Source)
        at com.serverless.InvokeBridge.invoke(InvokeBridge.java:93)
        at com.serverless.InvokeBridge.<init>(InvokeBridge.java:39)
        at com.serverless.InvokeBridge.main(InvokeBridge.java:150)
Caused by: java.lang.IllegalStateException: httpMethod must not be null
        at org.http4k.serverless.lambda.LambdaFunctionKt.asHttp4k(LambdaFunction.kt:25)
        at org.http4k.serverless.lambda.LambdaFunction.handle(LambdaFunction.kt:19)
        ... 7 more
```
Values forwarded via `--data` are ignore because [ApiGatewayProxyRequest](https://github.com/http4k/http4k/blob/master/http4k-serverless-lambda/src/main/java/org/http4k/serverless/lambda/ApiGatewayProxyRequest.java) does not define settters or getters.

Although [AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/java-handler-using-predefined-interfaces.html) regarding supported interfaces states the given object must be a POJO, the examples show the class `Response` defined as a bean.

## Steps to reproduce

###Define a handler
```
object PingHandler : AppLoader {
    override fun invoke(env: Map<String, String>) = {
        Response(OK).body("pong")
    }
}
```

### Define serverless lambda cfg
```
functions:
  ping:
    handler: org.http4k.serverless.lambda.LambdaFunction::handle
    environment:
      HTTP4K_BOOTSTRAP_CLASS: PingHandler
```

### Invoke the function locally and watch it fail
```
serverless invoke local -f ping -d "{\"httpMethod\": \"GET\", \"path\": \"/\"}"
```