### PR TITLE
Ensure dir for linkmapping in dokka task is a unix path.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,7 +251,7 @@ task dokka(type: org.jetbrains.dokka.gradle.DokkaTask, overwrite: true) {
 
             def relativePath = rootDir.toPath().relativize(path.toPath()).toString()
             linkMapping {
-                dir = path
+                dir = path.toString().replace(File.separator, "/")
                 url = "https://github.com/http4k/http4k/blob/master/$relativePath"
                 suffix = "#L"
             }


### PR DESCRIPTION
When importing the latest http4k in Intellij on Windows it fails with message:

> Incorrect dir property, only Unix based path allowed.

This is happening in the dokka task because the dir property in the linkmapping is being passed a Windows file path, but since dokka 0.9.18 this isn't allowed (verified by trying 0.9.17 and the project imported fine).

I believe Replacing whatever file separator the OS uses with "/" will always result in a valid Unix path for the projectDir in this case.

Only tested on my Windows machine since it's such a small change but I'm happy to spin up different OS and verify there too if need be.