### PR TITLE
Made the multipart header parser case-insensitive.

### DIFF
--- a/http4k-multipart/src/main/kotlin/org/http4k/multipart/StreamingMultipartFormParts.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/multipart/StreamingMultipartFormParts.kt
@@ -4,7 +4,7 @@ import org.apache.commons.fileupload.util.ParameterParser
 import java.io.IOException
 import java.io.InputStream
 import java.nio.charset.Charset
-import java.util.HashMap
+import java.util.TreeMap
 import java.util.NoSuchElementException
 
 /**
@@ -103,7 +103,7 @@ internal class StreamingMultipartFormParts private constructor(inBoundary: ByteA
     private fun parseHeaderLines(): Map<String, String> {
         if (MultipartFormStreamState.Header != state) throw IllegalStateException("Expected state ${MultipartFormStreamState.Header} but got $state")
 
-        val result = HashMap<String, String>()
+        val result = TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER)
         var previousHeaderName: String? = null
         val maxByteIndexForHeader = inputStream.currentByteIndex() + HEADER_SIZE_MAX
         while (inputStream.currentByteIndex() < maxByteIndexForHeader) {

--- a/http4k-multipart/src/test/kotlin/org/http4k/multipart/StreamingMultipartFormHappyTests.kt
+++ b/http4k-multipart/src/test/kotlin/org/http4k/multipart/StreamingMultipartFormHappyTests.kt
@@ -74,6 +74,21 @@ class StreamingMultipartFormHappyTests {
     }
 
     @Test
+    fun uploadFileWithLowercaseContentDisposition() {
+        val boundary = "-----2345"
+        val form = getMultipartFormParts(boundary, MultipartFormBuilder(boundary)
+            .part("File contents here".byteInputStream(),
+                  "content-disposition" to listOf("form-data" to null, "name" to "aFile", "filename" to "file.name"),
+                  "Content-Type" to listOf("application/octet-stream" to null)
+            )
+            .stream())
+
+        assertFilePart(form, "aFile", "file.name", "application/octet-stream", "File contents here")
+
+        assertThereAreNoMoreParts(form)
+    }
+
+    @Test
     fun uploadSmallFileAsAttachment() {
         val boundary = "-----4567"
         val form = getMultipartFormParts(boundary, MultipartFormBuilder(boundary)


### PR DESCRIPTION
We build our mobile client with react-native. We use plain XMLHttpRequest and FormData to create file upload requests. We found that http4k failed to parse lowercase multipart header field names generated by XMLHttpRequest.