### PR TITLE
Modernize gradle dependency configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -226,7 +226,7 @@ dependencies {
     provided project(":http4k-testing-hamkrest")
     provided project(":http4k-testing-webdriver")
 
-    testCompile Config.TestDependencies
+    testImplementation Config.TestDependencies
 }
 
 sourceSets {

--- a/http4k-aws/build.gradle
+++ b/http4k-aws/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile project(":http4k-client-apache")
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation project(":http4k-client-apache")
+    testImplementation Config.TestDependencies
 }

--- a/http4k-client-apache-async/build.gradle
+++ b/http4k-client-apache-async/build.gradle
@@ -4,9 +4,9 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.httpasyncclient
+    api Libs.httpasyncclient
 
-    testCompile project(path: ":http4k-core", configuration: "testArtifacts")
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: "testArtifacts")
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-client-apache/build.gradle
+++ b/http4k-client-apache/build.gradle
@@ -4,9 +4,9 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.httpclient // apache
+    api Libs.httpclient // apache
 
-    testCompile project(path: ":http4k-core", configuration: "testArtifacts")
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: "testArtifacts")
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-client-jetty/build.gradle
+++ b/http4k-client-jetty/build.gradle
@@ -4,9 +4,8 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.jetty_client
+    api Libs.jetty_client
 
-    testCompile project(path: ":http4k-core", configuration: "testArtifacts")
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: "testArtifacts")
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-client-okhttp/build.gradle
+++ b/http4k-client-okhttp/build.gradle
@@ -4,9 +4,8 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.okhttp
+    api Libs.okhttp
 
-    testCompile project(path: ":http4k-core", configuration: "testArtifacts")
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: "testArtifacts")
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-client-websocket/build.gradle
+++ b/http4k-client-websocket/build.gradle
@@ -4,10 +4,9 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.java_websocket
+    api Libs.java_websocket
 
-    testCompile project(path: ":http4k-core", configuration: "testArtifacts")
-    testCompile project(path: ":http4k-server-jetty")
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: "testArtifacts")
+    testImplementation project(path: ":http4k-server-jetty")
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-cloudnative/build.gradle
+++ b/http4k-cloudnative/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile project(":http4k-testing-hamkrest")
-    testCompile project(":http4k-format-argo")
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(":http4k-format-argo")
+    testImplementation Config.TestDependencies
 }

--- a/http4k-contract/build.gradle
+++ b/http4k-contract/build.gradle
@@ -6,13 +6,15 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
     provided project(":http4k-format-jackson")
-    compile Libs.kotlin_reflect
 
-    testCompile project(":http4k-format-jackson")
-    testCompile project(":http4k-format-argo")
-    testCompile project(":http4k-testing-approval")
-    testCompile project(path: ":http4k-core", configuration: "testArtifacts")
-    testCompile Config.TestDependencies
+    api Libs.kotlin_reflect
+
+    testImplementation project(":http4k-format-jackson")
+    testImplementation project(":http4k-format-argo")
+    testImplementation project(":http4k-testing-approval")
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: "testArtifacts")
+    testImplementation Config.TestDependencies
 }
 
 task generateOpenApi3AutoClient(type: org.openapitools.generator.gradle.plugin.tasks.GenerateTask) {

--- a/http4k-core/build.gradle
+++ b/http4k-core/build.gradle
@@ -4,10 +4,9 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided Libs.javax_servlet_api
 
-    testCompile Config.TestDependencies
-    testCompile project(":http4k-client-apache")
-    testCompile project(":http4k-client-websocket")
-    testCompile project(":http4k-testing-hamkrest")
-    testCompile project(":http4k-server-jetty")
+    testImplementation Config.TestDependencies
+    testImplementation project(":http4k-client-apache")
+    testImplementation project(":http4k-client-websocket")
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(":http4k-server-jetty")
 }
-

--- a/http4k-format-argo/build.gradle
+++ b/http4k-format-argo/build.gradle
@@ -4,10 +4,10 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.argo
+    api Libs.argo
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile project(path: ":http4k-jsonrpc", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation project(path: ":http4k-jsonrpc", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-format-gson/build.gradle
+++ b/http4k-format-gson/build.gradle
@@ -4,12 +4,10 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.gson
+    api Libs.gson
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile project(path: ":http4k-jsonrpc", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation project(path: ":http4k-jsonrpc", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-
-
-

--- a/http4k-format-jackson-xml/build.gradle
+++ b/http4k-format-jackson-xml/build.gradle
@@ -4,9 +4,11 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile project(":http4k-format-jackson")
-    compile Libs.jackson_dataformat_xml
+    api project(":http4k-format-jackson")
+    api Libs.jackson_module_kotlin
+    api Libs.jackson_dataformat_xml
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }

--- a/http4k-format-jackson/build.gradle
+++ b/http4k-format-jackson/build.gradle
@@ -4,11 +4,12 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.jackson_module_kotlin
-    compile Libs.jackson_dataformat_xml
+    api Libs.jackson_module_kotlin
+    api Libs.jackson_dataformat_xml
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile project(path: ":http4k-jsonrpc", configuration: 'testArtifacts')
-    testCompile project(":http4k-testing-approval")
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation project(path: ":http4k-jsonrpc", configuration: 'testArtifacts')
+    testImplementation project(":http4k-testing-approval")
+    testImplementation Config.TestDependencies
 }

--- a/http4k-format-moshi/build.gradle
+++ b/http4k-format-moshi/build.gradle
@@ -5,12 +5,9 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.moshi
-    compile Libs.moshi_kotlin
+    api Libs.moshi
+    api Libs.moshi_kotlin
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-
-
-

--- a/http4k-format-xml/build.gradle
+++ b/http4k-format-xml/build.gradle
@@ -4,9 +4,9 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile project(":http4k-format-gson")
-    compile Libs.json
+    api project(":http4k-format-gson")
+    api Libs.json
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }

--- a/http4k-incubator/build.gradle
+++ b/http4k-incubator/build.gradle
@@ -4,10 +4,8 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    testCompile Config.TestDependencies
-    testCompile project(":http4k-client-apache")
-    testCompile project(":http4k-testing-hamkrest")
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
+    testImplementation project(":http4k-client-apache")
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
 }
-
-

--- a/http4k-jsonrpc/build.gradle
+++ b/http4k-jsonrpc/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }

--- a/http4k-metrics-micrometer/build.gradle
+++ b/http4k-metrics-micrometer/build.gradle
@@ -3,9 +3,10 @@ description = 'Http4k metrics support, integrating with micrometer.io'
 dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
-    compile Libs.micrometer_core
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    api Libs.micrometer_core
+
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-multipart/build.gradle
+++ b/http4k-multipart/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    testCompile Config.TestDependencies
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-resilience4j/build.gradle
+++ b/http4k-resilience4j/build.gradle
@@ -4,12 +4,12 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.resilience4j_bulkhead
-    compile Libs.resilience4j_circuitbreaker
-    compile Libs.resilience4j_ratelimiter
-    compile Libs.resilience4j_retry
+    api Libs.resilience4j_bulkhead
+    api Libs.resilience4j_circuitbreaker
+    api Libs.resilience4j_ratelimiter
+    api Libs.resilience4j_retry
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-security-oauth/build.gradle
+++ b/http4k-security-oauth/build.gradle
@@ -4,9 +4,10 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
     provided project(":http4k-format-jackson")
-    compile Libs.result4k
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    api Libs.result4k
+
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-server-apache/build.gradle
+++ b/http4k-server-apache/build.gradle
@@ -8,10 +8,10 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.httpcore // apache
+    api Libs.httpcore // apache
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(":http4k-client-apache")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-
-

--- a/http4k-server-jetty/build.gradle
+++ b/http4k-server-jetty/build.gradle
@@ -4,17 +4,19 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.jetty_server
-    compile Libs.jetty_servlet
-    compile Libs.javax_websocket_server_impl
-    compile Libs.javax_servlet_api
+    api Libs.jetty_server
+    api Libs.jetty_servlet
+    api Libs.javax_websocket_server_impl
+    api Libs.javax_servlet_api
 
     // this list is for reference since http2 support is optional
     provided Libs.http2_server
     provided Libs.jetty_alpn_conscrypt_server
     provided Libs.alpn_boot
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-client-apache")
+    testImplementation project(":http4k-client-websocket")
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-server-ktorcio/build.gradle
+++ b/http4k-server-ktorcio/build.gradle
@@ -4,10 +4,10 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile group: 'io.ktor', name: 'ktor-server-cio', version: '1.1.1'
+    api group: 'io.ktor', name: 'ktor-server-cio', version: '1.1.1'
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-client-apache")
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-
-

--- a/http4k-server-netty/build.gradle
+++ b/http4k-server-netty/build.gradle
@@ -4,10 +4,10 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.netty_codec_http2
+    api Libs.netty_codec_http2
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-client-apache")
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-
-

--- a/http4k-server-undertow/build.gradle
+++ b/http4k-server-undertow/build.gradle
@@ -4,11 +4,11 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.undertow_core
-    compile Libs.undertow_servlet
+    api Libs.undertow_core
+    api Libs.undertow_servlet
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-client-apache")
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-
-

--- a/http4k-serverless-lambda/build.gradle
+++ b/http4k-serverless-lambda/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     provided Libs.kotlin_reflect
     provided project(":http4k-core")
 
-    testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-template-dust/build.gradle
+++ b/http4k-template-dust/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.commons_pool2
+    api Libs.commons_pool2
 
-    testCompile project(path: ":http4k-core", configuration: "testArtifacts")
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: "testArtifacts")
+    testImplementation Config.TestDependencies
 }

--- a/http4k-template-freemarker/build.gradle
+++ b/http4k-template-freemarker/build.gradle
@@ -4,9 +4,8 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.freemarker
+    api Libs.freemarker
 
-    testCompile project(path: ":http4k-core", configuration: "testArtifacts")
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: "testArtifacts")
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-template-handlebars/build.gradle
+++ b/http4k-template-handlebars/build.gradle
@@ -4,9 +4,8 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.handlebars
+    api Libs.handlebars
 
-    testCompile project(path: ":http4k-core", configuration: "testArtifacts")
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: "testArtifacts")
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-template-pebble/build.gradle
+++ b/http4k-template-pebble/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.pebble
+    api Libs.pebble
 
-    testCompile project(path: ":http4k-core", configuration: "testArtifacts")
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: "testArtifacts")
+    testImplementation Config.TestDependencies
 }

--- a/http4k-template-thymeleaf/build.gradle
+++ b/http4k-template-thymeleaf/build.gradle
@@ -4,9 +4,8 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.thymeleaf
+    api Libs.thymeleaf
 
-    testCompile project(path: ":http4k-core", configuration: "testArtifacts")
-    testCompile Config.TestDependencies
+    testImplementation project(path: ":http4k-core", configuration: "testArtifacts")
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-testing-approval/build.gradle
+++ b/http4k-testing-approval/build.gradle
@@ -5,8 +5,9 @@ dependencies {
     provided project(":http4k-core")
     provided Libs.junit_jupiter_api
     provided Libs.hamkrest
-    compile Libs.underscore
 
-    testCompile project(":http4k-testing-hamkrest")
-    testCompile Config.TestDependencies
+    api Libs.underscore
+
+    testImplementation project(":http4k-testing-hamkrest")
+    testImplementation Config.TestDependencies
 }

--- a/http4k-testing-chaos/build.gradle
+++ b/http4k-testing-chaos/build.gradle
@@ -4,9 +4,9 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile project(":http4k-contract")
-    compile project(":http4k-format-jackson")
-    compile project(":http4k-testing-hamkrest")
+    api project(":http4k-contract")
+    api project(":http4k-format-jackson")
+    api project(":http4k-testing-hamkrest")
 
-    testCompile Config.TestDependencies
+    testImplementation Config.TestDependencies
 }

--- a/http4k-testing-hamkrest/build.gradle
+++ b/http4k-testing-hamkrest/build.gradle
@@ -4,9 +4,8 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.hamkrest
+    api Libs.hamkrest
 
-    testCompile project(":http4k-format-jackson")
-    testCompile Config.TestDependencies
+    testImplementation project(":http4k-format-jackson")
+    testImplementation Config.TestDependencies
 }
-

--- a/http4k-testing-webdriver/build.gradle
+++ b/http4k-testing-webdriver/build.gradle
@@ -4,9 +4,8 @@ dependencies {
     provided Libs.kotlin_stdlib_jdk8
     provided project(":http4k-core")
 
-    compile Libs.selenium_api
-    compile Libs.jsoup
+    api Libs.selenium_api
+    api Libs.jsoup
 
-    testCompile Config.TestDependencies
+    testImplementation Config.TestDependencies
 }
-


### PR DESCRIPTION
The current version of gradle recommends not using the `compile`
dependency configuration:

> The `compile` configuration still exists but should not be used as it
> will not offer the guarantees that the `api` and `implementation`
> configurations provide.

(from <https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation>)

Thus, I've changed every `testCompile` to `testImplementation` (minor),
and more importantly, every `compile` to `api`.

Why `api`, rather than `implementation`?

> Dependencies appearing in the `api` configurations will be
> transitively exposed to consumers of the library, and as such will
> appear on the compile classpath of consumers.
> Dependencies found in the `implementation` configuration will, on the
> other hand, not be exposed to consumers, and therefore not leak into
> the consumers' compile classpath.

Because the old `compile` dependency configuration behaved as the `api`
one, in that it exposed the dependencies of http4k and its modules
to consumers, changing it now to `implementation` would be a breaking
change -- as a user updating http4k and accidentally referencing
one of its dependencies in its code would suddenly get errors about
missing dependencies.

Instead, from now on, new dependencies should be evaluated if they
should be added as `api` or `implementation`, and in a future 4.x
version of http4k, the current items marked as `implementation` can
be revisited.

Issue #250