### PR TITLE
Improve api documentation: Link to JDK 9 and dependencies' javadocs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,10 +247,10 @@ task dokka(type: org.jetbrains.dokka.gradle.DokkaTask, overwrite: true) {
     outputDirectory = "$buildDir/ddoc"
     outputFormat = "gfm"
     processConfigurations = []
+    jdkVersion = 9
 
     sourceDirs = files(subprojects.collect {
         p ->
-
             def path = new File(p.projectDir, "/src/main/kotlin")
 
             def relativePath = rootDir.toPath().relativize(path.toPath()).toString()

--- a/build.gradle
+++ b/build.gradle
@@ -249,6 +249,63 @@ task dokka(type: org.jetbrains.dokka.gradle.DokkaTask, overwrite: true) {
     processConfigurations = []
     jdkVersion = 9
 
+    externalDocumentationLink {
+        // No version, apache does not seem to keep old versions of javadoc around
+        url = new URL("https://hc.apache.org/httpcomponents-asyncclient-ga/httpasyncclient/apidocs/")
+    }
+    externalDocumentationLink {
+        // No version, apache does not seem to keep old versions of javadoc around
+        url = new URL("https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/")
+    }
+    externalDocumentationLink {
+        // No version, apache does not seem to keep old versions of javadoc around
+        url = new URL("https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/")
+    }
+    externalDocumentationLink {
+        def version = Versions.okhttp_major
+        url = new URL("https://square.github.io/okhttp/${version}.x/okhttp/")
+    }
+    externalDocumentationLink {
+        // No version, argo does not seem to keep old versions of javadoc around
+        url = new URL("http://argo.sourceforge.net/javadoc/")
+    }
+    externalDocumentationLink {
+        def version = Versions.jackson_dataformat_xml_major_minor
+        url = new URL("https://fasterxml.github.io/jackson-dataformat-xml/javadoc/$version/")
+    }
+    externalDocumentationLink {
+        def version = Versions.com_fasterxml_jackson_module_major_minor
+        url = new URL("https://fasterxml.github.io/jackson-databind/javadoc/$version/")
+    }
+    externalDocumentationLink {
+        def version = Versions.com_squareup_moshi_major
+        url = new URL("http://square.github.io/moshi/${version}.x/moshi/")
+    }
+    externalDocumentationLink {
+        def version = Versions.io_undertow_major_minor
+        url = new URL("http://undertow.io/javadoc/${version}.x/")
+    }
+    externalDocumentationLink {
+        def version = Versions.netty_codec_http2_major_minor
+        url = new URL("https://netty.io/$version/api/")
+    }
+    externalDocumentationLink {
+        // No version, this was the latest linkable javadoc I could find for javax servlet api
+        url = new URL("https://javaee.github.io/javaee-spec/javadocs/")
+    }
+    externalDocumentationLink {
+        def version = Versions.org_junit_jupiter
+        url = new URL("https://junit.org/junit5/docs/$version/api/")
+    }
+    externalDocumentationLink {
+        // No version, selenium does not seem to keep old versions of javadoc around
+        url = new URL("https://seleniumhq.github.io/selenium/docs/api/java/")
+    }
+    externalDocumentationLink {
+        // No version, jsoup does not seem to keep old versions of javadoc around
+        url = new URL("https://jsoup.org/apidocs/")
+    }
+
     sourceDirs = files(subprojects.collect {
         p ->
             def path = new File(p.projectDir, "/src/main/kotlin")

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -5,9 +5,11 @@
  *
  * YOU are responsible for updating manually the dependency version. */
 object Versions {
-    const val jackson_dataformat_xml: String = "2.9.9"
+    const val jackson_dataformat_xml_major_minor: String = "2.9"
+    const val jackson_dataformat_xml: String = "$jackson_dataformat_xml_major_minor.9"
 
-    const val com_fasterxml_jackson_module: String = "2.9.9"
+    const val com_fasterxml_jackson_module_major_minor: String = "2.9"
+    const val com_fasterxml_jackson_module: String = "$com_fasterxml_jackson_module_major_minor.9"
 
     const val underscore: String = "1.44"
 
@@ -23,9 +25,11 @@ object Versions {
 
     const val result4k: String = "2.0.0"
 
-    const val com_squareup_moshi: String = "1.8.0"
+    const val com_squareup_moshi_major: String = "1"
+    const val com_squareup_moshi: String = "$com_squareup_moshi_major.8.0"
 
-    const val okhttp: String = "3.14.1"
+    const val okhttp_major: String = "3"
+    const val okhttp: String = "$okhttp_major.14.1"
 
     const val io_github_resilience4j: String = "0.15.0"
 
@@ -33,11 +37,13 @@ object Versions {
 
     const val micrometer_core: String = "1.1.4"
 
-    const val netty_codec_http2: String = "4.1.36.Final"
+    const val netty_codec_http2_major_minor = "4.1"
+    const val netty_codec_http2: String = "$netty_codec_http2_major_minor.36.Final"
 
     const val pebble: String = "3.0.9"
 
-    const val io_undertow: String = "2.0.20.Final"
+    const val io_undertow_major_minor: String = "2.0"
+    const val io_undertow: String = "$io_undertow_major_minor.20.Final"
 
     const val javax_servlet_api: String = "4.0.1"
 


### PR DESCRIPTION
I've configured dokka to target JDK 9 (later versions not possible due to bug, see commit for more details), and also added links to many of http4k dependencies' javadocs, so that they are usable from the api docs.