### PR TITLE
Fix invalid OpenAPI2 when root and base path match

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/OpenApi2.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/OpenApi2.kt
@@ -62,13 +62,19 @@ open class OpenApi2<out NODE>(
     private fun renderPaths(routes: List<ContractRoute>, contractRoot: PathSegments, security: Security): FieldsAndDefinitions<NODE> = routes
         .groupBy { it.describeFor(contractRoot) }.entries
         .fold(FieldsAndDefinitions()) { memo, (path, routes) ->
+            println("memo = $memo, path=$path, routes=$routes")
             val routeFieldsAndDefinitions = routes.fold(FieldsAndDefinitions<NODE>()) { memoFields, route ->
                 memoFields + render(contractRoot, security, route)
             }
             memo + FieldAndDefinitions(
-                path to json { obj(routeFieldsAndDefinitions.fields) }, routeFieldsAndDefinitions.definitions
+                normalisePath(path) to json { obj(routeFieldsAndDefinitions.fields) }, routeFieldsAndDefinitions.definitions
             )
         }
+
+    private fun normalisePath(path: String): String = when(path) {
+        "" -> "/"
+        else -> path
+    }
 
     private fun Meta.renderMeta(schema: JsonSchema<NODE>? = null) = json {
         obj(

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/OpenApi2.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/OpenApi2.kt
@@ -62,7 +62,6 @@ open class OpenApi2<out NODE>(
     private fun renderPaths(routes: List<ContractRoute>, contractRoot: PathSegments, security: Security): FieldsAndDefinitions<NODE> = routes
         .groupBy { it.describeFor(contractRoot) }.entries
         .fold(FieldsAndDefinitions()) { memo, (path, routes) ->
-            println("memo = $memo, path=$path, routes=$routes")
             val routeFieldsAndDefinitions = routes.fold(FieldsAndDefinitions<NODE>()) { memoFields, route ->
                 memoFields + render(contractRoot, security, route)
             }

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(JsonApprovalTest::class)
-abstract class ContractRendererContract<NODE>(private val json: Json<NODE>, private val rendererToUse: ContractRenderer) {
+abstract class ContractRendererContract<NODE>(private val json: Json<NODE>, val rendererToUse: ContractRenderer) {
     @Test
     fun `can build 400`() {
         val response = rendererToUse.badRequest(listOf(

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v2/OpenApi2Test.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v2/OpenApi2Test.kt
@@ -1,8 +1,29 @@
 package org.http4k.contract.openapi.v2
 
 import argo.jdom.JsonNode
-import org.http4k.contract.ContractRendererContract
+import org.http4k.contract.*
 import org.http4k.contract.openapi.ApiInfo
+import org.http4k.contract.security.ApiKeySecurity
+import org.http4k.core.*
 import org.http4k.format.Argo
+import org.http4k.lens.*
+import org.http4k.routing.bind
+import org.http4k.testing.Approver
+import org.junit.jupiter.api.Test
 
-class OpenApi2Test : ContractRendererContract<JsonNode>(Argo, OpenApi2(ApiInfo("title", "1.2", "module description"), Argo))
+class OpenApi2Test : ContractRendererContract<JsonNode>(Argo, OpenApi2(ApiInfo("title", "1.2", "module description"), Argo)) {
+
+    @Test
+    fun `renders root path correctly when bind path and root path match`(approver: Approver) {
+
+        val router = "/" bind contract {
+            renderer = rendererToUse
+            security = ApiKeySecurity(Query.required("the_api_key"), { true })
+            routes += "/" bindContract Method.GET to { Response(Status.OK) }
+            descriptionPath = "/docs"
+        }
+
+        approver.assertApproved(router(Request(Method.GET, "/docs?the_api_key=somevalue")))
+    }
+
+}

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.renders root path correctly when bind path and root path match.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.renders root path correctly when bind path and root path match.approved
@@ -1,0 +1,50 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "title",
+    "version": "1.2",
+    "description": "module description"
+  },
+  "basePath": "/",
+  "tags": [
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "tags": [
+          ""
+        ],
+        "summary": "<unknown>",
+        "operationId": "get",
+        "produces": [
+        ],
+        "consumes": [
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "in": "query",
+      "name": "the_api_key"
+    }
+  },
+  "definitions": {
+  }
+}


### PR DESCRIPTION
When generating OpenAPI2 descriptions where the root and base path are the same, an invalid description is generated.

For example:

```kotlin
  val router = "/" bind contract {
      routes += "/" bindContract Method.GET to { Response(Status.OK) }
      descriptionPath = "/docs"
  }
```

Would generate swagger as follows:

```json
  {
    "swagger": "2.0",
    "info": {
      "title": "title",
      "version": "1.2",
      "description": "module description"
    },
    "basePath": "/",
    "paths": {
      "": {
        "get": {
          "operationId": "get"
        }
      }
    }
  }
```

Which is invalid as empty strings for `#path` URIs are not allowed. This can be tested by running the output of the API through a swagger validator as follows:

```sh
  $ npm install swagger-cli -g
  $ swagger-cli validate example-http4k-swagger.json
```