### PR TITLE
Optionally include description path in description

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
@@ -13,7 +13,8 @@ import org.http4k.util.Appendable
 fun contract(fn: ContractBuilder.() -> Unit) = ContractBuilder().apply(fn).run {
     ContractRoutingHttpHandler(renderer, security, descriptionPath, preFlightExtraction, routes.all,
         preSecurityFilter = preSecurityFilter,
-        postSecurityFilter = postSecurityFilter)
+        postSecurityFilter = postSecurityFilter,
+        includeDescriptionRoute = includeDescriptionRoute)
 }
 
 class ContractBuilder internal constructor() {
@@ -24,6 +25,7 @@ class ContractBuilder internal constructor() {
     var routes = Appendable<ContractRoute>()
     var preSecurityFilter = Filter.NoOp
     var postSecurityFilter = Filter.NoOp
+    var includeDescriptionRoute = false
 }
 
 operator fun <A> String.div(next: PathLens<A>): ContractRouteSpec1<A> = ContractRouteSpec0(toBaseFn(this), RouteMeta()) / next

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -165,6 +165,19 @@ abstract class ContractRendererContract<NODE>(private val json: Json<NODE>, prot
         approver.assertApproved(router(Request(GET, "/basepath?the_api_key=somevalue")))
     }
 
+    @Test
+    fun `when enabled renders description including its own path`(approver: Approver) {
+        val router = "/" bind contract {
+            renderer = rendererToUse
+            security = ApiKeySecurity(Query.required("the_api_key"), { true })
+            routes += "/" bindContract GET to { Response(OK) }
+            descriptionPath = "/docs"
+            includeDescriptionRoute = true
+        }
+
+        approver.assertApproved(router(Request(GET, "/docs?the_api_key=somevalue")))
+    }
+
 }
 
 private val credentials = Credentials("user", "password")

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.when enabled renders description including its own path.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.when enabled renders description including its own path.approved
@@ -1,0 +1,82 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "title",
+    "version": "1.2",
+    "description": "module description"
+  },
+  "basePath": "/",
+  "tags": [
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "tags": [
+          ""
+        ],
+        "summary": "<unknown>",
+        "operationId": "get",
+        "produces": [
+        ],
+        "consumes": [
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ]
+      }
+    },
+    "/docs": {
+      "get": {
+        "tags": [
+          ""
+        ],
+        "summary": "<unknown>",
+        "operationId": "description",
+        "produces": [
+        ],
+        "consumes": [
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "securityDefinitions": {
+    "api_key": {
+      "type": "apiKey",
+      "in": "query",
+      "name": "the_api_key"
+    }
+  },
+  "definitions": {
+  },
+  "host": "example.org:8000",
+  "schemes": [
+    "http"
+  ]
+}

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.when enabled renders description including its own path.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.when enabled renders description including its own path.approved
@@ -1,0 +1,63 @@
+{
+  "info": {
+    "title": "title",
+    "version": "1.2",
+    "description": "module description"
+  },
+  "tags": [
+  ],
+  "paths": {
+    "": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          ""
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "get"
+      }
+    },
+    "/docs": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          ""
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "description"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+    },
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "the_api_key"
+      }
+    }
+  },
+  "openapi": "3.0.0"
+}

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.when enabled renders description including its own path.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.when enabled renders description including its own path.approved
@@ -1,0 +1,63 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "title",
+    "version": "1.2",
+    "description": "module description"
+  },
+  "tags": [
+  ],
+  "paths": {
+    "": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          ""
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "get"
+      }
+    },
+    "/docs": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          ""
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "description"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+    },
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "the_api_key"
+      }
+    }
+  }
+}

--- a/http4k-contract/src/test/resources/org/http4k/contract/simple/SimpleJsonTest.when enabled renders description including its own path.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/simple/SimpleJsonTest.when enabled renders description including its own path.approved
@@ -1,0 +1,6 @@
+{
+  "resources": {
+    "GET:": "<unknown>",
+    "GET:/docs": "<unknown>"
+  }
+}


### PR DESCRIPTION
Google Cloud Endpoints (GCE) will only make an endpoint publicly accessible if it has a path directive in the OpenAPI description. But by default http4k-contract does not include the contract path in the OpenAPI description.

This means hosted Swagger documentation is inaccessible unless we manually re-format the results of the contract route.

This change adds an optional directive to the contract DSL that adds the description path to the OpenAPI description, allowing it to be accessed when deployed in GCE.