### PR TITLE
Add support for Google Cloud Endpoints OAuth2

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/OpenApi2SecurityRenderer.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/OpenApi2SecurityRenderer.kt
@@ -6,11 +6,12 @@ import org.http4k.contract.openapi.SecurityRenderer
 import org.http4k.contract.openapi.rendererFor
 import org.http4k.contract.security.ApiKeySecurity
 import org.http4k.contract.security.BasicAuthSecurity
+import org.http4k.contract.security.ImplicitOAuthSecurity
 
 /**
  * Compose the supported Security models
  */
-val OpenApi2SecurityRenderer = SecurityRenderer(ApiKeySecurity.renderer, BasicAuthSecurity.renderer)
+val OpenApi2SecurityRenderer = SecurityRenderer(ApiKeySecurity.renderer, BasicAuthSecurity.renderer, ImplicitOAuthSecurity.renderer)
 
 val ApiKeySecurity.Companion.renderer
     get() = rendererFor<ApiKeySecurity<*>> {
@@ -39,3 +40,23 @@ val BasicAuthSecurity.Companion.renderer
             override fun <NODE> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
         }
     }
+
+val ImplicitOAuthSecurity.Companion.renderer
+    get() = rendererFor<ImplicitOAuthSecurity> {
+        object : RenderModes {
+            override fun <NODE> full(): Render<NODE> = {
+                obj(it.name to
+                    obj(
+                        listOfNotNull(
+                            "type" to string("oauth2"),
+                            "flows" to string("implicit"),
+                            "authorizationUrl" to string(it.authorizationUrl.toString())
+                        ) + it.extraFields.map { it.key to string(it.value) }
+                    )
+                )
+            }
+
+            override fun <NODE> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
+        }
+    }
+

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.renders Google Cloud Endpoints OAuth2.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.renders Google Cloud Endpoints OAuth2.approved
@@ -1,0 +1,57 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "title",
+    "version": "1.2",
+    "description": "module description"
+  },
+  "basePath": "/",
+  "tags": [
+  ],
+  "paths": {
+    "/example": {
+      "get": {
+        "tags": [
+          ""
+        ],
+        "summary": "<unknown>",
+        "operationId": "getExample",
+        "produces": [
+        ],
+        "consumes": [
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+            }
+          }
+        },
+        "security": [
+          {
+            "oauth2": [
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "securityDefinitions": {
+    "oauth2": {
+      "type": "oauth2",
+      "flows": "implicit",
+      "authorizationUrl": "",
+      "x-google-issuer": "example-google-issuer",
+      "x-google-jwks_uri": "http://example.org/jwks",
+      "x-google-audiences": "client-id1,client-id2"
+    }
+  },
+  "definitions": {
+  },
+  "host": "example.org:8000",
+  "schemes": [
+    "http"
+  ]
+}


### PR DESCRIPTION
This ticket adds support for Google Cloud Endpoints (GCE) OAuth2 as defined in this document:

https://cloud.google.com/endpoints/docs/openapi/authenticating-users-custom

Note: by default the GCE Extensible Service Proxy handles authentication, so the new GCE Security implementation sets a NOOP authentication filter by default.