### PR TITLE
Parse access token response as json when content-type is missing encoding directive

### DIFF
--- a/http4k-security-oauth/src/main/kotlin/org/http4k/security/AccessTokenFetcher.kt
+++ b/http4k-security-oauth/src/main/kotlin/org/http4k/security/AccessTokenFetcher.kt
@@ -25,7 +25,7 @@ class AccessTokenFetcher(
         .form("code", code))
         .let { if (it.status != Status.OK) null else it }
         ?.let {
-            if (CONTENT_TYPE(it) == ContentType.APPLICATION_JSON) {
+            if (CONTENT_TYPE(it) == ContentType.APPLICATION_JSON || CONTENT_TYPE(it) == ContentType.APPLICATION_JSON.withNoDirective()) {
                 with(accessTokenResponseBody(it)) {
                     AccessTokenDetails(AccessToken(accessToken), idToken?.let(::IdToken))
                 }

--- a/http4k-security-oauth/src/test/kotlin/org/http4k/security/AccessTokenFetcherTest.kt
+++ b/http4k-security-oauth/src/test/kotlin/org/http4k/security/AccessTokenFetcherTest.kt
@@ -36,6 +36,19 @@ internal class AccessTokenFetcherTest {
     }
 
     @Test
+    fun `can get access token from json body for content-type without directive`() {
+        val api = { _: Request ->
+            Response(OK)
+                .header("Content-Type", "application/json")
+                .body("{\"access_token\": \"some-access-token\"}")
+        }
+
+        val fetcher = AccessTokenFetcher(api, Uri.of("irrelevant"), config)
+
+        assertThat(fetcher.fetch("some-code"), equalTo(AccessTokenDetails(AccessToken("some-access-token"))))
+    }
+
+    @Test
     fun `handle non-successful response`() {
         val api = { _: Request -> Response(BAD_REQUEST) }
 


### PR DESCRIPTION
When the `Content-Type` of the response is `application/json` instead of `application/json;charset=utf-8` http4k fails to parse the body as JSON. When no charset is specified, the default is utf-8.

This problem came to light when I was using http4k to authenticate to Keycloak.