### PR TITLE
Refix writer lookup for jackson

### DIFF
--- a/http4k-format-jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
+++ b/http4k-format-jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
@@ -72,19 +72,15 @@ open class ConfigurableJackson(val mapper: ObjectMapper) : JsonLibAutoMarshallin
 
     inline fun <reified T : Any> Body.Companion.auto(description: String? = null, contentNegotiation: ContentNegotiation = None) = autoBody<T>(description, contentNegotiation)
 
-    inline fun <reified T : Any> Body.Companion.autoGeneric(description: String? = null, contentNegotiation: ContentNegotiation = None) =
-        autoBody<T>(description, contentNegotiation) {
+    inline fun <reified T : Any> autoBody(description: String? = null, contentNegotiation: ContentNegotiation = None): BiDiBodyLensSpec<T> {
+        return jsonHttpBodyLens(description, contentNegotiation).map(mapper.read(), {
             val typeRef = jacksonTypeRef<T>()
-            if (typeFactory.constructType(typeRef).isContainerType) {
-                writer().forType(typeRef).writeValueAsString(it)
+            if (mapper.typeFactory.constructType(typeRef).isContainerType) {
+                mapper.writer().forType(typeRef).writeValueAsString(it)
             } else {
-                writeValueAsString(it)
+                mapper.writeValueAsString(it)
             }
-        }
-
-    inline fun <reified T : Any> autoBody(description: String? = null, contentNegotiation: ContentNegotiation = None,
-                                          crossinline writeFn: ObjectMapper.(T) -> String = ObjectMapper::writeValueAsString): BiDiBodyLensSpec<T> {
-        return jsonHttpBodyLens(description, contentNegotiation).map(mapper.read(), { mapper.writeFn(it) })
+        })
     }
 
     // views

--- a/http4k-format-jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
+++ b/http4k-format-jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.databind.node.TextNode
 import com.fasterxml.jackson.module.kotlin.KotlinModule
 import com.fasterxml.jackson.module.kotlin.convertValue
+import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.http4k.core.Body
 import org.http4k.core.ContentType.Companion.APPLICATION_JSON
@@ -71,10 +72,8 @@ open class ConfigurableJackson(val mapper: ObjectMapper) : JsonLibAutoMarshallin
 
     inline fun <reified T : Any> Body.Companion.auto(description: String? = null, contentNegotiation: ContentNegotiation = None) = autoBody<T>(description, contentNegotiation)
 
-    inline fun <reified T : Any> autoBody(description: String? = null, contentNegotiation: ContentNegotiation = None,
-                                          crossinline writeFn: ObjectMapper.(T) -> String = ObjectMapper::writeValueAsString): BiDiBodyLensSpec<T> {
-        return jsonHttpBodyLens(description, contentNegotiation).map(mapper.read(), { mapper.writeFn(it) })
-    }
+    inline fun <reified T : Any> autoBody(description: String? = null, contentNegotiation: ContentNegotiation = None): BiDiBodyLensSpec<T> =
+        jsonHttpBodyLens(description, contentNegotiation).map(mapper.read(), { mapper.writerFor(jacksonTypeRef<T>()).writeValueAsString(it) })
 
     // views
     fun <T : Any, V : Any> T.asCompactJsonStringUsingView(v: KClass<V>): String = mapper.writerWithView(v.java).writeValueAsString(this)

--- a/http4k-format-jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
+++ b/http4k-format-jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
@@ -72,7 +72,15 @@ open class ConfigurableJackson(val mapper: ObjectMapper) : JsonLibAutoMarshallin
 
     inline fun <reified T : Any> Body.Companion.auto(description: String? = null, contentNegotiation: ContentNegotiation = None) = autoBody<T>(description, contentNegotiation)
 
-    inline fun <reified T : Any> Body.Companion.autoGeneric(description: String? = null, contentNegotiation: ContentNegotiation = None) = autoBody<T>(description, contentNegotiation) { writerFor(jacksonTypeRef<T>()).writeValueAsString(it) }
+    inline fun <reified T : Any> Body.Companion.autoGeneric(description: String? = null, contentNegotiation: ContentNegotiation = None) =
+        autoBody<T>(description, contentNegotiation) {
+            val typeRef = jacksonTypeRef<T>()
+            if (typeFactory.constructType(typeRef).isContainerType) {
+                writer().forType(typeRef).writeValueAsString(it)
+            } else {
+                writeValueAsString(it)
+            }
+        }
 
     inline fun <reified T : Any> autoBody(description: String? = null, contentNegotiation: ContentNegotiation = None,
                                           crossinline writeFn: ObjectMapper.(T) -> String = ObjectMapper::writeValueAsString): BiDiBodyLensSpec<T> {

--- a/http4k-format-jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
+++ b/http4k-format-jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
@@ -72,8 +72,12 @@ open class ConfigurableJackson(val mapper: ObjectMapper) : JsonLibAutoMarshallin
 
     inline fun <reified T : Any> Body.Companion.auto(description: String? = null, contentNegotiation: ContentNegotiation = None) = autoBody<T>(description, contentNegotiation)
 
-    inline fun <reified T : Any> autoBody(description: String? = null, contentNegotiation: ContentNegotiation = None): BiDiBodyLensSpec<T> =
-        jsonHttpBodyLens(description, contentNegotiation).map(mapper.read(), { mapper.writerFor(jacksonTypeRef<T>()).writeValueAsString(it) })
+    inline fun <reified T : Any> Body.Companion.autoGeneric(description: String? = null, contentNegotiation: ContentNegotiation = None) = autoBody<T>(description, contentNegotiation) { writerFor(jacksonTypeRef<T>()).writeValueAsString(it) }
+
+    inline fun <reified T : Any> autoBody(description: String? = null, contentNegotiation: ContentNegotiation = None,
+                                          crossinline writeFn: ObjectMapper.(T) -> String = ObjectMapper::writeValueAsString): BiDiBodyLensSpec<T> {
+        return jsonHttpBodyLens(description, contentNegotiation).map(mapper.read(), { mapper.writeFn(it) })
+    }
 
     // views
     fun <T : Any, V : Any> T.asCompactJsonStringUsingView(v: KClass<V>): String = mapper.writerWithView(v.java).writeValueAsString(this)

--- a/http4k-format-jackson/src/test/kotlin/org/http4k/format/JacksonTest.kt
+++ b/http4k-format-jackson/src/test/kotlin/org/http4k/format/JacksonTest.kt
@@ -95,8 +95,15 @@ class JacksonAutoTest : AutoMarshallingContract(Jackson) {
     @Test
     fun `write interface implementation to body`() {
         assertThat(Response(OK).with(
-            Body.auto<Interface>().toLens() of InterfaceImpl()
+            Body.autoGeneric<Interface>().toLens() of InterfaceImpl()
         ).bodyString(), equalTo("""{"value":"hello","subValue":"123"}"""))
+    }
+
+    @Test
+    fun `write list of interface implementation to body`() {
+        assertThat(Response(OK).with(
+            Body.autoGeneric<List<Interface>>().toLens() of listOf(InterfaceImpl())
+        ).bodyString(), equalTo("""[{"value":"hello","subValue":"123"}]"""))
     }
 
     @Test

--- a/http4k-format-jackson/src/test/kotlin/org/http4k/format/JacksonTest.kt
+++ b/http4k-format-jackson/src/test/kotlin/org/http4k/format/JacksonTest.kt
@@ -13,7 +13,6 @@ import org.http4k.core.Status.Companion.OK
 import org.http4k.core.with
 import org.http4k.format.Jackson.asA
 import org.http4k.format.Jackson.auto
-import org.http4k.format.Jackson.autoGeneric
 import org.http4k.format.Jackson.autoView
 import org.http4k.hamkrest.hasBody
 import org.http4k.websocket.WsMessage
@@ -95,14 +94,14 @@ class JacksonAutoTest : AutoMarshallingContract(Jackson) {
     @Test
     fun `write interface implementation to body`() {
         assertThat(Response(OK).with(
-            Body.autoGeneric<Interface>().toLens() of InterfaceImpl()
+            Body.auto<Interface>().toLens() of InterfaceImpl()
         ).bodyString(), equalTo("""{"value":"hello","subValue":"123"}"""))
     }
 
     @Test
     fun `write list of interface implementation to body`() {
         assertThat(Response(OK).with(
-            Body.autoGeneric<List<Interface>>().toLens() of listOf(InterfaceImpl())
+            Body.auto<List<Interface>>().toLens() of listOf(InterfaceImpl())
         ).bodyString(), equalTo("""[{"value":"hello","subValue":"123"}]"""))
     }
 
@@ -114,7 +113,7 @@ class JacksonAutoTest : AutoMarshallingContract(Jackson) {
 
     @Test
     fun `roundtrip list of polymorphic objects to and from body`() {
-        val body = Body.autoGeneric<List<PolymorphicParent>>().toLens()
+        val body = Body.auto<List<PolymorphicParent>>().toLens()
 
         val list = listOf(FirstChild("hello"), SecondChild("world"))
 

--- a/http4k-format-jackson/src/test/kotlin/org/http4k/format/JacksonTest.kt
+++ b/http4k-format-jackson/src/test/kotlin/org/http4k/format/JacksonTest.kt
@@ -96,23 +96,12 @@ class JacksonAutoTest : AutoMarshallingContract(Jackson) {
         assertThat(Response(OK).with(
             Body.auto<Interface>().toLens() of InterfaceImpl()
         ).bodyString(), equalTo("""{"value":"hello","subValue":"123"}"""))
-
-        // this is the wrong behaviour if we want to use the same auto method for both ...
-        assertThat(Response(OK).with(
-            Jackson.autoBody<Interface>(writeFn = { writerFor(jacksonTypeRef<Interface>()).writeValueAsString(it) }).toLens() of InterfaceImpl()
-        ).bodyString(), equalTo("""{"value":"hello"}"""))
-        assertThat(Response(OK).with(Body.auto<Interface>().toLens() of InterfaceImpl()).bodyString(), equalTo("""{"value":"hello","subValue":"123"}"""))
     }
 
     @Test
     fun `writes using non-sealed parent type`() {
         val nonSealedChild = NonSealedChild("hello")
         assertThat(Response(OK).with(Body.auto<NotSealedParent>().toLens() of nonSealedChild).bodyString(), equalTo("""{"something":"hello"}"""))
-
-        // this is the wrong behaviour if we want to use the same auto method for both ...
-        assertThat(Response(OK).with(
-            Jackson.autoBody<NotSealedParent>(writeFn = { writerFor(jacksonTypeRef<NotSealedParent>()).writeValueAsString(it) }).toLens() of nonSealedChild
-        ).bodyString(), equalTo("""{}"""))
     }
 
     @Test

--- a/http4k-format-jackson/src/test/kotlin/org/http4k/format/JacksonTest.kt
+++ b/http4k-format-jackson/src/test/kotlin/org/http4k/format/JacksonTest.kt
@@ -13,6 +13,7 @@ import org.http4k.core.Status.Companion.OK
 import org.http4k.core.with
 import org.http4k.format.Jackson.asA
 import org.http4k.format.Jackson.auto
+import org.http4k.format.Jackson.autoGeneric
 import org.http4k.format.Jackson.autoView
 import org.http4k.hamkrest.hasBody
 import org.http4k.websocket.WsMessage
@@ -106,7 +107,7 @@ class JacksonAutoTest : AutoMarshallingContract(Jackson) {
 
     @Test
     fun `roundtrip list of polymorphic objects to and from body`() {
-        val body = Body.auto<List<PolymorphicParent>>().toLens()
+        val body = Body.autoGeneric<List<PolymorphicParent>>().toLens()
 
         val list = listOf(FirstChild("hello"), SecondChild("world"))
 

--- a/http4k-format-jackson/src/test/kotlin/org/http4k/format/JacksonTest.kt
+++ b/http4k-format-jackson/src/test/kotlin/org/http4k/format/JacksonTest.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonView
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.module.kotlin.jacksonTypeRef
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.http4k.core.Body
@@ -102,6 +101,7 @@ class JacksonAutoTest : AutoMarshallingContract(Jackson) {
         assertThat(Response(OK).with(
             Jackson.autoBody<Interface>(writeFn = { writerFor(jacksonTypeRef<Interface>()).writeValueAsString(it) }).toLens() of InterfaceImpl()
         ).bodyString(), equalTo("""{"value":"hello"}"""))
+        assertThat(Response(OK).with(Body.auto<Interface>().toLens() of InterfaceImpl()).bodyString(), equalTo("""{"value":"hello","subValue":"123"}"""))
     }
 
     @Test
@@ -117,7 +117,7 @@ class JacksonAutoTest : AutoMarshallingContract(Jackson) {
 
     @Test
     fun `roundtrip list of polymorphic objects to and from body`() {
-        val body = Jackson.autoBody<List<PolymorphicParent>>(writeFn = { writerFor(jacksonTypeRef<List<PolymorphicParent>>()).writeValueAsString(it) }).toLens()
+        val body = Body.auto<List<PolymorphicParent>>().toLens()
 
         val list = listOf(FirstChild("hello"), SecondChild("world"))
 


### PR DESCRIPTION
By porting the [Spring MVC's Jackson serialization logic](https://github.com/spring-projects/spring-framework/blob/9c17eb59a4312a9787b23ebaea3bff6e95f3657c/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java#L250)