### PR TITLE
Add method to allow copying of trace information to child worker threads

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ZipkinTraces.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ZipkinTraces.kt
@@ -55,6 +55,12 @@ data class ZipkinTraces(val traceId: TraceId, val spanId: TraceId, val parentSpa
         operator fun invoke(target: HttpMessage): ZipkinTraces = lens(target)
         operator fun <T : HttpMessage> invoke(value: ZipkinTraces, target: T): T = lens(value, target)
 
+        fun setForCurrentThread(zipkinTraces: ZipkinTraces) {
+            THREAD_LOCAL.set(zipkinTraces)
+        }
+
+        fun forCurrentThread(): ZipkinTraces = THREAD_LOCAL.get()
+
         internal val THREAD_LOCAL = object : ThreadLocal<ZipkinTraces>() {
             override fun initialValue() = ZipkinTraces(TraceId.new(), TraceId.new(), null, SAMPLE)
         }

--- a/http4k-core/src/test/kotlin/org/http4k/filter/RequestTracingTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/RequestTracingTest.kt
@@ -3,15 +3,12 @@ package org.http4k.filter
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.present
-import org.http4k.core.HttpHandler
-import org.http4k.core.Method
-import org.http4k.core.Request
-import org.http4k.core.Response
+import org.http4k.core.*
 import org.http4k.core.Status.Companion.OK
-import org.http4k.core.then
 import org.http4k.filter.SamplingDecision.Companion.DO_NOT_SAMPLE
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.concurrent.Executors
 
 class RequestTracingTest {
 
@@ -39,6 +36,39 @@ class RequestTracingTest {
         }
 
         val simpleProxyServer: HttpHandler = ServerFilters.RequestTracing().then { client(Request(Method.GET, "/somePath")) }
+
+        val response = simpleProxyServer(ZipkinTraces(traces, Request(Method.GET, "")))
+
+        assertThat(ZipkinTraces(response), equalTo(traces))
+    }
+
+    @Test
+    fun `request traces may be copied to child threads`() {
+        val originalTraceId = TraceId("originalTrace")
+        val originalSpanId = TraceId("originalSpan")
+        val originalParentSpanId = TraceId("originalParentSpanId")
+        val traces = ZipkinTraces(originalTraceId, originalSpanId, originalParentSpanId, DO_NOT_SAMPLE)
+
+        val client: HttpHandler = ClientFilters.RequestTracing().then {
+            val actual = ZipkinTraces(it)
+
+            assertThat(actual.traceId, equalTo(originalTraceId))
+            assertThat(actual.parentSpanId, equalTo(originalSpanId))
+            assertThat(actual.spanId, present())
+            assertThat(actual.samplingDecision, equalTo(DO_NOT_SAMPLE))
+
+            Response(OK)
+        }
+
+        val executor = Executors.newSingleThreadExecutor()
+        val simpleProxyServer: HttpHandler = ServerFilters.RequestTracing().then {
+            val traceForOuterThread = ZipkinTraces.forCurrentThread()
+            val clientTask = {
+                ZipkinTraces.setForCurrentThread(traceForOuterThread)
+                client(Request(Method.GET, "/somePath"))
+            }
+            executor.submit(clientTask).get()
+        }
 
         val response = simpleProxyServer(ZipkinTraces(traces, Request(Method.GET, "")))
 


### PR DESCRIPTION
This adds method to expose, and allow overwriting, the current Zipkin trace data.

> "Why, this is madness! Why would you break encapsulation in such a way?"

I'm glad you asked. We have a case where we use a thread-pool to query various services in parallel. We need to ensure that these threads have a copy of the current trace data to ensure that we can reconstruct the trace. As such, we need to copy the data across on task initialisation, in a similar manner to the provided test.