### PR TITLE
Introduce support for GZipping response streams

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ClientFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ClientFilters.kt
@@ -136,11 +136,12 @@ object ClientFilters {
     }
 
     /**
-     * Basic GZip and Gunzip support of Request/Response. Does not currently support GZipping streams.
+     * Basic GZip and Gunzip support of Request/Response.
      * Only Gunzip responses when the response contains "transfer-encoding" header containing 'gzip'
      */
     object GZip {
-        operator fun invoke(): Filter = RequestFilters.GZip().then(ResponseFilters.GunZip())
+        operator fun invoke(compressionMode: GzipCompressionMode = GzipCompressionMode.NON_STREAMING): Filter =
+                RequestFilters.GZip(compressionMode).then(ResponseFilters.GunZip(compressionMode))
     }
 
     /**

--- a/http4k-core/src/main/kotlin/org/http4k/filter/RequestFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/RequestFilters.kt
@@ -1,10 +1,8 @@
 package org.http4k.filter
 
-import org.http4k.core.Filter
-import org.http4k.core.Request
-import org.http4k.core.Response
+import org.http4k.core.*
 import org.http4k.core.Status.Companion.BAD_REQUEST
-import org.http4k.core.Uri
+import org.http4k.filter.GzipCompressionMode.NON_STREAMING
 
 object RequestFilters {
 
@@ -21,25 +19,25 @@ object RequestFilters {
     }
 
     /**
-     * Basic GZipping of Request. Does not currently support GZipping streams
+     * Basic GZipping of Request.
      */
     object GZip {
-        operator fun invoke() = Filter { next ->
+        operator fun invoke(compressionMode: GzipCompressionMode = NON_STREAMING) = Filter { next ->
             { request ->
-                next(request.body(request.body.gzipped()).replaceHeader("content-encoding", "gzip"))
+                next(request.body(compressionMode.compress(request.body)).replaceHeader("content-encoding", "gzip"))
             }
         }
     }
 
     /**
-     * Basic UnGZipping of Request. Does not currently support GZipping streams
+     * Basic UnGZipping of Request.
      */
     object GunZip {
-        operator fun invoke() = Filter { next ->
+        operator fun invoke(compressionMode: GzipCompressionMode = NON_STREAMING) = Filter { next ->
             { request ->
                 request.header("content-encoding")
-                    ?.let { if (it.contains("gzip")) it else null }
-                    ?.let { next(request.body(request.body.gunzipped())) } ?: next(request)
+                        ?.let { if (it.contains("gzip")) it else null }
+                        ?.let { next(request.body(compressionMode.decompress(request.body))) } ?: next(request)
             }
         }
     }

--- a/http4k-core/src/main/kotlin/org/http4k/filter/ext.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ext.kt
@@ -3,10 +3,18 @@ package org.http4k.filter
 import org.http4k.core.Body
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
 import java.nio.ByteBuffer
+import java.util.zip.CRC32
+import java.util.zip.Deflater
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
+enum class GzipCompressionMode(val compress: (Body) -> Body, val decompress: (Body) -> Body) {
+    NON_STREAMING({ it.gzipped() }, { it.gunzipped() }),
+    STREAMING({ it.gzippedStream() }, { it.gunzippedStream() })
+}
 
 fun Body.gzipped(): Body = if (payload.array().isEmpty()) Body.EMPTY
 else ByteArrayOutputStream().run {
@@ -18,4 +26,118 @@ fun Body.gunzipped(): Body = if (payload.array().isEmpty()) Body.EMPTY
 else ByteArrayOutputStream().use {
     GZIPInputStream(ByteArrayInputStream(payload.array())).copyTo(it)
     Body(ByteBuffer.wrap(it.toByteArray()))
+}
+
+fun Body.gzippedStream(): Body = Body(GZippingInputStream(stream))
+
+fun Body.gunzippedStream(): Body = if (length != null && length == 0L) {
+    Body.EMPTY
+} else {
+    Body(GZIPInputStream(stream))
+}
+
+internal class GZippingInputStream(private val source: InputStream) : InputStream() {
+
+    companion object {
+        // see http://www.zlib.org/rfc-gzip.html#header-trailer
+        private const val GZIP_MAGIC = 0x8b1f
+        private val HEADER_DATA = byteArrayOf(
+                GZIP_MAGIC.toByte(),
+                (GZIP_MAGIC shr 8).toByte(),
+                Deflater.DEFLATED.toByte(),
+                0, 0, 0, 0, 0, 0, 0)
+    }
+
+    private enum class State {
+        HEADER, DATA, FINALISE, TRAILER, DONE
+    }
+
+    private val deflater = Deflater(Deflater.DEFLATED, true)
+    private val crc = CRC32()
+    private var trailer: ByteArrayInputStream? = null
+    private val header = ByteArrayInputStream(HEADER_DATA)
+
+    private var stage = State.HEADER
+
+    override fun read(): Int {
+        val readBytes = ByteArray(1)
+        var bytesRead = 0
+        while (bytesRead == 0) {
+            bytesRead = read(readBytes, 0, 1)
+        }
+        return if (bytesRead != -1) {
+            readBytes[0].toInt().and(0xFF)
+        } else {
+            -1
+        }
+    }
+
+    @Throws(IOException::class)
+    override fun read(readBuffer: ByteArray, readOffset: Int, readLength: Int): Int = when (stage) {
+        State.HEADER -> {
+            val bytesRead = header.read(readBuffer, readOffset, readLength)
+            if (header.available() == 0) {
+                stage = State.DATA
+            }
+            bytesRead
+        }
+        State.DATA -> {
+            val deflationBuffer = ByteArray(readLength)
+            val bytesRead = source.read(deflationBuffer, 0, readLength)
+            if (bytesRead <= 0) {
+                stage = State.FINALISE
+                deflater.finish()
+                0
+            } else {
+                crc.update(deflationBuffer, 0, bytesRead)
+                deflater.setInput(deflationBuffer, 0, bytesRead)
+                var bufferBytesRead = 0
+                while (!deflater.needsInput() && readLength - bufferBytesRead > 0) {
+                    bufferBytesRead += deflater.deflate(readBuffer, readOffset + bufferBytesRead, readLength - bufferBytesRead, Deflater.NO_FLUSH)
+                }
+                bufferBytesRead
+            }
+        }
+        State.FINALISE -> if (deflater.finished()) {
+            stage = State.TRAILER
+            val crcValue = crc.value.toInt()
+            val totalIn = deflater.totalIn
+            trailer = createTrailer(crcValue, totalIn)
+            0
+        } else {
+            deflater.deflate(readBuffer, readOffset, readLength, Deflater.FULL_FLUSH)
+        }
+        State.TRAILER -> {
+            val trailerStream = trailer ?: error("Trailer stream is null in trailer stage")
+            val bytesRead = trailerStream.read(readBuffer, readOffset, readLength)
+            if (trailerStream.available() == 0) {
+                stage = State.DONE
+            }
+            bytesRead
+        }
+        State.DONE -> -1
+    }
+
+    private fun createTrailer(crcValue: Int, totalIn: Int) =
+            ByteArrayInputStream(byteArrayOf(
+                    (crcValue shr 0).toByte(),
+                    (crcValue shr 8).toByte(),
+                    (crcValue shr 16).toByte(),
+                    (crcValue shr 24).toByte(),
+                    (totalIn shr 0).toByte(),
+                    (totalIn shr 8).toByte(),
+                    (totalIn shr 16).toByte(),
+                    (totalIn shr 24).toByte()))
+
+    @Throws(IOException::class)
+    override fun close() {
+        source.close()
+        deflater.end()
+        trailer?.close()
+        header.close()
+    }
+
+    init {
+        crc.reset()
+    }
 }

--- a/http4k-core/src/test/kotlin/org/http4k/filter/GzipBodyTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/GzipBodyTest.kt
@@ -2,13 +2,77 @@ package org.http4k.filter
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import org.http4k.asString
 import org.http4k.core.Body
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.InputStreamReader
+import java.nio.ByteBuffer
+import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
 
 class GzipBodyTest {
 
-    @Test
-    fun `roundtrip`() {
-        assertThat(Body("foo").gzipped().gunzipped(), equalTo(Body("foo")))
+    @Nested
+    inner class InMemoryGzip {
+
+        @Test
+        fun roundtrip() {
+            assertThat(Body("foo").gzipped().gunzipped(), equalTo(Body("foo")))
+        }
+
     }
+
+    @Nested
+    inner class StreamingGzip {
+        @Test
+        fun `a gzipped body can be decompressed by the standard library`() {
+            val gzipped = Body("foo").gzippedStream()
+
+            val decompressedOutput = InputStreamReader(GZIPInputStream(gzipped.stream), Charsets.UTF_8).use {
+                it.readText()
+            }
+
+            assertThat(decompressedOutput, equalTo("foo"))
+        }
+
+        @Test
+        fun `a body gzipped by the standard library can be decompressed`() {
+            val compressedBody = ByteArrayOutputStream().run {
+                GZIPOutputStream(this).use { it.write("foo".toByteArray(Charsets.UTF_8)) }
+                Body(ByteBuffer.wrap(toByteArray()))
+            }
+
+            val gunzipped = compressedBody.gunzippedStream()
+
+            assertThat(gunzipped.payload.asString(), equalTo("foo"))
+        }
+
+        @Test
+        fun `a empty body can be decompressed`() {
+            val compressedBody = Body("")
+
+            val gunzipped = compressedBody.gunzippedStream()
+
+            assertThat(gunzipped.payload.asString(), equalTo(""))
+        }
+
+        @Test
+        fun `a round-trip of an empty body works`() {
+            assertThat(Body("").gzippedStream().gunzippedStream(), equalTo(Body("")))
+        }
+
+        @Test
+        fun `a round-trip of a memory body works`() {
+            assertThat(Body("foo").gzippedStream().gunzippedStream(), equalTo(Body("foo")))
+        }
+
+        @Test
+        fun `a round-trip of a streaming body works`() {
+            assertThat(Body("foo".byteInputStream(Charsets.UTF_8)).gzippedStream().gunzippedStream().payload,
+                    equalTo(Body("foo").payload))
+        }
+    }
+
 }


### PR DESCRIPTION
This PR introduces a parameter to the various GZip filters, allowing then to be used with streaming operations, as opposed to the current implementation which relies on in-memory transformations.

This has a number of benefits:
* We can support the GZip en/decoding of resources requiring streaming
* It should reduce memory usage

It also has a number of drawbacks, primarily that you can only consume the stream a single time. As such, it has been introduced as a variation of behaviour, to allow both existing users and convenient applications (e.g. testing) to retain the current behaviour.

And in any case, better devs than I have buggered up streaming code, so it's definitely safer to introduce it as an opt-in option, rather than a mandated replacement.

`GZippingInputStream` is derived from @nicolai-budico's code on [Stack Overflow](https://stackoverflow.com/a/28072468), with a few tweaks (primarily implementing `read(): Int`, to allow its use in pipelined streams, especially for testing).