### PR TITLE
Add editorconfig file to ensure contributed code uses the non-standard continuation indent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset=utf-8
+end_of_line=lf
+indent_style=space
+indent_size = 4
+insert_final_newline = true
+
+[*.kt]
+continuation_indent_size = 4


### PR DESCRIPTION
Minor addition - `editorconfig` file, since your edits suggest you're using a lower continuation indent than standard, and I'm all for keeping diffs simple.