### PR TITLE
Gzip fixes

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/RequestFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/RequestFilters.kt
@@ -26,8 +26,8 @@ object RequestFilters {
      */
     object GZip {
         operator fun invoke(compressionMode: GzipCompressionMode = Memory) = Filter { next ->
-            { request ->
-                next(request.body(compressionMode.compress(request.body)).replaceHeader("content-encoding", "gzip"))
+            {
+                next(compressionMode.compress(it.body).apply(it))
             }
         }
     }

--- a/http4k-core/src/main/kotlin/org/http4k/filter/ext.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ext.kt
@@ -1,6 +1,8 @@
 package org.http4k.filter
 
 import org.http4k.core.Body
+import org.http4k.core.Request
+import org.http4k.core.Response
 import java.io.*
 import java.nio.ByteBuffer
 import java.util.zip.CRC32
@@ -8,17 +10,33 @@ import java.util.zip.Deflater
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
-sealed class GzipCompressionMode(internal val compress: (Body) -> Body, internal val decompress: (Body) -> Body) {
+sealed class GzipCompressionMode(internal val compress: (Body) -> CompressionResult, internal val decompress: (Body) -> Body) {
 
     object Memory : GzipCompressionMode(Body::gzipped, Body::gunzipped)
 
     object Streaming : GzipCompressionMode(Body::gzippedStream, Body::gunzippedStream)
 }
 
-fun Body.gzipped(): Body = if (payload.array().isEmpty()) Body.EMPTY
+data class CompressionResult(val body: Body,
+                             val contentEncoding: String?) {
+    fun apply(request: Request): Request =
+        (contentEncoding?.let {
+            request.header("content-encoding", it)
+        } ?: request)
+            .body(body)
+
+    fun apply(response: Response): Response =
+        (contentEncoding?.let {
+            response.header("content-encoding", it)
+        } ?: response)
+            .body(body)
+}
+
+fun Body.gzipped(): CompressionResult = if (payload.array().isEmpty())
+    CompressionResult(Body.EMPTY, null)
 else ByteArrayOutputStream().run {
     GZIPOutputStream(this).use { it.write(payload.array()) }
-    Body(ByteBuffer.wrap(toByteArray()))
+    CompressionResult(Body(ByteBuffer.wrap(toByteArray())), "gzip")
 }
 
 fun Body.gunzipped(): Body = if (payload.array().isEmpty()) Body.EMPTY
@@ -27,18 +45,27 @@ else ByteArrayOutputStream().use {
     Body(ByteBuffer.wrap(it.toByteArray()))
 }
 
-fun Body.gzippedStream(): Body = Body(GZippingInputStream(stream))
+fun Body.gzippedStream(): CompressionResult =
+    sampleStream(stream,
+        { CompressionResult(Body.EMPTY, null) },
+        { compressedStream -> CompressionResult(Body(GZippingInputStream(compressedStream)), "gzip") })
 
 fun Body.gunzippedStream(): Body = if (length != null && length == 0L) {
     Body.EMPTY
 } else {
-    val pushbackStream = PushbackInputStream(stream)
+    sampleStream(stream,
+        { Body.EMPTY },
+        { compressedStream -> Body(GZIPInputStream(compressedStream)) })
+}
+
+private fun <T> sampleStream(sourceStream: InputStream, actionIfEmpty: () -> T, actionIfHasContent: (InputStream) -> T): T {
+    val pushbackStream = PushbackInputStream(sourceStream)
     val firstByte = pushbackStream.read()
-    if (firstByte == -1) {
-        Body.EMPTY
+    return if (firstByte == -1) {
+        actionIfEmpty()
     } else {
         pushbackStream.unread(firstByte)
-        Body(GZIPInputStream(pushbackStream))
+        actionIfHasContent(pushbackStream)
     }
 }
 

--- a/http4k-core/src/test/kotlin/org/http4k/filter/GzipBodyTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/GzipBodyTest.kt
@@ -50,8 +50,17 @@ class GzipBodyTest {
         }
 
         @Test
-        fun `a empty body can be decompressed`() {
+        fun `a empty in-memory body can be decompressed`() {
             val compressedBody = Body("")
+
+            val gunzipped = compressedBody.gunzippedStream()
+
+            assertThat(gunzipped.payload.asString(), equalTo(""))
+        }
+
+        @Test
+        fun `a empty stream body can be decompressed`() {
+            val compressedBody = Body("".byteInputStream(Charsets.UTF_8))
 
             val gunzipped = compressedBody.gunzippedStream()
 

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
@@ -200,7 +200,19 @@ class ServerFiltersTest {
                 Response(OK).body(it.body)
             }
 
-            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped())), hasHeader("content-encoding", "gzip").and(hasBody(equalTo(Body("hello").gzipped()))))
+            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped().body)),
+                hasHeader("content-encoding", "gzip").and(hasBody(equalTo(Body("hello").gzipped().body))))
+        }
+
+        @Test
+        fun `handle empty messages with incorrect content-encoding`() {
+            val handler = ServerFilters.GZip().then {
+                assertThat(it, hasBody(equalTo(Body.EMPTY)))
+                Response(OK).body(it.body)
+            }
+
+            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body.EMPTY)),
+                hasBody(equalTo(Body.EMPTY)).and(!hasHeader("content-encoding", "gzip")))
         }
 
         @Test
@@ -220,7 +232,8 @@ class ServerFiltersTest {
                 Response(OK).header("content-type", "text/plain").body(it.body)
             }
 
-            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped())), hasHeader("content-encoding", "gzip").and(hasBody(equalTo(Body("hello").gzipped()))))
+            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped().body)),
+                hasHeader("content-encoding", "gzip").and(hasBody(equalTo(Body("hello").gzipped().body))))
         }
 
         @Test
@@ -230,7 +243,8 @@ class ServerFiltersTest {
                 Response(OK).header("content-type", "text/plain").body(it.body)
             }
 
-            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped())), !hasHeader("content-encoding", "gzip").and(hasBody(equalTo(Body("hello")))))
+            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped().body)),
+                !hasHeader("content-encoding", "gzip").and(hasBody(equalTo(Body("hello")))))
         }
 
         @Test
@@ -253,8 +267,19 @@ class ServerFiltersTest {
                 Response(OK).body(Body("hello"))
             }
 
-            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped())),
-                    hasHeader("content-encoding", "gzip").and(hasBody(equalTo(Body("hello").gzippedStream()))))
+            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped().body)),
+                    hasHeader("content-encoding", "gzip").and(hasBody(equalTo(Body("hello").gzippedStream().body))))
+        }
+
+        @Test
+        fun `handle empty messages with incorrect content-encoding`() {
+            val handler = ServerFilters.GZip(Streaming).then {
+                assertThat(it, hasBody(equalTo(Body.EMPTY)))
+                Response(OK).body(it.body)
+            }
+
+            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body.EMPTY)),
+                hasBody(equalTo(Body.EMPTY)).and(!hasHeader("content-encoding", "gzip")))
         }
 
         @Test
@@ -274,8 +299,8 @@ class ServerFiltersTest {
                 Response(OK).header("content-type", "text/plain").body(Body("hello"))
             }
 
-            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped())),
-                    hasHeader("content-encoding", "gzip").and(hasBody(equalTo(Body("hello").gzippedStream()))))
+            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped().body)),
+                    hasHeader("content-encoding", "gzip").and(hasBody(equalTo(Body("hello").gzippedStream().body))))
         }
 
         @Test
@@ -285,7 +310,7 @@ class ServerFiltersTest {
                 Response(OK).header("content-type", "text/plain").body(it.body)
             }
 
-            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped())),
+            assertThat(handler(Request(GET, "/").header("accept-encoding", "gzip").header("content-encoding", "gzip").body(Body("hello").gzipped().body)),
                     !hasHeader("content-encoding", "gzip").and(hasBody(equalTo(Body("hello")))))
         }
 


### PR DESCRIPTION
These changes fix two issues described in #338:

* both in-memory and streaming Gzip filters would apply a `content-encoding` header of `gzip` even if no transformation had taken place. In particular this led to us sending requests with absent/empty bodies with an incorrect `content-encoding`. We now only apply the header when compression has taken place.
* the streaming decompressor would try and deserialise anything with a `content-encoding` of `gzip`. If the body was empty then Java's `GZIPInputStream` would throw an `EOFException`. We no longer attempt to decompress empty streams.

As an aside, whoever came up with providing a useless default impl of `available()` on `InputStream` is a twit and I don't like them. Being unable to rely on that made this a chunk more painful.