### PR TITLE
Add missing `accept-encoding` header; add remote-gzip-only client filter

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ClientFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ClientFilters.kt
@@ -137,12 +137,21 @@ object ClientFilters {
     }
 
     /**
+     * Support for GZipped responses from clients.
+     */
+    object AcceptGZip {
+        operator fun invoke(compressionMode: GzipCompressionMode = Memory): Filter =
+            ResponseFilters.GunZip(compressionMode)
+    }
+
+    /**
      * Basic GZip and Gunzip support of Request/Response.
      * Only Gunzip responses when the response contains "transfer-encoding" header containing 'gzip'
      */
     object GZip {
         operator fun invoke(compressionMode: GzipCompressionMode = Memory): Filter =
-                RequestFilters.GZip(compressionMode).then(ResponseFilters.GunZip(compressionMode))
+            RequestFilters.GZip(compressionMode)
+                .then(ResponseFilters.GunZip(compressionMode))
     }
 
     /**

--- a/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
@@ -101,7 +101,7 @@ object ResponseFilters {
     object GunZip {
         operator fun invoke(compressionMode: GzipCompressionMode = Memory) = Filter { next ->
             { request ->
-                next(request).let { response ->
+                next(request.header("accept-encoding", "gzip")).let { response ->
                     response.header("content-encoding")
                             ?.let { if (it.contains("gzip")) it else null }
                             ?.let { response.body(compressionMode.decompress(response.body)) } ?: response

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ResponseFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ResponseFiltersTest.kt
@@ -11,6 +11,7 @@ import org.http4k.filter.GzipCompressionMode.Streaming
 import org.http4k.filter.ResponseFilters.ReportHttpTransaction
 import org.http4k.hamkrest.hasBody
 import org.http4k.hamkrest.hasHeader
+import org.http4k.hamkrest.hasStatus
 import org.http4k.routing.RoutedRequest
 import org.http4k.routing.RoutedResponse
 import org.http4k.routing.bind
@@ -73,6 +74,15 @@ class ResponseFiltersTest {
     @Nested
     inner class GzipFilters {
         @Test
+        fun `gunzip response handling sets the accept-encoding header to gzip on requests`() {
+            val handler = ResponseFilters.GunZip().then {
+                assertThat(it, hasHeader("accept-encoding", "gzip"))
+                Response(OK)
+            }
+            assertThat(handler(Request(GET, "/")), hasStatus(OK))
+        }
+
+        @Test
         fun `gzip response and adds gzip content encoding if the request has accept-encoding of gzip`() {
             val zipped = ResponseFilters.GZip().then { Response(OK).body("foobar") }
             assertThat(zipped(Request(GET, "").header("accept-encoding", "gzip")),
@@ -133,6 +143,15 @@ class ResponseFiltersTest {
 
     @Nested
     inner class GzipStreamFilters {
+        @Test
+        fun `gunzip response handling sets the accept-encoding header to gzip on requests`() {
+            val handler = ResponseFilters.GunZip(Streaming).then {
+                assertThat(it, hasHeader("accept-encoding", "gzip"))
+                Response(OK)
+            }
+            assertThat(handler(Request(GET, "/")), hasStatus(OK))
+        }
+
         @Test
         fun `gzip response and adds gzip content encoding if the request has accept-encoding of gzip`() {
             val zipped = ResponseFilters.GZip(Streaming).then { Response(OK).body("foobar") }


### PR DESCRIPTION
This fixes one bug - that the GZip client filters never set the `accept-encoding` header on the outgoing requests, and hence cannot expect to receive gzipped content in the response.

It also adds a new client filter, `AcceptGZip`, which will only set the header and handle gzipped responses, unlike `ClientFilters.GZip` which will also Gzip the request (which is pretty specialised, as you cannot determine if the server will request it and need to implement 415 handling to be safe).