### PR TITLE
Update index.md

### DIFF
--- a/src/docs/performance/index.md
+++ b/src/docs/performance/index.md
@@ -58,4 +58,7 @@ The standard Jackson module is used for JSON creation and marshalling.
 #### Plaintext pipelining: [results](https://www.techempower.com/benchmarks/#section=data-r17&hw=ph&test=plaintext&l=fjd30b):
 *Top rank: 23/66 - Apache backend*
 
+### Recommendations
+Benchmark your own app's performance trying different engines if performance is critical.  The Tech Empower benchmarks attempt to simulate simple real-world scenarios, but they can behave drastically different than your app.  One other consideration is test time; some engines start up much faster than others.
+
 [http4k]: https://http4k.org


### PR DESCRIPTION
Add suggestion to do your own benchmarks.  
As an example, under real-world loads, our app's performance with Undertow was faster than Apache.  This may or not be true for others.  Another consideration for us was that Undertow took about 10ms to start up in tests, while Apache took about 400ms per test.