### PR TITLE
Support SameSite Cookies #340

### DIFF
--- a/http4k-core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
@@ -24,9 +24,10 @@ class CookieTest {
             .path("/")
             .secure()
             .httpOnly()
+            .sameSite(Cookie.SameSite.Lax)
 
         assertThat(cookie.toString(),
-            equalTo("""my-cookie="my-value"; Max-Age=37; Expires=Sat, 11 Mar 2017 12:15:21 GMT; Domain=google.com; Path=/; secure; HttpOnly"""))
+            equalTo("""my-cookie="my-value"; Max-Age=37; Expires=Sat, 11 Mar 2017 12:15:21 GMT; Domain=google.com; Path=/; secure; HttpOnly; SameSite=Lax"""))
     }
 
     @Test
@@ -51,6 +52,7 @@ class CookieTest {
             .path("/")
             .secure()
             .httpOnly()
+            .sameSite(Cookie.SameSite.Lax)
 
         val parsed = Cookie.parse(original.toString())
 
@@ -203,5 +205,12 @@ class CookieTest {
         assertThat(Cookie.parse("foo=bar; Expires=Sat Mar 11 17 12:15:21 GMT"), equalTo(expected))
         assertThat(Cookie.parse("foo=bar; Expires=Sat Mar 11 2017 12:15:21 GMT"), equalTo(expected))
         assertThat(Cookie.parse("foo=bar; Expires=anything else"), equalTo(Cookie("foo", "bar")))
+    }
+
+    @Test
+    fun `ignores unrecognized SameSite attribute`() {
+        val expected = Cookie("foo", "bar")
+
+        assertThat(Cookie.parse("foo=bar; SameSite=Unknown"), equalTo(expected))
     }
 }

--- a/http4k-testing-hamkrest/src/main/kotlin/org/http4k/hamkrest/cookie.kt
+++ b/http4k-testing-hamkrest/src/main/kotlin/org/http4k/hamkrest/cookie.kt
@@ -27,3 +27,5 @@ fun isHttpOnlyCookie(expected: Boolean = true): Matcher<Cookie> = has("httpOnly"
 fun hasCookieExpiry(expected: LocalDateTime): Matcher<Cookie> = hasCookieExpiry(equalTo(expected))
 
 fun hasCookieExpiry(matcher: Matcher<LocalDateTime>): Matcher<Cookie> = has("expiry", { c: Cookie -> c.expires!! }, matcher)
+
+fun hasCookieSameSite(expected: Cookie.SameSite): Matcher<Cookie> = has("sameSite", { c: Cookie -> c.sameSite }, equalTo(expected))

--- a/http4k-testing-hamkrest/src/test/kotlin/org/http4k/hamkrest/CookieMatchersTest.kt
+++ b/http4k-testing-hamkrest/src/test/kotlin/org/http4k/hamkrest/CookieMatchersTest.kt
@@ -38,4 +38,7 @@ class CookieMatchersTest {
             hasCookieExpiry(expires), hasCookieExpiry(expires.plusDays(1)))
     }
 
+    @Test
+    fun `sameSite`() = assertMatchAndNonMatch(Cookie("name", "value", sameSite = Cookie.SameSite.Strict), hasCookieSameSite(Cookie.SameSite.Strict), hasCookieSameSite(Cookie.SameSite.None))
+
 }


### PR DESCRIPTION
Add the SameSite attribute to Cookies using an enum for the current possible values. SameSite is a modeled here as a nullable attribute without any default value. Although many browsers currently treat a missing SameSite attribute as `Lax` for first-party cookies, this change does not set a default value since some browsers inconsistently handle values of `None` for third-party cookies, notably Safari on Mac OS X 10.14 and iOS 12. To support "SameSite=None" behavior on these browsers, the SameSite attribute should be omitted.

 References:

   - web.dev: SameSite Cookies Explained https://web.dev/samesite-cookies-explained/
   - web.dev: SameSite Cookie Recipes https://web.dev/samesite-cookie-recipes/
   - List of incompatible SameSite=None clients https://www.chromium.org/updates/same-site/incompatible-clients