### PR TITLE
Support method not allowed

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
@@ -10,6 +10,7 @@ import org.http4k.core.NoOp
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.BAD_REQUEST
+import org.http4k.core.Status.Companion.METHOD_NOT_ALLOWED
 import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.Uri
@@ -18,6 +19,8 @@ import org.http4k.filter.ServerFilters
 import org.http4k.lens.LensFailure
 import org.http4k.lens.PathLens
 import org.http4k.routing.Router
+import org.http4k.routing.RouterMatchResult
+import org.http4k.routing.RouterMatchResult.*
 
 class ContractRoute internal constructor(val method: Method,
                                          val spec: ContractRouteSpec,
@@ -32,20 +35,20 @@ class ContractRoute internal constructor(val method: Method,
     internal fun toRouter(contractRoot: PathSegments) = object : Router {
         override fun toString(): String = "${method.name}: ${spec.describe(contractRoot)}"
 
-        override fun match(request: Request): HttpHandler? =
+        override fun match(request: Request): RouterMatchResult =
             if ((request.method == OPTIONS || request.method == method) && request.pathSegments().startsWith(spec.pathFn(contractRoot))) {
                 try {
                     request.without(spec.pathFn(contractRoot))
                         .extract(spec.pathLenses.toList())
                         ?.let {
                             if (request.method == OPTIONS) {
-                                { Response(OK) }
-                            } else toHandler(it)
-                        }
+                                MatchingHandler { Response(OK) }
+                            } else MatchingHandler(toHandler(it))
+                        } ?: Unmatched
                 } catch (e: LensFailure) {
-                    null
+                    Unmatched
                 }
-            } else null
+            } else Unmatched
     }
 
     fun describeFor(contractRoot: PathSegments) = spec.describe(contractRoot)
@@ -55,16 +58,18 @@ class ContractRoute internal constructor(val method: Method,
      * but this function exists to enable the testing of the ContractRoute logic outside of a wider contract context.
      * This means that certain behaviour is defaulted - chiefly the generation of NOT_FOUND and BAD_REQUEST responses.
      */
-    override fun invoke(p1: Request): Response {
-        val handler = toRouter(Root).match(p1)
-            ?.let {
-                (meta.security?.filter ?: Filter.NoOp)
-                    .then(ServerFilters.CatchLensFailure { Response(BAD_REQUEST) })
-                    .then(PreFlightExtractionFilter(meta, Companion.All))
-                    .then(it)
+    override fun invoke(request: Request): Response {
+        return when (val matchResult = toRouter(Root).match(request)) {
+                is MatchingHandler -> {
+                    (meta.security?.filter ?: Filter.NoOp)
+                        .then(ServerFilters.CatchLensFailure { Response(BAD_REQUEST) })
+                        .then(PreFlightExtractionFilter(meta, Companion.All))
+                        .then(matchResult.httpHandler)(request)
+                }
+                is MethodNotMatched -> Response(METHOD_NOT_ALLOWED)
+                is Unmatched -> Response(NOT_FOUND)
             }
-        return handler?.invoke(p1) ?: Response(NOT_FOUND)
-    }
+        }
 
     override fun toString() = "${method.name}: ${spec.describe(Root)}"
 }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
@@ -64,7 +64,7 @@ class ContractRoute internal constructor(val method: Method,
                     (meta.security?.filter ?: Filter.NoOp)
                         .then(ServerFilters.CatchLensFailure { Response(BAD_REQUEST) })
                         .then(PreFlightExtractionFilter(meta, Companion.All))
-                        .then(matchResult.httpHandler)(request)
+                        .then(matchResult)(request)
                 }
                 is MethodNotMatched -> Response(METHOD_NOT_ALLOWED)
                 is Unmatched -> Response(NOT_FOUND)

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoutingHttpHandler.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoutingHttpHandler.kt
@@ -75,7 +75,7 @@ data class ContractRoutingHttpHandler(private val renderer: ContractRenderer,
                 when (memo) {
                     is MatchingHandler -> memo
                     else -> when (val matchResult = router.match(request)) {
-                        is MatchingHandler -> MatchingHandler(routeFilter.then(matchResult.httpHandler))
+                        is MatchingHandler -> MatchingHandler(routeFilter.then(matchResult))
                         else -> minOf(memo, matchResult)
                     }
                 }

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
@@ -1,10 +1,7 @@
 package org.http4k.contract
 
-import com.natpryce.hamkrest.absent
+import com.natpryce.hamkrest.*
 import com.natpryce.hamkrest.assertion.assertThat
-import com.natpryce.hamkrest.equalTo
-import com.natpryce.hamkrest.present
-import com.natpryce.hamkrest.throws
 import org.http4k.contract.security.ApiKeySecurity
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.DELETE
@@ -23,6 +20,8 @@ import org.http4k.lens.Path
 import org.http4k.lens.Query
 import org.http4k.lens.int
 import org.http4k.lens.string
+import org.http4k.routing.RouterMatchResult
+import org.http4k.routing.RouterMatchResult.*
 import org.junit.jupiter.api.Test
 
 class ContractRouteTest {
@@ -75,11 +74,12 @@ class ContractRouteTest {
 
     @Test
     fun `0 parts - matches route`() {
-        val route = "/" bindContract GET to { Response(OK) }
+        val handler: (Request) -> Response = { Response(OK) }
+        val route = "/" bindContract GET to handler
         val router = route.toRouter(Root)
-        assertThat(router.match(Request(GET, "/")), present())
-        assertThat(router.match(Request(POST, "/")), absent())
-        assertThat(router.match(Request(GET, "/bob")), absent())
+        assertThat(router.match(Request(GET, "/")), equalTo(MatchingHandler(handler) as RouterMatchResult))
+        assertThat(router.match(Request(POST, "/")), equalTo(Unmatched as RouterMatchResult))
+        assertThat(router.match(Request(GET, "/bob")), equalTo(Unmatched as RouterMatchResult))
     }
 
     @Test
@@ -248,13 +248,18 @@ class ContractRouteTest {
         assertThat(route(Request(DELETE, valid)), hasStatus(NOT_FOUND))
 
         val routerOnNoPrefix = route.toRouter(Root)
-        assertThat(routerOnNoPrefix.match(Request(GET, "")), absent())
-        assertThat(routerOnNoPrefix.match(Request(POST, valid)), absent())
-        assertThat(routerOnNoPrefix.match(Request(GET, valid))?.invoke(Request(GET, valid))?.bodyString(), equalTo(expected))
+        assertThat(routerOnNoPrefix.match(Request(GET, "")), equalTo(Unmatched as RouterMatchResult))
+        assertThat(routerOnNoPrefix.match(Request(POST, valid)), equalTo(Unmatched as RouterMatchResult))
+        assertThat(routerOnNoPrefix.match(Request(GET, valid)).matchOrNull()?.invoke(Request(GET, valid))?.bodyString(), equalTo(expected))
 
         val routerOnPrefix = route.toRouter(Root / "somePrefix")
-        assertThat(routerOnPrefix.match(Request(GET, "/somePrefix")), absent())
-        assertThat(routerOnPrefix.match(Request(POST, "/somePrefix/$valid")), absent())
-        assertThat(routerOnPrefix.match(Request(GET, "/somePrefix/$valid"))?.invoke(Request(GET, valid))?.bodyString(), equalTo(expected))
+        assertThat(routerOnPrefix.match(Request(GET, "/somePrefix")), equalTo(Unmatched as RouterMatchResult))
+        assertThat(routerOnPrefix.match(Request(POST, "/somePrefix/$valid")), equalTo(Unmatched as RouterMatchResult))
+        assertThat(routerOnPrefix.match(Request(GET, "/somePrefix/$valid")).matchOrNull()?.invoke(Request(GET, valid))?.bodyString(), equalTo(expected))
+    }
+
+    private fun RouterMatchResult.matchOrNull() : HttpHandler? = when (this) {
+        is MatchingHandler -> this.httpHandler
+        else -> null
     }
 }

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
@@ -259,7 +259,7 @@ class ContractRouteTest {
     }
 
     private fun RouterMatchResult.matchOrNull() : HttpHandler? = when (this) {
-        is MatchingHandler -> this.httpHandler
+        is MatchingHandler -> this
         else -> null
     }
 }

--- a/http4k-core/src/main/kotlin/org/http4k/routing/internal.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/routing/internal.kt
@@ -11,10 +11,12 @@ import org.http4k.core.MimeTypes
 import org.http4k.core.NoOp
 import org.http4k.core.Request
 import org.http4k.core.Response
+import org.http4k.core.Status.Companion.METHOD_NOT_ALLOWED
 import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.UriTemplate
 import org.http4k.core.then
+import org.http4k.routing.RouterMatchResult.*
 import org.http4k.websocket.Websocket
 import org.http4k.websocket.WsConsumer
 
@@ -55,47 +57,64 @@ internal data class StaticRoutingHttpHandler(private val pathSegments: String,
     private val handlerNoFilter = ResourceLoadingHandler(pathSegments, resourceLoader, extraFileExtensionToContentTypes)
     private val handlerWithFilter = filter.then(handlerNoFilter)
 
-    override fun match(request: Request): HttpHandler? = handlerNoFilter(request).let {
-        if (it.status != NOT_FOUND) filter.then { _: Request -> it } else null
-    }
+    override fun match(request: Request): RouterMatchResult = handlerNoFilter(request).let {
+        if (it.status != NOT_FOUND) MatchingHandler(filter.then { _: Request -> it }) else null
+    } ?: Unmatched
 
     override fun invoke(request: Request): Response = handlerWithFilter(request)
 }
 
 internal data class AggregateRoutingHttpHandler(
     private val list: List<RoutingHttpHandler>,
-    private val notFoundHandler: HttpHandler = routeNotFoundHandler) : RoutingHttpHandler {
+    private val notFoundHandler: HttpHandler = routeNotFoundHandler,
+    private val methodNotMatchedHandler: HttpHandler = routeMethodNotAllowedHandler) : RoutingHttpHandler {
 
     constructor(vararg list: RoutingHttpHandler) : this(list.toList())
 
-    override fun invoke(request: Request): Response = (match(request) ?: notFoundHandler)(request)
+    override fun invoke(request: Request): Response = when (val matchResult = match(request)) {
+        is MatchingHandler -> matchResult(request)
+        is MethodNotMatched -> methodNotMatchedHandler(request)
+        is Unmatched -> notFoundHandler(request)
+    }
 
-    override fun match(request: Request): HttpHandler? = list.asSequence().mapNotNull { next -> next.match(request) }.firstOrNull()
+    override fun match(request: Request): RouterMatchResult = list.asSequence()
+        .map { next -> next.match(request) }
+        .sorted()
+        .firstOrNull() ?: Unmatched
 
     override fun withFilter(new: Filter): RoutingHttpHandler =
-        copy(list = list.map { it.withFilter(new) }, notFoundHandler = new.then(notFoundHandler))
+        copy(list = list.map { it.withFilter(new) }, notFoundHandler = new.then(notFoundHandler), methodNotMatchedHandler = new.then(methodNotMatchedHandler))
 
     override fun withBasePath(new: String): RoutingHttpHandler = copy(list = list.map { it.withBasePath(new) })
 }
 
 internal val routeNotFoundHandler: HttpHandler = { Response(NOT_FOUND.description("Route not found")) }
 
+internal val routeMethodNotAllowedHandler: HttpHandler = { Response(METHOD_NOT_ALLOWED.description("Method not allowed")) }
+
 internal data class TemplateRoutingHttpHandler(
     private val method: Method?,
     private val template: UriTemplate,
     private val httpHandler: HttpHandler,
-    private val notFoundHandler: HttpHandler = routeNotFoundHandler
-) : RoutingHttpHandler {
+    private val notFoundHandler: HttpHandler = routeNotFoundHandler,
+    private val methodNotAllowedHandler: HttpHandler = routeMethodNotAllowedHandler) : RoutingHttpHandler {
 
-    override fun match(request: Request): HttpHandler? =
-        if (template.matches(request.uri.path) && (method == null || method == request.method))
-            { r: Request -> RoutedResponse(httpHandler(RoutedRequest(r, template)), template) }
-        else null
+    override fun match(request: Request): RouterMatchResult =
+        if (template.matches(request.uri.path)) {
+            when (method) {
+                null, request.method -> MatchingHandler { RoutedResponse(httpHandler(RoutedRequest(it, template)), template) }
+                else -> MethodNotMatched
+            }
+        } else Unmatched
 
-    override fun invoke(request: Request): Response = (match(request) ?: notFoundHandler)(request)
+    override fun invoke(request: Request): Response = when (val matchResult = match(request)) {
+        is MatchingHandler -> matchResult(request)
+        is MethodNotMatched -> methodNotAllowedHandler(request)
+        is Unmatched -> notFoundHandler(request)
+    }
 
     override fun withFilter(new: Filter): RoutingHttpHandler =
-        copy(httpHandler = new.then(httpHandler), notFoundHandler = new.then(notFoundHandler))
+        copy(httpHandler = new.then(httpHandler), notFoundHandler = new.then(notFoundHandler), methodNotAllowedHandler = new.then(methodNotAllowedHandler))
 
     override fun withBasePath(new: String): RoutingHttpHandler = copy(template = UriTemplate.from("$new/$template"))
 }
@@ -116,14 +135,22 @@ internal data class SinglePageAppRoutingHandler(
     private val staticHandler: StaticRoutingHttpHandler
 ) : RoutingHttpHandler {
 
-    override fun invoke(p1: Request): Response {
-        val matchOnStatic = staticHandler.match(p1)?.let { it(p1) }
-        val matchOnIndex = staticHandler.match(Request(GET, pathSegments))
+    override fun invoke(request: Request): Response {
+        val matchOnStatic = when(val matchResult = staticHandler.match(request)) {
+            is MatchingHandler -> matchResult(request)
+            else -> null
+        }
+
+        val matchOnIndex = when (val matchResult = staticHandler.match(Request(GET, pathSegments))) {
+            is MatchingHandler -> matchResult.httpHandler
+            else -> null
+        }
+
         val fallbackHandler = matchOnIndex ?: { Response(NOT_FOUND) }
         return matchOnStatic ?: fallbackHandler(Request(GET, pathSegments))
     }
 
-    override fun match(request: Request) = this
+    override fun match(request: Request) = MatchingHandler(this)
 
     override fun withFilter(new: Filter) = copy(staticHandler = staticHandler.withFilter(new) as StaticRoutingHttpHandler)
 

--- a/http4k-core/src/main/kotlin/org/http4k/routing/internal.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/routing/internal.kt
@@ -141,8 +141,8 @@ internal data class SinglePageAppRoutingHandler(
             else -> null
         }
 
-        val matchOnIndex = when (val matchResult = staticHandler.match(Request(GET, pathSegments))) {
-            is MatchingHandler -> matchResult.httpHandler
+        val matchOnIndex: HttpHandler? = when (val matchResult = staticHandler.match(Request(GET, pathSegments))) {
+            is MatchingHandler -> matchResult
             else -> null
         }
 

--- a/http4k-core/src/main/kotlin/org/http4k/routing/routing.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/routing/routing.kt
@@ -15,8 +15,8 @@ import org.http4k.websocket.WsHandler
 import java.io.InputStream
 
 sealed class RouterMatchResult(private val priority: Int) : Comparable<RouterMatchResult> {
-    data class MatchingHandler(val httpHandler: HttpHandler) : RouterMatchResult(0) {
-        operator fun invoke(request: Request) = httpHandler(request)
+    data class MatchingHandler(private val httpHandler: HttpHandler) : RouterMatchResult(0), HttpHandler {
+        override fun invoke(request: Request): Response = httpHandler(request)
     }
     object MethodNotMatched : RouterMatchResult(5)
     object Unmatched : RouterMatchResult(10)

--- a/http4k-core/src/test/kotlin/org/http4k/routing/RoutingHttpHandlerContract.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/routing/RoutingHttpHandlerContract.kt
@@ -12,6 +12,7 @@ import org.http4k.core.Status.Companion.OK
 import org.http4k.hamkrest.hasBody
 import org.http4k.hamkrest.hasHeader
 import org.http4k.hamkrest.hasStatus
+import org.http4k.routing.RouterMatchResult.*
 import org.junit.jupiter.api.Test
 
 abstract class RoutingHttpHandlerContract {
@@ -95,7 +96,10 @@ abstract class RoutingHttpHandlerContract {
         assertThat(withBase(request), criteria)
     }
 
-    protected fun RoutingHttpHandler.matchAndInvoke(request: Request) = match(request)?.invoke(request)
+    protected fun RoutingHttpHandler.matchAndInvoke(request: Request) = when (val matchResult = match(request)) {
+        is MatchingHandler -> matchResult(request)
+        else -> null
+    }
 
     protected fun filterAppending(value: String) = Filter { next ->
         {

--- a/http4k-core/src/test/kotlin/org/http4k/routing/RoutingTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/routing/RoutingTest.kt
@@ -45,7 +45,6 @@ class RoutingTest {
     }
 
     @Test
-    @Disabled
     fun `method not allowed`() {
         val routes = routes(
             "/a/{route}" bind GET to { Response(OK).body("matched") }

--- a/http4k-core/src/test/kotlin/org/http4k/routing/StaticRoutingHttpHandlerTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/routing/StaticRoutingHttpHandlerTest.kt
@@ -198,7 +198,7 @@ open class StaticRoutingHttpHandlerTest : RoutingHttpHandlerContract() {
     fun `as a router when does not fine file`() {
         val handler = "/svc" bind static()
 
-        assertThat(handler.match(Request(GET, of("/svc/../svc/Bob.xml"))), absent())
+        assertThat(handler.match(Request(GET, of("/svc/../svc/Bob.xml"))), equalTo(RouterMatchResult.Unmatched as RouterMatchResult))
     }
 
     @Test

--- a/http4k-incubator/src/main/kotlin/org/http4k/routing/experimental/ResourceLoaders.kt
+++ b/http4k-incubator/src/main/kotlin/org/http4k/routing/experimental/ResourceLoaders.kt
@@ -5,6 +5,8 @@ import org.http4k.core.HttpHandler
 import org.http4k.core.MimeTypes
 import org.http4k.core.Request
 import org.http4k.routing.Router
+import org.http4k.routing.RouterMatchResult
+import org.http4k.routing.RouterMatchResult.*
 import java.net.URL
 import java.time.Instant
 import java.time.temporal.ChronoUnit.SECONDS
@@ -50,5 +52,8 @@ interface ResourceLoading : Router {
 
     fun match(path: String): HttpHandler?
 
-    override fun match(request: Request): HttpHandler? = match(request.uri.path)
+    override fun match(request: Request): RouterMatchResult = when (val matchResult = match(request.uri.path)) {
+        is HttpHandler -> MatchingHandler(matchResult)
+        else -> Unmatched
+    }
 }

--- a/http4k-incubator/src/main/kotlin/org/http4k/routing/experimental/StaticRoutingHttpHandler.kt
+++ b/http4k-incubator/src/main/kotlin/org/http4k/routing/experimental/StaticRoutingHttpHandler.kt
@@ -6,10 +6,13 @@ import org.http4k.core.Method.GET
 import org.http4k.core.NoOp
 import org.http4k.core.Request
 import org.http4k.core.Response
+import org.http4k.core.Status.Companion.METHOD_NOT_ALLOWED
 import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.core.Uri.Companion.of
 import org.http4k.core.then
 import org.http4k.routing.Router
+import org.http4k.routing.RouterMatchResult
+import org.http4k.routing.RouterMatchResult.*
 import org.http4k.routing.RoutingHttpHandler
 
 fun static(resourceLoader: Router): RoutingHttpHandler = StaticRoutingHttpHandler("", resourceLoader)
@@ -27,8 +30,11 @@ internal data class StaticRoutingHttpHandler(
     private val handlerNoFilter = ResourceLoadingHandler(pathSegments, resourceLoader)
     private val handlerWithFilter = filter.then(handlerNoFilter)
 
-    override fun match(request: Request): HttpHandler? = handlerNoFilter(request).let {
-        if (it.status != NOT_FOUND) filter.then { _: Request -> it } else null
+    override fun match(request: Request): RouterMatchResult = handlerNoFilter(request).let {
+        if (it.status != NOT_FOUND)
+            MatchingHandler(filter.then { _: Request -> it })
+        else
+            Unmatched
     }
 
     override fun invoke(request: Request): Response = handlerWithFilter(request)
@@ -42,8 +48,11 @@ internal class ResourceLoadingHandler(
 
     override fun invoke(request: Request): Response =
         if (request.method == GET && request.uri.path.startsWith(pathSegments))
-            resourceLoader.match(request.uri(of(convertPath(request.uri.path))))?.invoke(request)
-                ?: Response(NOT_FOUND)
+            when (val matchResult = resourceLoader.match(request.uri(of(convertPath(request.uri.path))))) {
+                is MatchingHandler -> matchResult(request)
+                is MethodNotMatched -> Response(METHOD_NOT_ALLOWED)
+                is Unmatched -> Response(NOT_FOUND)
+            }
         else
             Response(NOT_FOUND)
 

--- a/http4k-incubator/src/test/kotlin/org/http4k/routing/experimental/ResourceLoaderContract.kt
+++ b/http4k-incubator/src/test/kotlin/org/http4k/routing/experimental/ResourceLoaderContract.kt
@@ -60,7 +60,7 @@ abstract class ResourceLoaderContract(private val loader: Router) {
     }
 
     private fun RouterMatchResult.matchOrExplode() : HttpHandler = when (this) {
-        is MatchingHandler -> this.httpHandler
+        is MatchingHandler -> this
         else -> error("Unmatched, got $this")
     }
 }

--- a/http4k-incubator/src/test/kotlin/org/http4k/routing/experimental/ResourceLoaderContract.kt
+++ b/http4k-incubator/src/test/kotlin/org/http4k/routing/experimental/ResourceLoaderContract.kt
@@ -2,17 +2,20 @@ package org.http4k.routing.experimental
 
 import com.natpryce.hamkrest.absent
 import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.or
 import org.http4k.core.ContentType
 import org.http4k.core.ContentType.Companion.APPLICATION_XML
 import org.http4k.core.ContentType.Companion.TEXT_HTML
-import org.http4k.core.Method
+import org.http4k.core.HttpHandler
 import org.http4k.core.Method.*
 import org.http4k.core.Request
 import org.http4k.core.Uri.Companion.of
 import org.http4k.hamkrest.hasBody
 import org.http4k.hamkrest.hasHeader
 import org.http4k.routing.Router
+import org.http4k.routing.RouterMatchResult
+import org.http4k.routing.RouterMatchResult.*
 import org.junit.jupiter.api.Test
 
 abstract class ResourceLoaderContract(private val loader: Router) {
@@ -47,13 +50,18 @@ abstract class ResourceLoaderContract(private val loader: Router) {
     protected fun checkContents(path: String, expected: String?, expectedContentType: ContentType) {
         val request = Request(GET, of(path))
         if (expected == null)
-            assertThat(loader.match(request), absent())
+            assertThat(loader.match(request), equalTo(Unmatched as RouterMatchResult))
         else {
-            val response = (loader.match(request)!!).invoke(request)
+            val response = loader.match(request).matchOrExplode().invoke(request)
             assertThat(response, hasBody(expected))
             assertThat(response, hasHeader("Content-Length", expected.length.toString()) or hasHeader("Content-Length", absent()))
             assertThat(response, hasHeader("Content-Type", expectedContentType.withNoDirectives().toHeaderValue()))
         }
+    }
+
+    private fun RouterMatchResult.matchOrExplode() : HttpHandler = when (this) {
+        is MatchingHandler -> this.httpHandler
+        else -> error("Unmatched, got $this")
     }
 }
 

--- a/http4k-incubator/src/test/kotlin/org/http4k/routing/experimental/ResourceLoadingHandlerTest.kt
+++ b/http4k-incubator/src/test/kotlin/org/http4k/routing/experimental/ResourceLoadingHandlerTest.kt
@@ -12,7 +12,6 @@ import org.http4k.core.MemoryRequest
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Response
-import org.http4k.core.Status
 import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.core.Status.Companion.NOT_MODIFIED
 import org.http4k.core.Status.Companion.OK
@@ -23,6 +22,7 @@ import org.http4k.hamkrest.hasContentType
 import org.http4k.hamkrest.hasHeader
 import org.http4k.hamkrest.hasStatus
 import org.http4k.routing.Router
+import org.http4k.routing.RouterMatchResult
 import org.junit.jupiter.api.Test
 import java.time.Instant
 
@@ -185,7 +185,9 @@ private class IndeterminateLengthResource : Resource {
 }
 
 private class InMemoryResourceLoader(val resources: Map<String, Resource>) : Router {
-    override fun match(request: Request): Resource? = resources[request.uri.path]
+    override fun match(request: Request): RouterMatchResult = resources[request.uri.path]?.let {
+        RouterMatchResult.MatchingHandler(it)
+    } ?: RouterMatchResult.Unmatched
 }
 
 

--- a/http4k-testing-chaos/src/test/kotlin/org/http4k/chaos/ChaosEngineTest.kt
+++ b/http4k-testing-chaos/src/test/kotlin/org/http4k/chaos/ChaosEngineTest.kt
@@ -10,6 +10,7 @@ import org.http4k.core.Method.POST
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.I_M_A_TEAPOT
+import org.http4k.core.Status.Companion.METHOD_NOT_ALLOWED
 import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.Status.Companion.UNAUTHORIZED
@@ -70,7 +71,7 @@ class ChaosEngineTest {
         assertThat(appWithChaos(Request(GET, "/chaos/status")), hasBody(noChaos))
         assertThat(appWithChaos(Request(POST, "/chaos/activate")), hasStatus(OK).and(hasBody(originalChaos)))
         assertThat(appWithChaos(Request(GET, "/chaos/status")), hasBody(originalChaos))
-        assertThat(appWithChaos(Request(POST, "/")), hasStatus(NOT_FOUND))
+        assertThat(appWithChaos(Request(POST, "/")), hasStatus(METHOD_NOT_ALLOWED))
         assertThat(appWithChaos(Request(GET, "/")), hasStatus(NOT_FOUND))
         assertThat(appWithChaos(Request(POST, "/chaos/deactivate")), hasStatus(OK).and(hasBody(noChaos)))
         assertThat(appWithChaos(Request(GET, "/chaos/status")), hasBody(noChaos))


### PR DESCRIPTION
At present the route-matching is boolean, i.e. a route either matches or it doesn't. This results in a 404 being served for all unmatched requests.

This PR changes the routing so that it returns a match object, allowing us to differentiate on match failures. At this point it represents three states - `matched`, `path matched, method mismatched`, `unmatched`. The result is that we can now support returning 405 where the path is matched but the supported methods differ.

This is a breaking change, as the `Router.match` signature is now `fun match(request: Request): RouterMatchResult`, rather than returning `HttpHandler?`.

Given the scope of this change there's no way I'm merging it without a sanity check 😄 