### PR TITLE
Fix #397  Fix up dependencies to not pull in optionals to maven publications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ changes with their rationale when appropriate:
 
 ### v3.244.0 (uncut)
 - [all] Upgrade some dependency versions.
-- [all] [Breaking (if you're not using it right!)] Fix #397 - Fixed up Maven dependencies so that they are not bringing in optional libraries. Any projects that were accidentally not including `http4k-core` will require it to be explicitly imported.
+- [all] [Breaking (if you're not using it right!)] Fix #397 - Fixed up Maven dependencies so that they are not bringing in runtime libraries.
 - [http4k-core] - Add enum StringBiDiMapping #395 - H/T @goodhoko
 
 ### v3.243.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ changes with their rationale when appropriate:
 
 ### v3.244.0 (uncut)
 - [all] Upgrade some dependency versions.
+- [all] [Breaking (if you're not using it right!)] Fix #397 - Fixed up Maven dependencies so that they are not bringing in optional libraries. Any projects that were accidentally not including `http4k-core` will require it to be explicitly imported.
 - [http4k-core] - Add enum StringBiDiMapping #395 - H/T @goodhoko
 
 ### v3.243.0

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ buildscript {
         classpath Libs.coveralls_gradle_plugin
         classpath Libs.dokka_gradle_plugin
         classpath Libs.com_jfrog_bintray_gradle_plugin
-        classpath Libs.nebula_provided_base_gradle_plugin
         classpath Libs.openapi_generator_gradle_plugin
         classpath Libs.kotlin_serialization
     }
@@ -20,7 +19,6 @@ plugins {
     id 'com.github.kt3k.coveralls' version "2.9.0"
     id "com.jfrog.bintray" version "1.8.4"
     id 'de.fayard.buildSrcVersions' version "0.7.0"
-    id 'nebula.provided-base' version "3.0.3"
     id 'net.saliman.cobertura' version "3.0.0"
 }
 
@@ -38,7 +36,6 @@ allprojects {
     apply plugin: 'com.jfrog.bintray'
     apply plugin: 'maven'
     apply plugin: 'maven-publish'
-    apply plugin: 'nebula.provided-base'
     apply plugin: 'org.jetbrains.dokka'
 
     jacoco {
@@ -105,16 +102,16 @@ allprojects {
                         asNode().appendNode('description', description)
                         asNode().appendNode('url', 'https://http4k.org')
                         asNode().appendNode('developers')
-                                .appendNode('developer').appendNode('name', 'Ivan Sanchez').parent().appendNode('email', 'ivan@http4k.org')
-                                .parent().parent()
-                                .appendNode('developer').appendNode('name', 'David Denton').parent().appendNode('email', 'david@http4k.org')
+                            .appendNode('developer').appendNode('name', 'Ivan Sanchez').parent().appendNode('email', 'ivan@http4k.org')
+                            .parent().parent()
+                            .appendNode('developer').appendNode('name', 'David Denton').parent().appendNode('email', 'david@http4k.org')
                         asNode().appendNode('scm').
-                                appendNode('url', 'git@github.com:http4k/' + archivesBaseName + '.git').parent().
-                                appendNode('connection', 'scm:git:git@github.com:http4k/' + archivesBaseName + '.git').parent().
-                                appendNode('developerConnection', 'scm:git:git@github.com:http4k/' + archivesBaseName + '.git')
+                            appendNode('url', 'git@github.com:http4k/' + archivesBaseName + '.git').parent().
+                            appendNode('connection', 'scm:git:git@github.com:http4k/' + archivesBaseName + '.git').parent().
+                            appendNode('developerConnection', 'scm:git:git@github.com:http4k/' + archivesBaseName + '.git')
                         asNode().appendNode('licenses').appendNode('license').
-                                appendNode('name', 'Apache License, Version 2.0').parent().
-                                appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.html')
+                            appendNode('name', 'Apache License, Version 2.0').parent().
+                            appendNode('url', 'http://www.apache.org/licenses/LICENSE-2.0.html')
                     }
                     from components.java
 
@@ -192,47 +189,45 @@ task jacocoRootReport(type: org.gradle.testing.jacoco.tasks.JacocoReport) {
 }
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-
-    provided project(":http4k-core")
-    provided project(":http4k-aws")
-    provided project(":http4k-client-apache")
-    provided project(":http4k-client-apache-async")
-    provided project(":http4k-client-jetty")
-    provided project(":http4k-client-okhttp")
-    provided project(":http4k-client-websocket")
-    provided project(":http4k-cloudnative")
-    provided project(":http4k-contract")
-    provided project(":http4k-format-argo")
-    provided project(":http4k-format-gson")
-    provided project(":http4k-format-jackson")
-    provided project(":http4k-format-jackson-xml")
-    provided project(":http4k-format-moshi")
-    provided project(":http4k-format-xml")
-    provided project(":http4k-incubator")
-    provided project(":http4k-jsonrpc")
-    provided project(":http4k-metrics-micrometer")
-    provided project(":http4k-multipart")
-    provided project(":http4k-resilience4j")
-    provided project(":http4k-security-oauth")
-    provided project(":http4k-server-apache")
-    provided project(":http4k-server-jetty")
-    provided project(":http4k-server-ktorcio")
-    provided project(":http4k-server-netty")
-    provided project(":http4k-server-undertow")
-    provided project(":http4k-serverless-lambda")
-    provided project(":http4k-template-dust")
-    provided project(":http4k-template-freemarker")
-    provided project(":http4k-template-handlebars")
-    provided project(":http4k-template-pebble")
-    provided project(":http4k-template-thymeleaf")
-    provided project(":http4k-template-dust")
-    provided project(":http4k-template-jade4j")
-    provided project(":http4k-testing-approval")
-    provided project(":http4k-testing-chaos")
-    provided project(":http4k-testing-hamkrest")
-    provided project(":http4k-testing-servirtium")
-    provided project(":http4k-testing-webdriver")
+    compile project(":http4k-core")
+    compile project(":http4k-aws")
+    compile project(":http4k-client-apache")
+    compile project(":http4k-client-apache-async")
+    compile project(":http4k-client-jetty")
+    compile project(":http4k-client-okhttp")
+    compile project(":http4k-client-websocket")
+    compile project(":http4k-cloudnative")
+    compile project(":http4k-contract")
+    compile project(":http4k-format-argo")
+    compile project(":http4k-format-gson")
+    compile project(":http4k-format-jackson")
+    compile project(":http4k-format-jackson-xml")
+    compile project(":http4k-format-moshi")
+    compile project(":http4k-format-xml")
+    compile project(":http4k-incubator")
+    compile project(":http4k-jsonrpc")
+    compile project(":http4k-metrics-micrometer")
+    compile project(":http4k-multipart")
+    compile project(":http4k-resilience4j")
+    compile project(":http4k-security-oauth")
+    compile project(":http4k-server-apache")
+    compile project(":http4k-server-jetty")
+    compile project(":http4k-server-ktorcio")
+    compile project(":http4k-server-netty")
+    compile project(":http4k-server-undertow")
+    compile project(":http4k-serverless-lambda")
+    compile project(":http4k-template-dust")
+    compile project(":http4k-template-freemarker")
+    compile project(":http4k-template-handlebars")
+    compile project(":http4k-template-pebble")
+    compile project(":http4k-template-thymeleaf")
+    compile project(":http4k-template-dust")
+    compile project(":http4k-template-jade4j")
+    compile project(":http4k-testing-approval")
+    compile project(":http4k-testing-chaos")
+    compile project(":http4k-testing-hamkrest")
+    compile project(":http4k-testing-servirtium")
+    compile project(":http4k-testing-webdriver")
 
     testCompile Config.TestDependencies
     testCompile project(path: ":http4k-testing-servirtium", configuration: 'testArtifacts')
@@ -256,7 +251,7 @@ dokka {
 
     subProjects = subprojects.collect { i -> i.name }
 
-    configuration  {
+    configuration {
         includes = ['src/packages.md']
         moduleName = "$rootProject.name"
         jdkVersion = 9

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -140,10 +140,6 @@ object Libs {
             "net.saliman.cobertura:net.saliman.cobertura.gradle.plugin:" +
             Versions.net_saliman_cobertura_gradle_plugin
 
-    const val nebula_provided_base_gradle_plugin: String =
-            "nebula.provided-base:nebula.provided-base.gradle.plugin:" +
-            Versions.nebula_provided_base_gradle_plugin
-
     const val com_jfrog_bintray_gradle_plugin: String =
             "com.jfrog.bintray:com.jfrog.bintray.gradle.plugin:" +
             Versions.com_jfrog_bintray_gradle_plugin

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -32,8 +32,6 @@ object Versions {
 
     const val net_saliman_cobertura_gradle_plugin: String = "3.0.0"
 
-    const val nebula_provided_base_gradle_plugin: String = "3.0.3" // available: "5.0.3"
-
     const val com_jfrog_bintray_gradle_plugin: String = "1.8.5"
 
     const val openapi_generator_gradle_plugin: String = "4.3.0"

--- a/http4k-aws/build.gradle
+++ b/http4k-aws/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k AWS API client'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile project(":http4k-client-apache")

--- a/http4k-aws/build.gradle
+++ b/http4k-aws/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k AWS API client'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile project(":http4k-client-apache")

--- a/http4k-client-apache-async/build.gradle
+++ b/http4k-client-apache-async/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k HTTP Client built on top of async apache httpclient'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.httpasyncclient
 

--- a/http4k-client-apache-async/build.gradle
+++ b/http4k-client-apache-async/build.gradle
@@ -1,11 +1,10 @@
 description = 'Http4k HTTP Client built on top of async apache httpclient'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.httpasyncclient
 
     testCompile project(path: ":http4k-core", configuration: "testArtifacts")
     testCompile Config.TestDependencies
 }
-

--- a/http4k-client-apache/build.gradle
+++ b/http4k-client-apache/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k HTTP Client built on top of apache-httpclient'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.httpclient // apache
 

--- a/http4k-client-apache/build.gradle
+++ b/http4k-client-apache/build.gradle
@@ -1,11 +1,10 @@
 description = 'Http4k HTTP Client built on top of apache-httpclient'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.httpclient // apache
 
     testCompile project(path: ":http4k-core", configuration: "testArtifacts")
     testCompile Config.TestDependencies
 }
-

--- a/http4k-client-jetty/build.gradle
+++ b/http4k-client-jetty/build.gradle
@@ -1,8 +1,7 @@
 description = 'HTTP Client built on top of jetty'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.jetty_client
 

--- a/http4k-client-jetty/build.gradle
+++ b/http4k-client-jetty/build.gradle
@@ -1,11 +1,10 @@
 description = 'HTTP Client built on top of jetty'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.jetty_client
 
     testCompile project(path: ":http4k-core", configuration: "testArtifacts")
     testCompile Config.TestDependencies
 }
-

--- a/http4k-client-okhttp/build.gradle
+++ b/http4k-client-okhttp/build.gradle
@@ -1,8 +1,7 @@
 description = 'HTTP Client built on top of okhttp'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.okhttp
 

--- a/http4k-client-okhttp/build.gradle
+++ b/http4k-client-okhttp/build.gradle
@@ -1,11 +1,10 @@
 description = 'HTTP Client built on top of okhttp'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.okhttp
 
     testCompile project(path: ":http4k-core", configuration: "testArtifacts")
     testCompile Config.TestDependencies
 }
-

--- a/http4k-client-websocket/build.gradle
+++ b/http4k-client-websocket/build.gradle
@@ -1,7 +1,7 @@
 description = 'HTTP Websocket Client'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.java_websocket
 
@@ -9,4 +9,3 @@ dependencies {
     testCompile project(path: ":http4k-server-jetty")
     testCompile Config.TestDependencies
 }
-

--- a/http4k-client-websocket/build.gradle
+++ b/http4k-client-websocket/build.gradle
@@ -1,8 +1,7 @@
 description = 'HTTP Websocket Client'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.java_websocket
 

--- a/http4k-cloudnative/build.gradle
+++ b/http4k-cloudnative/build.gradle
@@ -1,8 +1,7 @@
 description = 'Machinery for running Http4k apps in cloud-native environments'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile project(":http4k-testing-hamkrest")

--- a/http4k-cloudnative/build.gradle
+++ b/http4k-cloudnative/build.gradle
@@ -1,7 +1,7 @@
 description = 'Machinery for running Http4k apps in cloud-native environments'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile project(":http4k-testing-hamkrest")

--- a/http4k-contract/build.gradle
+++ b/http4k-contract/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'org.openapi.generator'
 
 dependencies {
     compileOnly project(":http4k-core")
-    compileOnly project(":http4k-security-oauth")
-    compileOnly project(":http4k-format-jackson")
+     compileOnly project(":http4k-security-oauth")
+     compileOnly project(":http4k-format-jackson")
 
     compile Libs.kotlin_reflect
 

--- a/http4k-contract/build.gradle
+++ b/http4k-contract/build.gradle
@@ -3,10 +3,10 @@ description = 'http4k typesafe HTTP contracts and OpenApi support'
 apply plugin: 'org.openapi.generator'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
-    provided project(":http4k-format-jackson")
-    provided project(":http4k-security-oauth")
+    compileOnly project(":http4k-core")
+    compileOnly project(":http4k-security-oauth")
+    compileOnly project(":http4k-format-jackson")
+
     compile Libs.kotlin_reflect
 
     testCompile project(":http4k-format-jackson")

--- a/http4k-contract/build.gradle
+++ b/http4k-contract/build.gradle
@@ -3,9 +3,9 @@ description = 'http4k typesafe HTTP contracts and OpenApi support'
 apply plugin: 'org.openapi.generator'
 
 dependencies {
-    compileOnly project(":http4k-core")
-     compileOnly project(":http4k-security-oauth")
-     compileOnly project(":http4k-format-jackson")
+    compile project(":http4k-core")
+    implementation project(":http4k-security-oauth")
+    implementation project(":http4k-format-jackson")
 
     compile Libs.kotlin_reflect
 

--- a/http4k-core/build.gradle
+++ b/http4k-core/build.gradle
@@ -2,7 +2,7 @@ description = 'Dependency-lite Server as a Function in pure Kotlin'
 
 dependencies {
     compile Libs.kotlin_stdlib_jdk8
-     compileOnly Libs.javax_servlet_api
+    implementation Libs.javax_servlet_api
 
     testCompile Config.TestDependencies
     testCompile project(":http4k-client-apache")
@@ -11,4 +11,3 @@ dependencies {
     testCompile project(":http4k-testing-hamkrest")
     testCompile project(":http4k-server-jetty")
 }
-

--- a/http4k-core/build.gradle
+++ b/http4k-core/build.gradle
@@ -1,8 +1,8 @@
-description = 'sane HTTP request API for Kotlin'
+description = 'Dependency-lite Server as a Function in pure Kotlin'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided Libs.javax_servlet_api
+    compile Libs.kotlin_stdlib_jdk8
+    compileOnly Libs.javax_servlet_api
 
     testCompile Config.TestDependencies
     testCompile project(":http4k-client-apache")

--- a/http4k-core/build.gradle
+++ b/http4k-core/build.gradle
@@ -2,7 +2,7 @@ description = 'Dependency-lite Server as a Function in pure Kotlin'
 
 dependencies {
     compile Libs.kotlin_stdlib_jdk8
-    compileOnly Libs.javax_servlet_api
+     compileOnly Libs.javax_servlet_api
 
     testCompile Config.TestDependencies
     testCompile project(":http4k-client-apache")

--- a/http4k-format-argo/build.gradle
+++ b/http4k-format-argo/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k Argo JSON support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.argo
 
@@ -9,4 +9,3 @@ dependencies {
     testCompile project(path: ":http4k-jsonrpc", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }
-

--- a/http4k-format-argo/build.gradle
+++ b/http4k-format-argo/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k Argo JSON support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.argo
 

--- a/http4k-format-gson/build.gradle
+++ b/http4k-format-gson/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k GSON JSON support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.gson
 

--- a/http4k-format-gson/build.gradle
+++ b/http4k-format-gson/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k GSON JSON support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.gson
 
@@ -9,6 +9,3 @@ dependencies {
     testCompile project(path: ":http4k-jsonrpc", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }
-
-
-

--- a/http4k-format-jackson-xml/build.gradle
+++ b/http4k-format-jackson-xml/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k XML support using Jackson as an underlying engine'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile project(":http4k-format-jackson")
     compile Libs.jackson_dataformat_xml

--- a/http4k-format-jackson-xml/build.gradle
+++ b/http4k-format-jackson-xml/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k XML support using Jackson as an underlying engine'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile project(":http4k-format-jackson")
     compile Libs.jackson_dataformat_xml

--- a/http4k-format-jackson/build.gradle
+++ b/http4k-format-jackson/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k Jackson JSON/XML support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.jackson_databind
     compile Libs.jackson_module_kotlin

--- a/http4k-format-jackson/build.gradle
+++ b/http4k-format-jackson/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k Jackson JSON/XML support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.jackson_databind
     compile Libs.jackson_module_kotlin

--- a/http4k-format-kotlinx-serialization/build.gradle
+++ b/http4k-format-kotlinx-serialization/build.gradle
@@ -3,8 +3,7 @@ description = 'Http4k Kotlinx Serialization JSON support'
 apply plugin: 'kotlinx-serialization'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.kotlinx_serialization_runtime
 

--- a/http4k-format-kotlinx-serialization/build.gradle
+++ b/http4k-format-kotlinx-serialization/build.gradle
@@ -3,7 +3,7 @@ description = 'Http4k Kotlinx Serialization JSON support'
 apply plugin: 'kotlinx-serialization'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.kotlinx_serialization_runtime
 

--- a/http4k-format-moshi/build.gradle
+++ b/http4k-format-moshi/build.gradle
@@ -2,8 +2,7 @@ description = 'Http4k Moshi JSON support'
 
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.moshi
     compile Libs.moshi_kotlin

--- a/http4k-format-moshi/build.gradle
+++ b/http4k-format-moshi/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k Moshi JSON support'
 
-
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.moshi
     compile Libs.moshi_kotlin
@@ -10,6 +9,3 @@ dependencies {
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }
-
-
-

--- a/http4k-format-xml/build.gradle
+++ b/http4k-format-xml/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k XML support using GSON as an underlying engine'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile project(":http4k-format-gson")
     compile Libs.json

--- a/http4k-format-xml/build.gradle
+++ b/http4k-format-xml/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k XML support using GSON as an underlying engine'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile project(":http4k-format-gson")
     compile Libs.json

--- a/http4k-incubator/build.gradle
+++ b/http4k-incubator/build.gradle
@@ -1,7 +1,7 @@
 description = 'http4k incubator module'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     testCompile Config.TestDependencies
     testCompile project(":http4k-client-apache")

--- a/http4k-incubator/build.gradle
+++ b/http4k-incubator/build.gradle
@@ -1,8 +1,7 @@
 description = 'http4k incubator module'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     testCompile Config.TestDependencies
     testCompile project(":http4k-client-apache")

--- a/http4k-jsonrpc/build.gradle
+++ b/http4k-jsonrpc/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k JSON-RPC support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies

--- a/http4k-jsonrpc/build.gradle
+++ b/http4k-jsonrpc/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k JSON-RPC support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies

--- a/http4k-metrics-micrometer/build.gradle
+++ b/http4k-metrics-micrometer/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k metrics support, integrating with micrometer.io'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
     compile Libs.micrometer_core
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')

--- a/http4k-metrics-micrometer/build.gradle
+++ b/http4k-metrics-micrometer/build.gradle
@@ -1,10 +1,9 @@
 description = 'Http4k metrics support, integrating with micrometer.io'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
     compile Libs.micrometer_core
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }
-

--- a/http4k-multipart/build.gradle
+++ b/http4k-multipart/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k multipart form support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     testCompile Config.TestDependencies
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')

--- a/http4k-multipart/build.gradle
+++ b/http4k-multipart/build.gradle
@@ -1,9 +1,8 @@
 description = 'Http4k multipart form support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     testCompile Config.TestDependencies
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
 }
-

--- a/http4k-resilience4j/build.gradle
+++ b/http4k-resilience4j/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     compile Libs.resilience4j_ratelimiter
     compile Libs.resilience4j_retry
 
+    testCompile project(":http4k-core")
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }

--- a/http4k-resilience4j/build.gradle
+++ b/http4k-resilience4j/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k Resilience4j support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.resilience4j_bulkhead
     compile Libs.resilience4j_circuitbreaker

--- a/http4k-resilience4j/build.gradle
+++ b/http4k-resilience4j/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     compile Libs.resilience4j_ratelimiter
     compile Libs.resilience4j_retry
 
-    testCompile project(":http4k-core")
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }

--- a/http4k-resilience4j/build.gradle
+++ b/http4k-resilience4j/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k Resilience4j support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.resilience4j_bulkhead
     compile Libs.resilience4j_circuitbreaker
@@ -12,4 +12,3 @@ dependencies {
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }
-

--- a/http4k-security-oauth/build.gradle
+++ b/http4k-security-oauth/build.gradle
@@ -1,9 +1,8 @@
 description = 'Http4k Security OAuth support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
-    provided project(":http4k-format-jackson")
+    compileOnly project(":http4k-core")
+    compile project(":http4k-format-jackson")
     compile Libs.result4k
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')

--- a/http4k-security-oauth/build.gradle
+++ b/http4k-security-oauth/build.gradle
@@ -1,11 +1,10 @@
 description = 'Http4k Security OAuth support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
     compile project(":http4k-format-jackson")
     compile Libs.result4k
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }
-

--- a/http4k-server-apache/build.gradle
+++ b/http4k-server-apache/build.gradle
@@ -5,8 +5,7 @@ ext {
 }
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.httpcore // apache
 

--- a/http4k-server-apache/build.gradle
+++ b/http4k-server-apache/build.gradle
@@ -1,16 +1,10 @@
 description = 'Http4k HTTP Server built on top of Apache httpcore'
 
-ext {
-    ext.apache_http_core_version = '4.4.10'
-}
-
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.httpcore // apache
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }
-
-

--- a/http4k-server-jetty/build.gradle
+++ b/http4k-server-jetty/build.gradle
@@ -14,8 +14,5 @@ dependencies {
     implementation Libs.alpn_boot
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
-    testCompile Libs.http2_server
-    testCompile Libs.jetty_alpn_conscrypt_server
-    testCompile Libs.alpn_boot
     testCompile Config.TestDependencies
 }

--- a/http4k-server-jetty/build.gradle
+++ b/http4k-server-jetty/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k HTTP Server built on top of jetty'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.jetty_server
     compile Libs.jetty_servlet
@@ -10,11 +9,14 @@ dependencies {
     compile Libs.javax_servlet_api
 
     // this list is for reference since http2 support is optional
-    provided Libs.http2_server
-    provided Libs.jetty_alpn_conscrypt_server
-    provided Libs.alpn_boot
+    compileOnly Libs.http2_server
+    compileOnly Libs.jetty_alpn_conscrypt_server
+    compileOnly Libs.alpn_boot
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
+    testCompile Libs.http2_server
+    testCompile Libs.jetty_alpn_conscrypt_server
+    testCompile Libs.alpn_boot
     testCompile Config.TestDependencies
 }
 

--- a/http4k-server-jetty/build.gradle
+++ b/http4k-server-jetty/build.gradle
@@ -9,9 +9,9 @@ dependencies {
     compile Libs.javax_servlet_api
 
     // this list is for reference since http2 support is optional
-    compileOnly Libs.http2_server
-    compileOnly Libs.jetty_alpn_conscrypt_server
-    compileOnly Libs.alpn_boot
+     compileOnly Libs.http2_server
+     compileOnly Libs.jetty_alpn_conscrypt_server
+     compileOnly Libs.alpn_boot
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Libs.http2_server

--- a/http4k-server-jetty/build.gradle
+++ b/http4k-server-jetty/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k HTTP Server built on top of jetty'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.jetty_server
     compile Libs.jetty_servlet
@@ -9,9 +9,9 @@ dependencies {
     compile Libs.javax_servlet_api
 
     // this list is for reference since http2 support is optional
-     compileOnly Libs.http2_server
-     compileOnly Libs.jetty_alpn_conscrypt_server
-     compileOnly Libs.alpn_boot
+    implementation Libs.http2_server
+    implementation Libs.jetty_alpn_conscrypt_server
+    implementation Libs.alpn_boot
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Libs.http2_server
@@ -19,4 +19,3 @@ dependencies {
     testCompile Libs.alpn_boot
     testCompile Config.TestDependencies
 }
-

--- a/http4k-server-ktorcio/build.gradle
+++ b/http4k-server-ktorcio/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k HTTP Server built on top of Ktor CIO engine'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile group: 'io.ktor', name: 'ktor-server-cio', version: '1.1.1'
 

--- a/http4k-server-ktorcio/build.gradle
+++ b/http4k-server-ktorcio/build.gradle
@@ -1,12 +1,10 @@
 description = 'Http4k HTTP Server built on top of Ktor CIO engine'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile group: 'io.ktor', name: 'ktor-server-cio', version: '1.1.1'
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }
-
-

--- a/http4k-server-netty/build.gradle
+++ b/http4k-server-netty/build.gradle
@@ -1,12 +1,10 @@
 description = 'Http4k HTTP Server built on top of Netty'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.netty_codec_http2
 
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }
-
-

--- a/http4k-server-netty/build.gradle
+++ b/http4k-server-netty/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k HTTP Server built on top of Netty'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.netty_codec_http2
 

--- a/http4k-server-undertow/build.gradle
+++ b/http4k-server-undertow/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k HTTP Server built on top of Undertow'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.undertow_core
     compile Libs.undertow_servlet

--- a/http4k-server-undertow/build.gradle
+++ b/http4k-server-undertow/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k HTTP Server built on top of Undertow'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.undertow_core
     compile Libs.undertow_servlet
@@ -9,5 +9,3 @@ dependencies {
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }
-
-

--- a/http4k-serverless-lambda/build.gradle
+++ b/http4k-serverless-lambda/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k Serverless support for AWS Lambda'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.kotlin_reflect
     compile Libs.aws_lambda_java_core
@@ -10,4 +10,3 @@ dependencies {
     testCompile project(path: ":http4k-core", configuration: 'testArtifacts')
     testCompile Config.TestDependencies
 }
-

--- a/http4k-serverless-lambda/build.gradle
+++ b/http4k-serverless-lambda/build.gradle
@@ -1,10 +1,9 @@
 description = 'Http4k Serverless support for AWS Lambda'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided Libs.kotlin_reflect
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
+    compile Libs.kotlin_reflect
     compile Libs.aws_lambda_java_core
     compile Libs.aws_lambda_java_events
 

--- a/http4k-template-dust/build.gradle
+++ b/http4k-template-dust/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k Dust templating support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.commons_pool2
 

--- a/http4k-template-dust/build.gradle
+++ b/http4k-template-dust/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k Dust templating support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.commons_pool2
 

--- a/http4k-template-freemarker/build.gradle
+++ b/http4k-template-freemarker/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k Freemarker templating support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.freemarker
 

--- a/http4k-template-freemarker/build.gradle
+++ b/http4k-template-freemarker/build.gradle
@@ -1,11 +1,10 @@
 description = 'Http4k Freemarker templating support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.freemarker
 
     testCompile project(path: ":http4k-core", configuration: "testArtifacts")
     testCompile Config.TestDependencies
 }
-

--- a/http4k-template-handlebars/build.gradle
+++ b/http4k-template-handlebars/build.gradle
@@ -1,11 +1,10 @@
 description = 'Http4k Handlebars templating support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.handlebars
 
     testCompile project(path: ":http4k-core", configuration: "testArtifacts")
     testCompile Config.TestDependencies
 }
-

--- a/http4k-template-handlebars/build.gradle
+++ b/http4k-template-handlebars/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k Handlebars templating support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.handlebars
 

--- a/http4k-template-jade4j/build.gradle
+++ b/http4k-template-jade4j/build.gradle
@@ -1,11 +1,10 @@
 description = 'Http4k jade4j templating support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.jade4j
 
     testCompile project(path: ":http4k-core", configuration: "testArtifacts")
     testCompile Config.TestDependencies
 }
-

--- a/http4k-template-jade4j/build.gradle
+++ b/http4k-template-jade4j/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k jade4j templating support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.jade4j
 

--- a/http4k-template-pebble/build.gradle
+++ b/http4k-template-pebble/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k Pebble templating support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.pebble
 

--- a/http4k-template-pebble/build.gradle
+++ b/http4k-template-pebble/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k Pebble templating support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.pebble
 

--- a/http4k-template-thymeleaf/build.gradle
+++ b/http4k-template-thymeleaf/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k Thymeleaf templating support'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.thymeleaf
 

--- a/http4k-template-thymeleaf/build.gradle
+++ b/http4k-template-thymeleaf/build.gradle
@@ -1,11 +1,10 @@
 description = 'Http4k Thymeleaf templating support'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.thymeleaf
 
     testCompile project(path: ":http4k-core", configuration: "testArtifacts")
     testCompile Config.TestDependencies
 }
-

--- a/http4k-testing-approval/build.gradle
+++ b/http4k-testing-approval/build.gradle
@@ -2,8 +2,8 @@ description = 'Http4k support for Approval Testing'
 
 dependencies {
     compileOnly project(":http4k-core")
-    compileOnly Libs.junit_jupiter_api
-    compileOnly Libs.hamkrest
+     compileOnly Libs.junit_jupiter_api
+     compileOnly Libs.hamkrest
 
     compile Libs.underscore
 

--- a/http4k-testing-approval/build.gradle
+++ b/http4k-testing-approval/build.gradle
@@ -1,12 +1,13 @@
 description = 'Http4k support for Approval Testing'
 
 dependencies {
-    compile project(":http4k-core")
+    compileOnly project(":http4k-core")
     compileOnly Libs.junit_jupiter_api
     compileOnly Libs.hamkrest
 
     compile Libs.underscore
 
+    testCompile project(":http4k-core")
     testCompile project(":http4k-testing-hamkrest")
     testCompile Config.TestDependencies
 }

--- a/http4k-testing-approval/build.gradle
+++ b/http4k-testing-approval/build.gradle
@@ -1,10 +1,10 @@
-description = 'Http4k support for chaos testing'
+description = 'Http4k support for Approval Testing'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
-    provided Libs.junit_jupiter_api
-    provided Libs.hamkrest
+    compile project(":http4k-core")
+    compileOnly Libs.junit_jupiter_api
+    compileOnly Libs.hamkrest
+
     compile Libs.underscore
 
     testCompile project(":http4k-testing-hamkrest")

--- a/http4k-testing-approval/build.gradle
+++ b/http4k-testing-approval/build.gradle
@@ -1,9 +1,9 @@
 description = 'Http4k support for Approval Testing'
 
 dependencies {
-    compileOnly project(":http4k-core")
-     compileOnly Libs.junit_jupiter_api
-     compileOnly Libs.hamkrest
+    compile project(":http4k-core")
+    implementation Libs.junit_jupiter_api
+    implementation Libs.hamkrest
 
     compile Libs.underscore
 

--- a/http4k-testing-chaos/build.gradle
+++ b/http4k-testing-chaos/build.gradle
@@ -1,8 +1,7 @@
 description = 'Http4k support for chaos testing'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile project(":http4k-contract")
     compile project(":http4k-format-jackson")

--- a/http4k-testing-chaos/build.gradle
+++ b/http4k-testing-chaos/build.gradle
@@ -1,7 +1,7 @@
 description = 'Http4k support for chaos testing'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile project(":http4k-contract")
     compile project(":http4k-format-jackson")

--- a/http4k-testing-hamkrest/build.gradle
+++ b/http4k-testing-hamkrest/build.gradle
@@ -1,8 +1,7 @@
 description = 'A set of Hamkrest matchers for common http4k types'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.hamkrest
 

--- a/http4k-testing-hamkrest/build.gradle
+++ b/http4k-testing-hamkrest/build.gradle
@@ -1,11 +1,10 @@
 description = 'A set of Hamkrest matchers for common http4k types'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.hamkrest
 
     testCompile project(":http4k-format-jackson")
     testCompile Config.TestDependencies
 }
-

--- a/http4k-testing-servirtium/build.gradle
+++ b/http4k-testing-servirtium/build.gradle
@@ -1,8 +1,8 @@
 description = 'http4k incubator module'
 
 dependencies {
-    compileOnly project(":http4k-core")
-     compileOnly Libs.junit_jupiter_api
+    compile project(":http4k-core")
+    implementation Libs.junit_jupiter_api
 
     compile project(":http4k-cloudnative")
     compile project(":http4k-format-jackson")

--- a/http4k-testing-servirtium/build.gradle
+++ b/http4k-testing-servirtium/build.gradle
@@ -2,7 +2,7 @@ description = 'http4k incubator module'
 
 dependencies {
     compileOnly project(":http4k-core")
-    compileOnly Libs.junit_jupiter_api
+     compileOnly Libs.junit_jupiter_api
 
     compile project(":http4k-cloudnative")
     compile project(":http4k-format-jackson")

--- a/http4k-testing-servirtium/build.gradle
+++ b/http4k-testing-servirtium/build.gradle
@@ -1,13 +1,12 @@
 description = 'http4k incubator module'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
-    provided Libs.junit_jupiter_api
+    compileOnly project(":http4k-core")
+    compileOnly Libs.junit_jupiter_api
+
     compile project(":http4k-cloudnative")
     compile project(":http4k-format-jackson")
     compile project(":http4k-client-apache")
-    compile project(":http4k-testing-chaos")
 
     testCompile Config.TestDependencies
     testCompile project(":http4k-testing-approval")

--- a/http4k-testing-webdriver/build.gradle
+++ b/http4k-testing-webdriver/build.gradle
@@ -1,8 +1,7 @@
 description = 'Ultra-lightweight Selenium WebDriver implementation for http4k apps'
 
 dependencies {
-    provided Libs.kotlin_stdlib_jdk8
-    provided project(":http4k-core")
+    compileOnly project(":http4k-core")
 
     compile Libs.selenium_api
     compile Libs.jsoup

--- a/http4k-testing-webdriver/build.gradle
+++ b/http4k-testing-webdriver/build.gradle
@@ -1,11 +1,10 @@
 description = 'Ultra-lightweight Selenium WebDriver implementation for http4k apps'
 
 dependencies {
-    compileOnly project(":http4k-core")
+    compile project(":http4k-core")
 
     compile Libs.selenium_api
     compile Libs.jsoup
 
     testCompile Config.TestDependencies
 }
-


### PR DESCRIPTION
Fixes #397 

Removes "provided" plugin from codebase, as evidently does not work!

Now optional dependencies are in the POM as follows (this is from http4k-core). There is no working way that I've found to modify the POM to include provided or optional:

```
  <dependencies>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-stdlib-jdk8</artifactId>
      <version>1.3.72</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>javax.servlet</groupId>
      <artifactId>javax.servlet-api</artifactId>
      <version>4.0.1</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
```

