### PR TITLE
Fix non-root pebble templates when using CachingClasspath from a compiled JAR

### DIFF
--- a/http4k-template-pebble/src/main/kotlin/org/http4k/template/PebbleTemplates.kt
+++ b/http4k-template-pebble/src/main/kotlin/org/http4k/template/PebbleTemplates.kt
@@ -21,7 +21,7 @@ class PebbleTemplates(private val configure: (PebbleEngine.Builder) -> PebbleEng
 
     override fun CachingClasspath(baseClasspathPackage: String): TemplateRenderer {
         val loader = ClasspathLoader(classLoader)
-        loader.prefix = if (baseClasspathPackage.isEmpty()) null else "./" + baseClasspathPackage.replace('.', '/')
+        loader.prefix = if (baseClasspathPackage.isEmpty()) null else baseClasspathPackage.replace('.', '/')
         return PebbleTemplateRenderer(configure(PebbleEngine.Builder().loader(loader)).build())
     }
 


### PR DESCRIPTION
Pebble templates, when loaded from a compiled JAR, do not load from non-root directories.

When using `ClassLoader.getResource`, any path is assumed to be from the root of the JAR - so passing in, say, "templates", would resolve to "templates" at the root of the JAR. This is different to the resolution behaviour from `Class.getResource`, which resolves relative to the class - getting a resource from the root of the JAR in that case would be done with a preceding slash.

Pebble's ClasspathLoader uses the prefix, then the expected separator if not present (which in the case of internal JAR file resolution is a forward slash, so this is hardcoded), followed by the template name, followed by the template name, followed by the suffix. 

This means that the prefix, if one wished to load templates from the root of the JAR, should be only the name of the folder - for instance, if one wished to use a directory named `templates` at the root of the JAR, the prefix should be set to `templates`.

However, when http4k is passed a prefix to `PebbleTemplates.CachingClasspath`, it prepends the prefix passed with "./". This works when running in IntelliJ - so when tests are run, it will resolve the template. When included as part of a compiled JAR, this does not work and causes ViewNotFound to be thrown.

The tests currently do attempt to test for non-root templates, but since the resolution works when testing, they pass - I'm not sure as to how one could test for this specific case within the scope of the tests.

There were also modifications to the resolution of templates as part of #30. Despite this Pebble templates still have problems in a compiled JAR in the latest version.

This PR Fixes this by removing the "./" prefix. This passes the current tests, and also works in compiled JARs.