### PR TITLE
Fix BasicAuth server filter to not throw an exception on invalid base64 input

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
@@ -29,6 +29,7 @@ import org.http4k.routing.ResourceLoader
 import org.http4k.routing.ResourceLoader.Companion.Classpath
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.lang.IllegalArgumentException
 
 data class CorsPolicy(val origins: List<String>,
                       val headers: List<String>,
@@ -137,7 +138,11 @@ object ServerFilters {
             ?.trim()
             ?.toCredentials()
 
-        private fun String.toCredentials(): Credentials? = base64Decoded().split(":").let { Credentials(it.getOrElse(0) { "" }, it.getOrElse(1) { "" }) }
+        private fun String.toCredentials(): Credentials? = try {
+            base64Decoded().split(":").let { Credentials(it.getOrElse(0) { "" }, it.getOrElse(1) { "" }) }
+        } catch (e: IllegalArgumentException) {
+            null
+        }
     }
 
     /**

--- a/http4k-core/src/test/kotlin/org/http4k/filter/BasicAuthenticationTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/BasicAuthenticationTest.kt
@@ -24,6 +24,14 @@ class BasicAuthenticationTest {
     }
 
     @Test
+    fun invalid_base64() {
+        val handler = ServerFilters.BasicAuth("my realm", "user", "password").then { Response(OK) }
+        val response = handler(Request(GET, "/")
+            .header("Authorization", "Basic ababa"))
+        assertThat(response.status, equalTo(UNAUTHORIZED))
+    }
+
+    @Test
     fun fails_to_authenticate() {
         val handler = ServerFilters.BasicAuth("my realm", "user", "password").then { Response(OK) }
         val response = handler(Request(GET, "/"))


### PR DESCRIPTION
Currently this filter throws an exception which results in an internal server error when the given base64 string is invalid (cut of byte sequence, invalid characters...).

This is bad since it's not a server but a client error. After this change, it will lead to an UNAUTHORIZED when a client submits an invalid base64 string.