### PR TITLE
Add support for securing the API description endpoint

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoutingHttpHandler.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoutingHttpHandler.kt
@@ -23,6 +23,7 @@ import org.http4k.routing.RoutingHttpHandler
 
 data class ContractRoutingHttpHandler(private val renderer: ContractRenderer,
                                       private val security: Security?,
+                                      private val descriptionSecurity: Security?,
                                       private val descriptionPath: String,
                                       private val preFlightExtraction: PreFlightExtraction,
                                       private val routes: List<ContractRoute> = emptyList(),
@@ -70,8 +71,11 @@ data class ContractRoutingHttpHandler(private val renderer: ContractRenderer,
                 .then(postSecurityFilter)
                 .then(CatchLensFailure(renderer::badRequest))
                 .then(PreFlightExtractionFilter(it.meta, preFlightExtraction)) to it.toRouter(contractRoot)
-        } +
-        (identify(descriptionRoute).then(preSecurityFilter).then(postSecurityFilter) to descriptionRoute.toRouter(contractRoot))
+        } + (identify(descriptionRoute)
+            .then(preSecurityFilter)
+            .then(descriptionSecurity?.filter ?: Filter.NoOp)
+            .then(postSecurityFilter) to descriptionRoute.toRouter(contractRoot))
+
 
     override fun toString() = contractRoot.toString() + "\n" + routes.joinToString("\n") { it.toString() }
 

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/extensions.kt
@@ -10,7 +10,7 @@ import org.http4k.lens.PathLens
 import org.http4k.util.Appendable
 
 fun contract(fn: ContractBuilder.() -> Unit) = ContractBuilder().apply(fn).run {
-    ContractRoutingHttpHandler(renderer, security, descriptionPath, preFlightExtraction, routes.all,
+    ContractRoutingHttpHandler(renderer, security, descriptionSecurity, descriptionPath, preFlightExtraction, routes.all,
         preSecurityFilter = preSecurityFilter,
         postSecurityFilter = postSecurityFilter,
         includeDescriptionRoute = includeDescriptionRoute)
@@ -19,6 +19,7 @@ fun contract(fn: ContractBuilder.() -> Unit) = ContractBuilder().apply(fn).run {
 class ContractBuilder internal constructor() {
     var renderer: ContractRenderer = NoRenderer
     var security: Security? = null
+    var descriptionSecurity: Security? = null
     var descriptionPath = ""
     var preFlightExtraction: PreFlightExtraction = All
     var routes = Appendable<ContractRoute>()


### PR DESCRIPTION
In our use case we needed to have the swagger JSON under authorised access. I wasn't able achieve that with the current public http4k APIs. Hence this MR.

Peace! .)