### PR TITLE
Fix separator propagation when adding values to an existing MapEnvironment

### DIFF
--- a/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/env/Environment.kt
+++ b/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/env/Environment.kt
@@ -74,7 +74,7 @@ interface Environment {
 class MapEnvironment private constructor(private val contents: Map<String, String>, override val separator: String = ",") : Environment {
     override operator fun <T> get(key: Lens<Environment, T>) = key(this)
     override operator fun get(key: String): String? = contents[key.convertFromKey()]
-    override operator fun set(key: String, value: String) = MapEnvironment(contents + (key.convertFromKey() to value))
+    override operator fun set(key: String, value: String) = MapEnvironment(contents + (key.convertFromKey() to value), separator)
     override fun minus(key: String): Environment = MapEnvironment(contents - key.convertFromKey(), separator)
     override fun keys() = contents.keys
 

--- a/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/env/Environment.kt
+++ b/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/env/Environment.kt
@@ -35,7 +35,7 @@ interface Environment {
      * Used to chain: eg. Local File -> System Properties -> Env Properties -> Defaults
      */
     infix fun overrides(that: Environment): Environment = MapEnvironment.from(
-        (that.keys().map { it to that[it]!! } + keys().map { it to this[it]!! }).toMap().toProperties()
+        (that.keys().map { it to that[it]!! } + keys().map { it to this[it]!! }).toMap().toProperties(), separator = separator
     )
 
     companion object {

--- a/http4k-cloudnative/src/test/kotlin/org/http4k/cloudnative/env/EnvironmentKeyTest.kt
+++ b/http4k-cloudnative/src/test/kotlin/org/http4k/cloudnative/env/EnvironmentKeyTest.kt
@@ -15,6 +15,7 @@ import org.http4k.lens.composite
 import org.http4k.lens.int
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.util.*
 
 class EnvironmentKeyTest {
 
@@ -44,6 +45,20 @@ class EnvironmentKeyTest {
 
         assertThat(EnvironmentKey.int().multi.required("SOME_VALUE")(withInjectedValue), equalTo(listOf(80, 81)))
         assertThat(EnvironmentKey.int().multi.required("SOME_VALUE")(from("SOME_VALUE" to "80  , 81  ")), equalTo(listOf(80, 81)))
+    }
+
+    @Test
+    fun `custom multi key roundtrip with non-standard separator`() {
+        val customEnv = MapEnvironment.from(Properties(), separator = ";")
+        val lens = EnvironmentKey.int().multi.required("some-value")
+        assertThrows<LensFailure> { lens(customEnv) }
+
+        val withInjectedValue = customEnv.with(lens of listOf(80, 81))
+
+        assertThat(withInjectedValue["SOME_VALUE"], equalTo("80;81"))
+
+        assertThat(EnvironmentKey.int().multi.required("SOME_VALUE")(withInjectedValue), equalTo(listOf(80, 81)))
+        assertThat(EnvironmentKey.int().multi.required("SOME_VALUE")(MapEnvironment.from(listOf("SOME_VALUE" to "80  ; 81  ").toMap().toProperties(), separator = ";")), equalTo(listOf(80, 81)))
     }
 
     @Test

--- a/http4k-cloudnative/src/test/kotlin/org/http4k/cloudnative/env/EnvironmentTest.kt
+++ b/http4k-cloudnative/src/test/kotlin/org/http4k/cloudnative/env/EnvironmentTest.kt
@@ -31,6 +31,13 @@ class EnvironmentTest {
     }
 
     @Test
+    fun `overriding overrides separator`() {
+        val finalEnv = MapEnvironment.from(listOf("FOO" to "foo;bar").toMap().toProperties(), separator = ";") overrides Environment.from("FOO" to "bob")
+
+        assertThat(EnvironmentKey.required("FOO")[finalEnv], equalTo("foo"))
+    }
+
+    @Test
     fun `add to overriding environment`() {
         val finalEnv = Environment.from("FOO" to "bob") overrides Environment.from("BAR" to "bill")
         val extendedEnv = finalEnv.set("BAZ", "bud")


### PR DESCRIPTION
As soon as we add to an existing `MapEnvironment` we lose custom separators, as they aren't propagated to the new object.