### PR TITLE
Implementation of remote address and port in Request interface

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -116,8 +116,9 @@ object Versions {
      * Current version: "6.1.1"
      * See issue 19: How to update Gradle itself?
      * https://github.com/jmfayard/buildSrcVersions/issues/19
+     * Why 6.1.1? See https://github.com/stevesaliman/gradle-cobertura-plugin/issues/168 for details.
      */
-    const val gradleLatestVersion: String = "6.4.1"
+    const val gradleLatestVersion: String = "6.1.1"
 }
 
 /**

--- a/http4k-core/src/main/kotlin/org/http4k/core/http.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/http.kt
@@ -7,6 +7,7 @@ import org.http4k.lens.WebForm
 import org.http4k.routing.RoutedRequest
 import java.io.Closeable
 import java.io.InputStream
+import java.net.InetAddress
 import java.nio.ByteBuffer
 
 typealias Headers = Parameters
@@ -160,6 +161,8 @@ interface HttpMessage : Closeable {
 enum class Method { GET, POST, PUT, DELETE, OPTIONS, TRACE, PATCH, PURGE, HEAD }
 
 interface Request : HttpMessage {
+    val sourceAddress: String?
+    val sourcePort: Int?
     val method: Method
     val uri: Uri
 
@@ -193,6 +196,16 @@ interface Request : HttpMessage {
      */
     fun removeQuery(name: String): Request
 
+    /**
+     * (Copy &) sets source address.
+     */
+    fun sourceAddress(address: String): Request
+
+    /**
+     * (Copy &) sets source port.
+     */
+    fun sourcePort(port: Int): Request
+
     override fun header(name: String, value: String?): Request
 
     override fun headers(headers: Headers): Request
@@ -219,7 +232,15 @@ interface Request : HttpMessage {
 }
 
 @Suppress("EqualsOrHashCode")
-data class MemoryRequest(override val method: Method, override val uri: Uri, override val headers: Headers = listOf(), override val body: Body = EMPTY, override val version: String = HTTP_1_1) : Request {
+data class MemoryRequest(
+    override val method: Method,
+    override val uri: Uri,
+    override val headers: Headers = listOf(),
+    override val body: Body = EMPTY,
+    override val version: String = HTTP_1_1,
+    override val sourceAddress: String? = null,
+    override val sourcePort: Int? = null
+) : Request {
     override fun method(method: Method): Request = copy(method = method)
 
     override fun uri(uri: Uri) = copy(uri = uri)
@@ -237,6 +258,10 @@ data class MemoryRequest(override val method: Method, override val uri: Uri, ove
     override fun headers(headers: Headers) = copy(headers = this.headers + headers)
 
     override fun replaceHeader(name: String, value: String?) = copy(headers = headers.replaceHeader(name, value))
+
+    override fun sourceAddress(address: String) = copy(sourceAddress = address)
+
+    override fun sourcePort(port: Int) = copy(sourcePort = port)
 
     override fun removeHeader(name: String) = copy(headers = headers.removeHeader(name))
 

--- a/http4k-core/src/main/kotlin/org/http4k/servlet/Http4kServletAdapter.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/servlet/Http4kServletAdapter.kt
@@ -28,6 +28,8 @@ private fun Response.transferTo(destination: HttpServletResponse) {
 private fun HttpServletRequest.asHttp4kRequest() =
     Request(Method.valueOf(method), Uri.of(requestURI + queryString.toQueryString()))
         .body(inputStream, getHeader("Content-Length").safeLong()).headers(headerParameters())
+        .sourceAddress(remoteAddr)
+        .sourcePort(remotePort)
 
 private fun HttpServletRequest.headerParameters() =
     headerNames.asSequence().fold(listOf()) { a: Parameters, b: String -> a.plus(getHeaders(b).asPairs(b)) }

--- a/http4k-core/src/test/kotlin/org/http4k/core/RequestTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/RequestTest.kt
@@ -47,6 +47,22 @@ class RequestTest {
     }
 
     private fun requestWithQuery(query: String) = Request(GET, Uri.of("http://ignore/?$query"))
+
+    @Test
+    fun `request has default src ip and port`() {
+        val request = Request(GET, "http://ignore")
+        assert(request.sourceAddress == null)
+        assert(request.sourcePort == null)
+    }
+
+    @Test
+    fun `request has modifiable src ip and port`() {
+        val request = Request(GET, "http://ignore")
+            .sourceAddress("192.168.0.1")
+            .sourcePort(32768)
+        assertThat(request.sourceAddress, equalTo("192.168.0.1"))
+        assertThat(request.sourcePort, equalTo(32768))
+    }
 }
 
 

--- a/http4k-server-apache/src/main/kotlin/org/http4k/server/ApacheServer.kt
+++ b/http4k-server-apache/src/main/kotlin/org/http4k/server/ApacheServer.kt
@@ -2,12 +2,14 @@ package org.http4k.server
 
 import org.apache.http.Header
 import org.apache.http.HttpEntityEnclosingRequest
+import org.apache.http.HttpInetConnection
 import org.apache.http.config.SocketConfig
 import org.apache.http.entity.InputStreamEntity
 import org.apache.http.impl.bootstrap.HttpServer
 import org.apache.http.impl.bootstrap.ServerBootstrap
 import org.apache.http.impl.io.EmptyInputStream
 import org.apache.http.protocol.HttpContext
+import org.apache.http.protocol.HttpCoreContext
 import org.apache.http.protocol.HttpRequestHandler
 import org.http4k.core.Headers
 import org.http4k.core.HttpHandler
@@ -30,17 +32,21 @@ class Http4kRequestHandler(handler: HttpHandler) : HttpRequestHandler {
     private val safeHandler = ServerFilters.CatchAll().then(handler)
 
     override fun handle(request: ApacheRequest, response: ApacheResponse, context: HttpContext) {
-        safeHandler(request.asHttp4kRequest()).into(response)
+        safeHandler(request.asHttp4kRequest(context)).into(response)
     }
 
-    private fun ApacheRequest.asHttp4kRequest(): Request =
-        Request(Method.valueOf(requestLine.method), requestLine.uri)
+    private fun ApacheRequest.asHttp4kRequest(context: HttpContext): Request {
+        val connection = context.getAttribute(HttpCoreContext.HTTP_CONNECTION) as HttpInetConnection
+        return Request(Method.valueOf(requestLine.method), requestLine.uri)
             .headers(allHeaders.toHttp4kHeaders()).let {
                 when (this) {
                     is HttpEntityEnclosingRequest -> it.body(entity.content, getFirstHeader("Content-Length")?.value.safeLong())
                     else -> it.body(EmptyInputStream.INSTANCE, 0)
                 }
             }
+            .sourceAddress(connection.remoteAddress.hostAddress)
+            .sourcePort(connection.remotePort)
+    }
 
     private val headersThatApacheInterceptorSets = setOf("Transfer-Encoding", "Content-Length")
 

--- a/http4k-server-jetty/src/main/kotlin/org/http4k/server/Http4kWebSocketListener.kt
+++ b/http4k-server-jetty/src/main/kotlin/org/http4k/server/Http4kWebSocketListener.kt
@@ -23,7 +23,10 @@ class Http4kWebSocketAdapter(private val innerSocket: PushPullAdaptingWebSocket)
     fun onMessage(body: Body) = innerSocket.triggerMessage(WsMessage(body))
 }
 
-internal fun ServletUpgradeRequest.asHttp4kRequest() = Request(Method.valueOf(method), Uri.of(requestURI.toString())).headers(headerParameters())
+internal fun ServletUpgradeRequest.asHttp4kRequest() =
+    Request(Method.valueOf(method), Uri.of(requestURI.toString())).headers(headerParameters())
+        .sourceAddress(remoteAddress)
+        .sourcePort(remotePort)
 
 private fun ServletUpgradeRequest.headerParameters(): Headers = headers.asSequence().fold(listOf()) { memo, next -> memo + next.value.map { next.key to it } }
 

--- a/http4k-server-ktorcio/src/main/kotlin/org/http4k/server/KtorCIO.kt
+++ b/http4k-server-ktorcio/src/main/kotlin/org/http4k/server/KtorCIO.kt
@@ -1,6 +1,7 @@
 package org.http4k.server
 
 import io.ktor.application.ApplicationCallPipeline.ApplicationPhase.Call
+import io.ktor.features.origin
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -51,6 +52,8 @@ data class KtorCIO(val port: Int = 8000) : ServerConfig {
 fun ApplicationRequest.asHttp4k() = Request(Method.valueOf(httpMethod.value), uri)
     .headers(headers.toHttp4kHeaders())
     .body(receiveChannel().toInputStream(), header("Content-Length")?.toLong())
+    .sourceAddress(origin.remoteHost)
+    // origin.remotePort does not exist for Ktor
 
 suspend fun ApplicationResponse.fromHttp4K(response: Response) {
     status(HttpStatusCode.fromValue(response.status.code))

--- a/http4k-server-ktornetty/src/main/kotlin/org/http4k/server/KtorNetty.kt
+++ b/http4k-server-ktornetty/src/main/kotlin/org/http4k/server/KtorNetty.kt
@@ -1,13 +1,11 @@
 package org.http4k.server
 
 import io.ktor.application.ApplicationCallPipeline.ApplicationPhase.Call
+import io.ktor.features.origin
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.request.ApplicationRequest
-import io.ktor.request.header
-import io.ktor.request.httpMethod
-import io.ktor.request.uri
+import io.ktor.request.*
 import io.ktor.response.ApplicationResponse
 import io.ktor.response.header
 import io.ktor.response.respondOutputStream
@@ -51,6 +49,8 @@ data class KtorNetty(val port: Int = 8000) : ServerConfig {
 fun ApplicationRequest.asHttp4k() = Request(Method.valueOf(httpMethod.value), uri)
     .headers(headers.toHttp4kHeaders())
     .body(receiveChannel().toInputStream(), header("Content-Length")?.toLong())
+    .sourceAddress(origin.remoteHost)
+    // origin.remotePort does not exist for Ktor
 
 suspend fun ApplicationResponse.fromHttp4K(response: Response) {
     status(HttpStatusCode.fromValue(response.status.code))

--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
@@ -36,6 +36,7 @@ import org.http4k.core.then
 import org.http4k.core.toParametersMap
 import org.http4k.filter.ServerFilters
 import java.net.InetSocketAddress
+import java.net.SocketAddress
 
 
 /**
@@ -54,8 +55,8 @@ class Http4kChannelHandler(handler: HttpHandler) : SimpleChannelInboundHandler<F
                 addListener(CLOSE)
             }
         }
-
-        val (response, stream) = safeHandler(request.asRequest()).asNettyResponse()
+        val address = ctx.channel().remoteAddress() as InetSocketAddress
+        val (response, stream) = safeHandler(request.asRequest(address)).asNettyResponse()
         ctx.write(response)
         ctx.write(stream)
         ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT).apply {
@@ -68,10 +69,12 @@ class Http4kChannelHandler(handler: HttpHandler) : SimpleChannelInboundHandler<F
             headers.toParametersMap().forEach { (key, values) -> headers().set(key, values) }
         } to ChunkedStream(body.stream)
 
-    private fun FullHttpRequest.asRequest() =
+    private fun FullHttpRequest.asRequest(address: InetSocketAddress) =
         Request(valueOf(method().name()), Uri.of(uri()))
             .headers(headers().map { it.key to it.value })
             .body(Body(ByteBufInputStream(content()), headers()["Content-Length"].safeLong()))
+            .sourceAddress(address.address.hostAddress)
+            .sourcePort(address.port)
 }
 
 data class Netty(val port: Int = 8000) : ServerConfig {

--- a/http4k-server-ratpack/src/main/kotlin/org/http4k/server/Ratpack.kt
+++ b/http4k-server-ratpack/src/main/kotlin/org/http4k/server/Ratpack.kt
@@ -49,6 +49,8 @@ class RatpackHttp4kHandler(private val httpHandler: HttpHandler) : Handler {
             })
         }
         .body(data.inputStream, request.headers.get("content-length")?.toLongOrNull())
+        .sourceAddress(request.remoteAddress.host)
+        .sourcePort(request.remoteAddress.port)
 
     private fun Response.pushTo(context: Context) {
         headers.groupBy { it.first }

--- a/http4k-server-undertow/src/main/kotlin/org/http4k/server/Undertow.kt
+++ b/http4k-server-undertow/src/main/kotlin/org/http4k/server/Undertow.kt
@@ -35,6 +35,8 @@ class HttpUndertowHandler(handler: HttpHandler) : io.undertow.server.HttpHandler
             .headers(requestHeaders
                 .flatMap { header -> header.map { header.headerName.toString() to it } })
             .body(inputStream, requestHeaders.getFirst("Content-Length").safeLong())
+            .sourceAddress(sourceAddress.hostString)
+            .sourcePort(sourceAddress.port)
 
     override fun handleRequest(exchange: HttpServerExchange) = safeHandler(exchange.asRequest()).into(exchange)
 }


### PR DESCRIPTION
closes #120

Hi! Thank you for http4k. I really like it.

I implemented support for source address and port in Request interface.
Added two tests for them, but servers have been tested manually (but I can try to write junit tests, if there's need in them).

A few moments:

* What will be default values, when address and port isn't specified? "" and -1 or null/null?
* Ratpack: for IPv6 loopback source address is 0:0:0:0:0:0:0:1%0. Just for your information.
* KtorNetty/KtorCIO: I couldn't find any information about retrieving source port.

Also. I'm getting errors in some tests and I don't understand how I could affect them, for example, in `src/docs/tutorials/tdding_http4k/_1/tests.kt` (IllegalStateException: server.uri must not be null)

Looks like the root cause is in this line:

https://github.com/http4k/http4k/blob/e09e2f6db7a66899728339967c7df25f0c62a76b/http4k-server-jetty/src/main/kotlin/org/http4k/server/jetty.kt#L38

Do you know what this `else server.uri.port` means?

Also 2: I kinda downgraded Gradle because `./gradle wrapper` was updating to a newer version that is incompatible with cobertura plugin.