### PR TITLE
Expose client address and port in Request

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -116,8 +116,9 @@ object Versions {
      * Current version: "6.1.1"
      * See issue 19: How to update Gradle itself?
      * https://github.com/jmfayard/buildSrcVersions/issues/19
+     * Why 6.1.1? See https://github.com/stevesaliman/gradle-cobertura-plugin/issues/168 for details.
      */
-    const val gradleLatestVersion: String = "6.4.1"
+    const val gradleLatestVersion: String = "6.1.1"
 }
 
 /**

--- a/http4k-core/src/main/kotlin/org/http4k/core/http.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/http.kt
@@ -7,6 +7,7 @@ import org.http4k.lens.WebForm
 import org.http4k.routing.RoutedRequest
 import java.io.Closeable
 import java.io.InputStream
+import java.net.InetAddress
 import java.nio.ByteBuffer
 
 typealias Headers = Parameters
@@ -160,6 +161,8 @@ interface HttpMessage : Closeable {
 enum class Method { GET, POST, PUT, DELETE, OPTIONS, TRACE, PATCH, PURGE, HEAD }
 
 interface Request : HttpMessage {
+    val sourceAddress: String?
+    val sourcePort: Int?
     val method: Method
     val uri: Uri
 
@@ -193,6 +196,16 @@ interface Request : HttpMessage {
      */
     fun removeQuery(name: String): Request
 
+    /**
+     * (Copy &) sets source address.
+     */
+    fun sourceAddress(address: String): Request
+
+    /**
+     * (Copy &) sets source port.
+     */
+    fun sourcePort(port: Int): Request
+
     override fun header(name: String, value: String?): Request
 
     override fun headers(headers: Headers): Request
@@ -219,7 +232,15 @@ interface Request : HttpMessage {
 }
 
 @Suppress("EqualsOrHashCode")
-data class MemoryRequest(override val method: Method, override val uri: Uri, override val headers: Headers = listOf(), override val body: Body = EMPTY, override val version: String = HTTP_1_1) : Request {
+data class MemoryRequest(
+    override val method: Method,
+    override val uri: Uri,
+    override val headers: Headers = listOf(),
+    override val body: Body = EMPTY,
+    override val version: String = HTTP_1_1,
+    override val sourceAddress: String? = null,
+    override val sourcePort: Int? = null
+) : Request {
     override fun method(method: Method): Request = copy(method = method)
 
     override fun uri(uri: Uri) = copy(uri = uri)
@@ -237,6 +258,10 @@ data class MemoryRequest(override val method: Method, override val uri: Uri, ove
     override fun headers(headers: Headers) = copy(headers = this.headers + headers)
 
     override fun replaceHeader(name: String, value: String?) = copy(headers = headers.replaceHeader(name, value))
+
+    override fun sourceAddress(address: String) = copy(sourceAddress = address)
+
+    override fun sourcePort(port: Int) = copy(sourcePort = port)
 
     override fun removeHeader(name: String) = copy(headers = headers.removeHeader(name))
 

--- a/http4k-core/src/main/kotlin/org/http4k/core/http.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/http.kt
@@ -329,9 +329,7 @@ data class MemoryResponse(override val status: Status, override val headers: Hea
         && body == other.body)
 }
 
-data class RequestSource(val address: ClientAddress, val port: Int? = 0)
-
-data class ClientAddress(val value: String)
+data class RequestSource(val address: String, val port: Int? = 0)
 
 fun <T : HttpMessage> T.with(vararg modifiers: (T) -> T): T = modifiers.fold(this) { memo, next -> next(memo) }
 

--- a/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
@@ -2,9 +2,11 @@ package org.http4k.server
 
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
+import org.http4k.core.ClientAddress
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
+import org.http4k.core.RequestSource
 import org.http4k.core.Response
 import org.http4k.core.Uri
 import org.http4k.core.safeLong
@@ -48,3 +50,4 @@ private fun HttpExchange.toRequest(): Request =
             ?: Uri.of(requestURI.rawPath))
         .body(requestBody, requestHeaders.getFirst("Content-Length").safeLong())
         .headers(requestHeaders.toList().flatMap { (key, values) -> values.map { key to it } })
+        .source(RequestSource(ClientAddress(localAddress.address.hostAddress), localAddress.port))

--- a/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
@@ -2,7 +2,6 @@ package org.http4k.server
 
 import com.sun.net.httpserver.HttpExchange
 import com.sun.net.httpserver.HttpServer
-import org.http4k.core.ClientAddress
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
@@ -50,4 +49,4 @@ private fun HttpExchange.toRequest(): Request =
             ?: Uri.of(requestURI.rawPath))
         .body(requestBody, requestHeaders.getFirst("Content-Length").safeLong())
         .headers(requestHeaders.toList().flatMap { (key, values) -> values.map { key to it } })
-        .source(RequestSource(ClientAddress(localAddress.address.hostAddress), localAddress.port))
+        .source(RequestSource(localAddress.address.hostAddress, localAddress.port))

--- a/http4k-core/src/main/kotlin/org/http4k/servlet/Http4kServletAdapter.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/servlet/Http4kServletAdapter.kt
@@ -28,6 +28,8 @@ private fun Response.transferTo(destination: HttpServletResponse) {
 private fun HttpServletRequest.asHttp4kRequest() =
     Request(Method.valueOf(method), Uri.of(requestURI + queryString.toQueryString()))
         .body(inputStream, getHeader("Content-Length").safeLong()).headers(headerParameters())
+        .sourceAddress(remoteAddr)
+        .sourcePort(remotePort)
 
 private fun HttpServletRequest.headerParameters() =
     headerNames.asSequence().fold(listOf()) { a: Parameters, b: String -> a.plus(getHeaders(b).asPairs(b)) }

--- a/http4k-core/src/main/kotlin/org/http4k/servlet/Http4kServletAdapter.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/servlet/Http4kServletAdapter.kt
@@ -1,9 +1,11 @@
 package org.http4k.servlet
 
+import org.http4k.core.ClientAddress
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Parameters
 import org.http4k.core.Request
+import org.http4k.core.RequestSource
 import org.http4k.core.Response
 import org.http4k.core.Uri
 import org.http4k.core.safeLong
@@ -28,8 +30,7 @@ private fun Response.transferTo(destination: HttpServletResponse) {
 private fun HttpServletRequest.asHttp4kRequest() =
     Request(Method.valueOf(method), Uri.of(requestURI + queryString.toQueryString()))
         .body(inputStream, getHeader("Content-Length").safeLong()).headers(headerParameters())
-        .sourceAddress(remoteAddr)
-        .sourcePort(remotePort)
+        .source(RequestSource(ClientAddress(remoteAddr), remotePort))
 
 private fun HttpServletRequest.headerParameters() =
     headerNames.asSequence().fold(listOf()) { a: Parameters, b: String -> a.plus(getHeaders(b).asPairs(b)) }

--- a/http4k-core/src/main/kotlin/org/http4k/servlet/Http4kServletAdapter.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/servlet/Http4kServletAdapter.kt
@@ -1,6 +1,5 @@
 package org.http4k.servlet
 
-import org.http4k.core.ClientAddress
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Parameters
@@ -30,7 +29,7 @@ private fun Response.transferTo(destination: HttpServletResponse) {
 private fun HttpServletRequest.asHttp4kRequest() =
     Request(Method.valueOf(method), Uri.of(requestURI + queryString.toQueryString()))
         .body(inputStream, getHeader("Content-Length").safeLong()).headers(headerParameters())
-        .source(RequestSource(ClientAddress(remoteAddr), remotePort))
+        .source(RequestSource(remoteAddr, remotePort))
 
 private fun HttpServletRequest.headerParameters() =
     headerNames.asSequence().fold(listOf()) { a: Parameters, b: String -> a.plus(getHeaders(b).asPairs(b)) }

--- a/http4k-core/src/test/kotlin/org/http4k/core/RequestTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/RequestTest.kt
@@ -51,17 +51,14 @@ class RequestTest {
     @Test
     fun `request has default src ip and port`() {
         val request = Request(GET, "http://ignore")
-        assert(request.sourceAddress == null)
-        assert(request.sourcePort == null)
+        assert(request.source == null)
     }
 
     @Test
     fun `request has modifiable src ip and port`() {
         val request = Request(GET, "http://ignore")
-            .sourceAddress("192.168.0.1")
-            .sourcePort(32768)
-        assertThat(request.sourceAddress, equalTo("192.168.0.1"))
-        assertThat(request.sourcePort, equalTo(32768))
+            .source(RequestSource(ClientAddress("192.168.0.1"), 32768))
+        assertThat(request.source, equalTo(RequestSource(ClientAddress("192.168.0.1"), 32768)))
     }
 }
 

--- a/http4k-core/src/test/kotlin/org/http4k/core/RequestTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/RequestTest.kt
@@ -47,6 +47,22 @@ class RequestTest {
     }
 
     private fun requestWithQuery(query: String) = Request(GET, Uri.of("http://ignore/?$query"))
+
+    @Test
+    fun `request has default src ip and port`() {
+        val request = Request(GET, "http://ignore")
+        assert(request.sourceAddress == null)
+        assert(request.sourcePort == null)
+    }
+
+    @Test
+    fun `request has modifiable src ip and port`() {
+        val request = Request(GET, "http://ignore")
+            .sourceAddress("192.168.0.1")
+            .sourcePort(32768)
+        assertThat(request.sourceAddress, equalTo("192.168.0.1"))
+        assertThat(request.sourcePort, equalTo(32768))
+    }
 }
 
 

--- a/http4k-core/src/test/kotlin/org/http4k/core/RequestTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/RequestTest.kt
@@ -57,8 +57,8 @@ class RequestTest {
     @Test
     fun `request has modifiable src ip and port`() {
         val request = Request(GET, "http://ignore")
-            .source(RequestSource(ClientAddress("192.168.0.1"), 32768))
-        assertThat(request.source, equalTo(RequestSource(ClientAddress("192.168.0.1"), 32768)))
+            .source(RequestSource("192.168.0.1", 32768))
+        assertThat(request.source, equalTo(RequestSource("192.168.0.1", 32768)))
     }
 }
 

--- a/http4k-core/src/test/kotlin/org/http4k/server/ServerContract.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/server/ServerContract.kt
@@ -13,7 +13,6 @@ import org.http4k.core.Method
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
-import org.http4k.core.RequestSource
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.ACCEPTED
 import org.http4k.core.Status.Companion.INTERNAL_SERVER_ERROR
@@ -22,7 +21,6 @@ import org.http4k.core.StreamBody
 import org.http4k.core.with
 import org.http4k.hamkrest.hasBody
 import org.http4k.hamkrest.hasHeader
-import org.http4k.hamkrest.hasPort
 import org.http4k.hamkrest.hasStatus
 import org.http4k.lens.binary
 import org.http4k.routing.bind
@@ -189,12 +187,12 @@ abstract class ServerContract(private val serverConfig: (Int) -> ServerConfig, p
     fun `can resolve request source`() {
         assertThat(client(Request(GET, "$baseUrl/request-source")),
             allOf(hasStatus(OK),
-                hasHeader("x-address", clientAddress() ?: ""),
+                hasHeader("x-address", clientAddress()),
                 hasHeader("x-port", present())
             ))
     }
 
-    open fun clientAddress(): String? = InetAddress.getLocalHost().hostAddress
+    open fun clientAddress() = equalTo(InetAddress.getLocalHost().hostAddress)
 
     @AfterEach
     fun after() {

--- a/http4k-core/src/test/kotlin/org/http4k/server/ServerContract.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/server/ServerContract.kt
@@ -63,7 +63,7 @@ abstract class ServerContract(private val serverConfig: (Int) -> ServerConfig, p
             "/boom" bind GET to { throw IllegalArgumentException("BOOM!") },
             "/request-source" bind GET to { request ->
                 Response(OK)
-                    .header("x-address", request.source?.address?.value ?: "")
+                    .header("x-address", request.source?.address ?: "")
                     .header("x-port", (request.source?.port ?: 0).toString())
             }
         )

--- a/http4k-server-apache/src/main/kotlin/org/http4k/server/ApacheServer.kt
+++ b/http4k-server-apache/src/main/kotlin/org/http4k/server/ApacheServer.kt
@@ -2,12 +2,14 @@ package org.http4k.server
 
 import org.apache.http.Header
 import org.apache.http.HttpEntityEnclosingRequest
+import org.apache.http.HttpInetConnection
 import org.apache.http.config.SocketConfig
 import org.apache.http.entity.InputStreamEntity
 import org.apache.http.impl.bootstrap.HttpServer
 import org.apache.http.impl.bootstrap.ServerBootstrap
 import org.apache.http.impl.io.EmptyInputStream
 import org.apache.http.protocol.HttpContext
+import org.apache.http.protocol.HttpCoreContext
 import org.apache.http.protocol.HttpRequestHandler
 import org.http4k.core.Headers
 import org.http4k.core.HttpHandler
@@ -30,17 +32,21 @@ class Http4kRequestHandler(handler: HttpHandler) : HttpRequestHandler {
     private val safeHandler = ServerFilters.CatchAll().then(handler)
 
     override fun handle(request: ApacheRequest, response: ApacheResponse, context: HttpContext) {
-        safeHandler(request.asHttp4kRequest()).into(response)
+        safeHandler(request.asHttp4kRequest(context)).into(response)
     }
 
-    private fun ApacheRequest.asHttp4kRequest(): Request =
-        Request(Method.valueOf(requestLine.method), requestLine.uri)
+    private fun ApacheRequest.asHttp4kRequest(context: HttpContext): Request {
+        val connection = context.getAttribute(HttpCoreContext.HTTP_CONNECTION) as HttpInetConnection
+        return Request(Method.valueOf(requestLine.method), requestLine.uri)
             .headers(allHeaders.toHttp4kHeaders()).let {
                 when (this) {
                     is HttpEntityEnclosingRequest -> it.body(entity.content, getFirstHeader("Content-Length")?.value.safeLong())
                     else -> it.body(EmptyInputStream.INSTANCE, 0)
                 }
             }
+            .sourceAddress(connection.remoteAddress.hostAddress)
+            .sourcePort(connection.remotePort)
+    }
 
     private val headersThatApacheInterceptorSets = setOf("Transfer-Encoding", "Content-Length")
 

--- a/http4k-server-apache/src/main/kotlin/org/http4k/server/ApacheServer.kt
+++ b/http4k-server-apache/src/main/kotlin/org/http4k/server/ApacheServer.kt
@@ -11,10 +11,12 @@ import org.apache.http.impl.io.EmptyInputStream
 import org.apache.http.protocol.HttpContext
 import org.apache.http.protocol.HttpCoreContext
 import org.apache.http.protocol.HttpRequestHandler
+import org.http4k.core.ClientAddress
 import org.http4k.core.Headers
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
+import org.http4k.core.RequestSource
 import org.http4k.core.Response
 import org.http4k.core.safeLong
 import org.http4k.core.then
@@ -44,8 +46,7 @@ class Http4kRequestHandler(handler: HttpHandler) : HttpRequestHandler {
                     else -> it.body(EmptyInputStream.INSTANCE, 0)
                 }
             }
-            .sourceAddress(connection.remoteAddress.hostAddress)
-            .sourcePort(connection.remotePort)
+            .source(RequestSource(ClientAddress(connection.remoteAddress.hostAddress), connection.remotePort))
     }
 
     private val headersThatApacheInterceptorSets = setOf("Transfer-Encoding", "Content-Length")

--- a/http4k-server-apache/src/main/kotlin/org/http4k/server/ApacheServer.kt
+++ b/http4k-server-apache/src/main/kotlin/org/http4k/server/ApacheServer.kt
@@ -11,7 +11,6 @@ import org.apache.http.impl.io.EmptyInputStream
 import org.apache.http.protocol.HttpContext
 import org.apache.http.protocol.HttpCoreContext
 import org.apache.http.protocol.HttpRequestHandler
-import org.http4k.core.ClientAddress
 import org.http4k.core.Headers
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
@@ -46,7 +45,7 @@ class Http4kRequestHandler(handler: HttpHandler) : HttpRequestHandler {
                     else -> it.body(EmptyInputStream.INSTANCE, 0)
                 }
             }
-            .source(RequestSource(ClientAddress(connection.remoteAddress.hostAddress), connection.remotePort))
+            .source(RequestSource(connection.remoteAddress.hostAddress, connection.remotePort))
     }
 
     private val headersThatApacheInterceptorSets = setOf("Transfer-Encoding", "Content-Length")

--- a/http4k-server-jetty/src/main/kotlin/org/http4k/server/Http4kWebSocketListener.kt
+++ b/http4k-server-jetty/src/main/kotlin/org/http4k/server/Http4kWebSocketListener.kt
@@ -4,9 +4,11 @@ import org.eclipse.jetty.websocket.api.Session
 import org.eclipse.jetty.websocket.api.WebSocketListener
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest
 import org.http4k.core.Body
+import org.http4k.core.ClientAddress
 import org.http4k.core.Headers
 import org.http4k.core.Method
 import org.http4k.core.Request
+import org.http4k.core.RequestSource
 import org.http4k.core.StreamBody
 import org.http4k.core.Uri
 import org.http4k.websocket.PushPullAdaptingWebSocket
@@ -25,8 +27,7 @@ class Http4kWebSocketAdapter(private val innerSocket: PushPullAdaptingWebSocket)
 
 internal fun ServletUpgradeRequest.asHttp4kRequest() =
     Request(Method.valueOf(method), Uri.of(requestURI.toString())).headers(headerParameters())
-        .sourceAddress(remoteAddress)
-        .sourcePort(remotePort)
+        .source(RequestSource(ClientAddress(remoteAddress), remotePort))
 
 private fun ServletUpgradeRequest.headerParameters(): Headers = headers.asSequence().fold(listOf()) { memo, next -> memo + next.value.map { next.key to it } }
 

--- a/http4k-server-jetty/src/main/kotlin/org/http4k/server/Http4kWebSocketListener.kt
+++ b/http4k-server-jetty/src/main/kotlin/org/http4k/server/Http4kWebSocketListener.kt
@@ -4,7 +4,6 @@ import org.eclipse.jetty.websocket.api.Session
 import org.eclipse.jetty.websocket.api.WebSocketListener
 import org.eclipse.jetty.websocket.servlet.ServletUpgradeRequest
 import org.http4k.core.Body
-import org.http4k.core.ClientAddress
 import org.http4k.core.Headers
 import org.http4k.core.Method
 import org.http4k.core.Request
@@ -27,7 +26,7 @@ class Http4kWebSocketAdapter(private val innerSocket: PushPullAdaptingWebSocket)
 
 internal fun ServletUpgradeRequest.asHttp4kRequest() =
     Request(Method.valueOf(method), Uri.of(requestURI.toString())).headers(headerParameters())
-        .source(RequestSource(ClientAddress(remoteAddress), remotePort))
+        .source(RequestSource(remoteAddress, remotePort))
 
 private fun ServletUpgradeRequest.headerParameters(): Headers = headers.asSequence().fold(listOf()) { memo, next -> memo + next.value.map { next.key to it } }
 

--- a/http4k-server-jetty/src/main/kotlin/org/http4k/server/Http4kWebSocketListener.kt
+++ b/http4k-server-jetty/src/main/kotlin/org/http4k/server/Http4kWebSocketListener.kt
@@ -23,7 +23,10 @@ class Http4kWebSocketAdapter(private val innerSocket: PushPullAdaptingWebSocket)
     fun onMessage(body: Body) = innerSocket.triggerMessage(WsMessage(body))
 }
 
-internal fun ServletUpgradeRequest.asHttp4kRequest() = Request(Method.valueOf(method), Uri.of(requestURI.toString())).headers(headerParameters())
+internal fun ServletUpgradeRequest.asHttp4kRequest() =
+    Request(Method.valueOf(method), Uri.of(requestURI.toString())).headers(headerParameters())
+        .sourceAddress(remoteAddress)
+        .sourcePort(remotePort)
 
 private fun ServletUpgradeRequest.headerParameters(): Headers = headers.asSequence().fold(listOf()) { memo, next -> memo + next.value.map { next.key to it } }
 

--- a/http4k-server-ktorcio/src/main/kotlin/org/http4k/server/KtorCIO.kt
+++ b/http4k-server-ktorcio/src/main/kotlin/org/http4k/server/KtorCIO.kt
@@ -1,6 +1,7 @@
 package org.http4k.server
 
 import io.ktor.application.ApplicationCallPipeline.ApplicationPhase.Call
+import io.ktor.features.origin
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -51,6 +52,8 @@ data class KtorCIO(val port: Int = 8000) : ServerConfig {
 fun ApplicationRequest.asHttp4k() = Request(Method.valueOf(httpMethod.value), uri)
     .headers(headers.toHttp4kHeaders())
     .body(receiveChannel().toInputStream(), header("Content-Length")?.toLong())
+    .sourceAddress(origin.remoteHost)
+    // origin.remotePort does not exist for Ktor
 
 suspend fun ApplicationResponse.fromHttp4K(response: Response) {
     status(HttpStatusCode.fromValue(response.status.code))

--- a/http4k-server-ktorcio/src/main/kotlin/org/http4k/server/KtorCIO.kt
+++ b/http4k-server-ktorcio/src/main/kotlin/org/http4k/server/KtorCIO.kt
@@ -17,10 +17,12 @@ import io.ktor.server.cio.CIOApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.engine.stop
 import io.ktor.utils.io.jvm.javaio.toInputStream
+import org.http4k.core.ClientAddress
 import org.http4k.core.Headers
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
+import org.http4k.core.RequestSource
 import org.http4k.core.Response
 import org.http4k.lens.Header
 import java.util.concurrent.TimeUnit.SECONDS
@@ -52,8 +54,7 @@ data class KtorCIO(val port: Int = 8000) : ServerConfig {
 fun ApplicationRequest.asHttp4k() = Request(Method.valueOf(httpMethod.value), uri)
     .headers(headers.toHttp4kHeaders())
     .body(receiveChannel().toInputStream(), header("Content-Length")?.toLong())
-    .sourceAddress(origin.remoteHost)
-    // origin.remotePort does not exist for Ktor
+    .source(RequestSource(ClientAddress(origin.remoteHost))) // origin.remotePort does not exist for Ktor
 
 suspend fun ApplicationResponse.fromHttp4K(response: Response) {
     status(HttpStatusCode.fromValue(response.status.code))

--- a/http4k-server-ktorcio/src/main/kotlin/org/http4k/server/KtorCIO.kt
+++ b/http4k-server-ktorcio/src/main/kotlin/org/http4k/server/KtorCIO.kt
@@ -17,7 +17,6 @@ import io.ktor.server.cio.CIOApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.engine.stop
 import io.ktor.utils.io.jvm.javaio.toInputStream
-import org.http4k.core.ClientAddress
 import org.http4k.core.Headers
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
@@ -54,7 +53,7 @@ data class KtorCIO(val port: Int = 8000) : ServerConfig {
 fun ApplicationRequest.asHttp4k() = Request(Method.valueOf(httpMethod.value), uri)
     .headers(headers.toHttp4kHeaders())
     .body(receiveChannel().toInputStream(), header("Content-Length")?.toLong())
-    .source(RequestSource(ClientAddress(origin.remoteHost))) // origin.remotePort does not exist for Ktor
+    .source(RequestSource(origin.remoteHost)) // origin.remotePort does not exist for Ktor
 
 suspend fun ApplicationResponse.fromHttp4K(response: Response) {
     status(HttpStatusCode.fromValue(response.status.code))

--- a/http4k-server-ktorcio/src/test/kotlin/org/http4k/server/KtorCIOTest.kt
+++ b/http4k-server-ktorcio/src/test/kotlin/org/http4k/server/KtorCIOTest.kt
@@ -3,6 +3,7 @@ package org.http4k.server
 import org.http4k.client.ApacheClient
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.net.InetAddress
 import java.util.Random
 
 class KtorCIOTest : ServerContract({ KtorCIO(Random().nextInt(1000) + 8745) }, ApacheClient()) {
@@ -19,4 +20,6 @@ class KtorCIOTest : ServerContract({ KtorCIO(Random().nextInt(1000) + 8745) }, A
     @Test
     override fun `can start on port zero and then get the port`() {
     }
+
+    override fun clientAddress(): String? = InetAddress.getLocalHost().hostName
 }

--- a/http4k-server-ktorcio/src/test/kotlin/org/http4k/server/KtorCIOTest.kt
+++ b/http4k-server-ktorcio/src/test/kotlin/org/http4k/server/KtorCIOTest.kt
@@ -1,9 +1,10 @@
 package org.http4k.server
 
+import com.natpryce.hamkrest.Matcher
+import com.natpryce.hamkrest.present
 import org.http4k.client.ApacheClient
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.net.InetAddress
 import java.util.Random
 
 class KtorCIOTest : ServerContract({ KtorCIO(Random().nextInt(1000) + 8745) }, ApacheClient()) {
@@ -21,5 +22,5 @@ class KtorCIOTest : ServerContract({ KtorCIO(Random().nextInt(1000) + 8745) }, A
     override fun `can start on port zero and then get the port`() {
     }
 
-    override fun clientAddress(): String? = InetAddress.getLocalHost().hostName
+    override fun clientAddress(): Matcher<String?> = present()
 }

--- a/http4k-server-ktornetty/src/main/kotlin/org/http4k/server/KtorNetty.kt
+++ b/http4k-server-ktornetty/src/main/kotlin/org/http4k/server/KtorNetty.kt
@@ -14,10 +14,12 @@ import io.ktor.server.engine.stop
 import io.ktor.server.netty.Netty
 import io.ktor.server.netty.NettyApplicationEngine
 import io.ktor.utils.io.jvm.javaio.toInputStream
+import org.http4k.core.ClientAddress
 import org.http4k.core.Headers
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
+import org.http4k.core.RequestSource
 import org.http4k.core.Response
 import org.http4k.lens.Header
 import java.util.concurrent.TimeUnit.SECONDS
@@ -49,8 +51,7 @@ data class KtorNetty(val port: Int = 8000) : ServerConfig {
 fun ApplicationRequest.asHttp4k() = Request(Method.valueOf(httpMethod.value), uri)
     .headers(headers.toHttp4kHeaders())
     .body(receiveChannel().toInputStream(), header("Content-Length")?.toLong())
-    .sourceAddress(origin.remoteHost)
-    // origin.remotePort does not exist for Ktor
+    .source(RequestSource(ClientAddress(origin.remoteHost))) // origin.remotePort does not exist for Ktor
 
 suspend fun ApplicationResponse.fromHttp4K(response: Response) {
     status(HttpStatusCode.fromValue(response.status.code))

--- a/http4k-server-ktornetty/src/main/kotlin/org/http4k/server/KtorNetty.kt
+++ b/http4k-server-ktornetty/src/main/kotlin/org/http4k/server/KtorNetty.kt
@@ -1,13 +1,11 @@
 package org.http4k.server
 
 import io.ktor.application.ApplicationCallPipeline.ApplicationPhase.Call
+import io.ktor.features.origin
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
-import io.ktor.request.ApplicationRequest
-import io.ktor.request.header
-import io.ktor.request.httpMethod
-import io.ktor.request.uri
+import io.ktor.request.*
 import io.ktor.response.ApplicationResponse
 import io.ktor.response.header
 import io.ktor.response.respondOutputStream
@@ -51,6 +49,8 @@ data class KtorNetty(val port: Int = 8000) : ServerConfig {
 fun ApplicationRequest.asHttp4k() = Request(Method.valueOf(httpMethod.value), uri)
     .headers(headers.toHttp4kHeaders())
     .body(receiveChannel().toInputStream(), header("Content-Length")?.toLong())
+    .sourceAddress(origin.remoteHost)
+    // origin.remotePort does not exist for Ktor
 
 suspend fun ApplicationResponse.fromHttp4K(response: Response) {
     status(HttpStatusCode.fromValue(response.status.code))

--- a/http4k-server-ktornetty/src/main/kotlin/org/http4k/server/KtorNetty.kt
+++ b/http4k-server-ktornetty/src/main/kotlin/org/http4k/server/KtorNetty.kt
@@ -14,7 +14,6 @@ import io.ktor.server.engine.stop
 import io.ktor.server.netty.Netty
 import io.ktor.server.netty.NettyApplicationEngine
 import io.ktor.utils.io.jvm.javaio.toInputStream
-import org.http4k.core.ClientAddress
 import org.http4k.core.Headers
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
@@ -51,7 +50,7 @@ data class KtorNetty(val port: Int = 8000) : ServerConfig {
 fun ApplicationRequest.asHttp4k() = Request(Method.valueOf(httpMethod.value), uri)
     .headers(headers.toHttp4kHeaders())
     .body(receiveChannel().toInputStream(), header("Content-Length")?.toLong())
-    .source(RequestSource(ClientAddress(origin.remoteHost))) // origin.remotePort does not exist for Ktor
+    .source(RequestSource(origin.remoteHost)) // origin.remotePort does not exist for Ktor
 
 suspend fun ApplicationResponse.fromHttp4K(response: Response) {
     status(HttpStatusCode.fromValue(response.status.code))

--- a/http4k-server-ktornetty/src/test/kotlin/org/http4k/server/KtorNettyTest.kt
+++ b/http4k-server-ktornetty/src/test/kotlin/org/http4k/server/KtorNettyTest.kt
@@ -2,10 +2,13 @@ package org.http4k.server
 
 import org.http4k.client.ApacheClient
 import org.junit.jupiter.api.Test
+import java.net.InetAddress
 import java.util.Random
 
 class KtorNettyTest : ServerContract({ KtorNetty(Random().nextInt(1000) + 7456) }, ApacheClient()) {
     @Test
     override fun `ok when length already set`() {
     }
+
+    override fun clientAddress(): String? = InetAddress.getLocalHost().hostName
 }

--- a/http4k-server-ktornetty/src/test/kotlin/org/http4k/server/KtorNettyTest.kt
+++ b/http4k-server-ktornetty/src/test/kotlin/org/http4k/server/KtorNettyTest.kt
@@ -1,14 +1,17 @@
 package org.http4k.server
 
+import com.natpryce.hamkrest.Matcher
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.present
 import org.http4k.client.ApacheClient
 import org.junit.jupiter.api.Test
 import java.net.InetAddress
-import java.util.Random
+import java.util.*
 
 class KtorNettyTest : ServerContract({ KtorNetty(Random().nextInt(1000) + 7456) }, ApacheClient()) {
     @Test
     override fun `ok when length already set`() {
     }
 
-    override fun clientAddress(): String? = InetAddress.getLocalHost().hostName
+    override fun clientAddress(): Matcher<String?> = present()
 }

--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
@@ -36,6 +36,7 @@ import org.http4k.core.then
 import org.http4k.core.toParametersMap
 import org.http4k.filter.ServerFilters
 import java.net.InetSocketAddress
+import java.net.SocketAddress
 
 
 /**
@@ -54,8 +55,8 @@ class Http4kChannelHandler(handler: HttpHandler) : SimpleChannelInboundHandler<F
                 addListener(CLOSE)
             }
         }
-
-        val (response, stream) = safeHandler(request.asRequest()).asNettyResponse()
+        val address = ctx.channel().remoteAddress() as InetSocketAddress
+        val (response, stream) = safeHandler(request.asRequest(address)).asNettyResponse()
         ctx.write(response)
         ctx.write(stream)
         ctx.writeAndFlush(LastHttpContent.EMPTY_LAST_CONTENT).apply {
@@ -68,10 +69,12 @@ class Http4kChannelHandler(handler: HttpHandler) : SimpleChannelInboundHandler<F
             headers.toParametersMap().forEach { (key, values) -> headers().set(key, values) }
         } to ChunkedStream(body.stream)
 
-    private fun FullHttpRequest.asRequest() =
+    private fun FullHttpRequest.asRequest(address: InetSocketAddress) =
         Request(valueOf(method().name()), Uri.of(uri()))
             .headers(headers().map { it.key to it.value })
             .body(Body(ByteBufInputStream(content()), headers()["Content-Length"].safeLong()))
+            .sourceAddress(address.address.hostAddress)
+            .sourcePort(address.port)
 }
 
 data class Netty(val port: Int = 8000) : ServerConfig {

--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
@@ -25,9 +25,11 @@ import io.netty.handler.codec.http.LastHttpContent
 import io.netty.handler.stream.ChunkedStream
 import io.netty.handler.stream.ChunkedWriteHandler
 import org.http4k.core.Body
+import org.http4k.core.ClientAddress
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.valueOf
 import org.http4k.core.Request
+import org.http4k.core.RequestSource
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.CONTINUE
 import org.http4k.core.Uri
@@ -36,7 +38,6 @@ import org.http4k.core.then
 import org.http4k.core.toParametersMap
 import org.http4k.filter.ServerFilters
 import java.net.InetSocketAddress
-import java.net.SocketAddress
 
 
 /**
@@ -73,8 +74,7 @@ class Http4kChannelHandler(handler: HttpHandler) : SimpleChannelInboundHandler<F
         Request(valueOf(method().name()), Uri.of(uri()))
             .headers(headers().map { it.key to it.value })
             .body(Body(ByteBufInputStream(content()), headers()["Content-Length"].safeLong()))
-            .sourceAddress(address.address.hostAddress)
-            .sourcePort(address.port)
+            .source(RequestSource(ClientAddress(address.address.hostAddress), address.port))
 }
 
 data class Netty(val port: Int = 8000) : ServerConfig {

--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
@@ -25,7 +25,6 @@ import io.netty.handler.codec.http.LastHttpContent
 import io.netty.handler.stream.ChunkedStream
 import io.netty.handler.stream.ChunkedWriteHandler
 import org.http4k.core.Body
-import org.http4k.core.ClientAddress
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.valueOf
 import org.http4k.core.Request
@@ -74,7 +73,7 @@ class Http4kChannelHandler(handler: HttpHandler) : SimpleChannelInboundHandler<F
         Request(valueOf(method().name()), Uri.of(uri()))
             .headers(headers().map { it.key to it.value })
             .body(Body(ByteBufInputStream(content()), headers()["Content-Length"].safeLong()))
-            .source(RequestSource(ClientAddress(address.address.hostAddress), address.port))
+            .source(RequestSource(address.address.hostAddress, address.port))
 }
 
 data class Netty(val port: Int = 8000) : ServerConfig {

--- a/http4k-server-ratpack/src/main/kotlin/org/http4k/server/Ratpack.kt
+++ b/http4k-server-ratpack/src/main/kotlin/org/http4k/server/Ratpack.kt
@@ -1,6 +1,5 @@
 package org.http4k.server
 
-import org.http4k.core.ClientAddress
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
@@ -51,7 +50,7 @@ class RatpackHttp4kHandler(private val httpHandler: HttpHandler) : Handler {
             })
         }
         .body(data.inputStream, request.headers.get("content-length")?.toLongOrNull())
-        .source(RequestSource(ClientAddress(request.remoteAddress.host), request.remoteAddress.port) )
+        .source(RequestSource(request.remoteAddress.host, request.remoteAddress.port) )
 
     private fun Response.pushTo(context: Context) {
         headers.groupBy { it.first }

--- a/http4k-server-ratpack/src/main/kotlin/org/http4k/server/Ratpack.kt
+++ b/http4k-server-ratpack/src/main/kotlin/org/http4k/server/Ratpack.kt
@@ -1,8 +1,10 @@
 package org.http4k.server
 
+import org.http4k.core.ClientAddress
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
+import org.http4k.core.RequestSource
 import org.http4k.core.Response
 import ratpack.handling.Context
 import ratpack.handling.Handler
@@ -49,8 +51,7 @@ class RatpackHttp4kHandler(private val httpHandler: HttpHandler) : Handler {
             })
         }
         .body(data.inputStream, request.headers.get("content-length")?.toLongOrNull())
-        .sourceAddress(request.remoteAddress.host)
-        .sourcePort(request.remoteAddress.port)
+        .source(RequestSource(ClientAddress(request.remoteAddress.host), request.remoteAddress.port) )
 
     private fun Response.pushTo(context: Context) {
         headers.groupBy { it.first }

--- a/http4k-server-ratpack/src/main/kotlin/org/http4k/server/Ratpack.kt
+++ b/http4k-server-ratpack/src/main/kotlin/org/http4k/server/Ratpack.kt
@@ -49,6 +49,8 @@ class RatpackHttp4kHandler(private val httpHandler: HttpHandler) : Handler {
             })
         }
         .body(data.inputStream, request.headers.get("content-length")?.toLongOrNull())
+        .sourceAddress(request.remoteAddress.host)
+        .sourcePort(request.remoteAddress.port)
 
     private fun Response.pushTo(context: Context) {
         headers.groupBy { it.first }

--- a/http4k-server-undertow/src/main/kotlin/org/http4k/server/Undertow.kt
+++ b/http4k-server-undertow/src/main/kotlin/org/http4k/server/Undertow.kt
@@ -35,6 +35,8 @@ class HttpUndertowHandler(handler: HttpHandler) : io.undertow.server.HttpHandler
             .headers(requestHeaders
                 .flatMap { header -> header.map { header.headerName.toString() to it } })
             .body(inputStream, requestHeaders.getFirst("Content-Length").safeLong())
+            .sourceAddress(sourceAddress.hostString)
+            .sourcePort(sourceAddress.port)
 
     override fun handleRequest(exchange: HttpServerExchange) = safeHandler(exchange.asRequest()).into(exchange)
 }

--- a/http4k-server-undertow/src/main/kotlin/org/http4k/server/Undertow.kt
+++ b/http4k-server-undertow/src/main/kotlin/org/http4k/server/Undertow.kt
@@ -5,7 +5,6 @@ import io.undertow.UndertowOptions.ENABLE_HTTP2
 import io.undertow.server.HttpServerExchange
 import io.undertow.server.handlers.BlockingHandler
 import io.undertow.util.HttpString
-import org.http4k.core.ClientAddress
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
@@ -37,7 +36,7 @@ class HttpUndertowHandler(handler: HttpHandler) : io.undertow.server.HttpHandler
             .headers(requestHeaders
                 .flatMap { header -> header.map { header.headerName.toString() to it } })
             .body(inputStream, requestHeaders.getFirst("Content-Length").safeLong())
-            .source(RequestSource(ClientAddress(sourceAddress.hostString), sourceAddress.port))
+            .source(RequestSource(sourceAddress.hostString, sourceAddress.port))
 
     override fun handleRequest(exchange: HttpServerExchange) = safeHandler(exchange.asRequest()).into(exchange)
 }

--- a/http4k-server-undertow/src/main/kotlin/org/http4k/server/Undertow.kt
+++ b/http4k-server-undertow/src/main/kotlin/org/http4k/server/Undertow.kt
@@ -5,9 +5,11 @@ import io.undertow.UndertowOptions.ENABLE_HTTP2
 import io.undertow.server.HttpServerExchange
 import io.undertow.server.handlers.BlockingHandler
 import io.undertow.util.HttpString
+import org.http4k.core.ClientAddress
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
 import org.http4k.core.Request
+import org.http4k.core.RequestSource
 import org.http4k.core.Response
 import org.http4k.core.Uri
 import org.http4k.core.safeLong
@@ -35,8 +37,7 @@ class HttpUndertowHandler(handler: HttpHandler) : io.undertow.server.HttpHandler
             .headers(requestHeaders
                 .flatMap { header -> header.map { header.headerName.toString() to it } })
             .body(inputStream, requestHeaders.getFirst("Content-Length").safeLong())
-            .sourceAddress(sourceAddress.hostString)
-            .sourcePort(sourceAddress.port)
+            .source(RequestSource(ClientAddress(sourceAddress.hostString), sourceAddress.port))
 
     override fun handleRequest(exchange: HttpServerExchange) = safeHandler(exchange.asRequest()).into(exchange)
 }


### PR DESCRIPTION
Closes #120

Based on #434. Simplified the API in `Request` and added tests for it in `ServerContract`.

It's worth noticing that this capability is inherently limited:
1. It depends on what the server implementation retrieves from the client socket. While most servers will bring an IP address, Ktor returns the client hostname.
2. It has very limited use if the server sits behind any proxy that masks client connections.