### PR TITLE
Add request scheme to RequestSource, where available

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/http.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/http.kt
@@ -329,7 +329,7 @@ data class MemoryResponse(override val status: Status, override val headers: Hea
         && body == other.body)
 }
 
-data class RequestSource(val address: String, val port: Int? = 0)
+data class RequestSource(val address: String, val port: Int? = 0, val scheme: String? = null)
 
 fun <T : HttpMessage> T.with(vararg modifiers: (T) -> T): T = modifiers.fold(this) { memo, next -> next(memo) }
 

--- a/http4k-core/src/main/kotlin/org/http4k/servlet/Http4kServletAdapter.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/servlet/Http4kServletAdapter.kt
@@ -29,7 +29,7 @@ private fun Response.transferTo(destination: HttpServletResponse) {
 private fun HttpServletRequest.asHttp4kRequest() =
     Request(Method.valueOf(method), Uri.of(requestURI + queryString.toQueryString()))
         .body(inputStream, getHeader("Content-Length").safeLong()).headers(headerParameters())
-        .source(RequestSource(remoteAddr, remotePort))
+        .source(RequestSource(remoteAddr, remotePort, scheme))
 
 private fun HttpServletRequest.headerParameters() =
     headerNames.asSequence().fold(listOf()) { a: Parameters, b: String -> a.plus(getHeaders(b).asPairs(b)) }

--- a/http4k-core/src/test/kotlin/org/http4k/server/ServerContract.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/server/ServerContract.kt
@@ -65,6 +65,7 @@ abstract class ServerContract(private val serverConfig: (Int) -> ServerConfig, p
                 Response(OK)
                     .header("x-address", request.source?.address ?: "")
                     .header("x-port", (request.source?.port ?: 0).toString())
+                    .header("x-scheme", (request.source?.scheme ?: "unsupported").toString())
             }
         )
 
@@ -188,11 +189,14 @@ abstract class ServerContract(private val serverConfig: (Int) -> ServerConfig, p
         assertThat(client(Request(GET, "$baseUrl/request-source")),
             allOf(hasStatus(OK),
                 hasHeader("x-address", clientAddress()),
-                hasHeader("x-port", present())
+                hasHeader("x-port", present()),
+                hasHeader("x-scheme", requestScheme())
             ))
     }
 
     open fun clientAddress() = equalTo(InetAddress.getLocalHost().hostAddress)
+
+    open fun requestScheme() = equalTo("unsupported")
 
     @AfterEach
     fun after() {

--- a/http4k-server-jetty/src/test/kotlin/org/http4k/server/JettyTest.kt
+++ b/http4k-server-jetty/src/test/kotlin/org/http4k/server/JettyTest.kt
@@ -1,5 +1,7 @@
 package org.http4k.server
 
+import com.natpryce.hamkrest.Matcher
+import com.natpryce.hamkrest.equalTo
 import org.http4k.client.ApacheClient
 import org.http4k.core.Request
 import org.http4k.core.Response
@@ -7,7 +9,9 @@ import org.http4k.core.Status.Companion.OK
 import org.junit.jupiter.api.Test
 import java.io.File
 
-class JettyTest : ServerContract(::Jetty, ApacheClient())
+class JettyTest : ServerContract(::Jetty, ApacheClient()) {
+    override fun requestScheme(): Matcher<String?> = equalTo("http")
+}
 
 class JettyHttp2Test {
 

--- a/http4k-server-ktorcio/src/main/kotlin/org/http4k/server/KtorCIO.kt
+++ b/http4k-server-ktorcio/src/main/kotlin/org/http4k/server/KtorCIO.kt
@@ -53,7 +53,7 @@ data class KtorCIO(val port: Int = 8000) : ServerConfig {
 fun ApplicationRequest.asHttp4k() = Request(Method.valueOf(httpMethod.value), uri)
     .headers(headers.toHttp4kHeaders())
     .body(receiveChannel().toInputStream(), header("Content-Length")?.toLong())
-    .source(RequestSource(origin.remoteHost)) // origin.remotePort does not exist for Ktor
+    .source(RequestSource(origin.remoteHost, scheme = origin.scheme)) // origin.remotePort does not exist for Ktor
 
 suspend fun ApplicationResponse.fromHttp4K(response: Response) {
     status(HttpStatusCode.fromValue(response.status.code))

--- a/http4k-server-ktorcio/src/test/kotlin/org/http4k/server/KtorCIOTest.kt
+++ b/http4k-server-ktorcio/src/test/kotlin/org/http4k/server/KtorCIOTest.kt
@@ -1,6 +1,7 @@
 package org.http4k.server
 
 import com.natpryce.hamkrest.Matcher
+import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.present
 import org.http4k.client.ApacheClient
 import org.junit.jupiter.api.BeforeEach
@@ -23,4 +24,6 @@ class KtorCIOTest : ServerContract({ KtorCIO(Random().nextInt(1000) + 8745) }, A
     }
 
     override fun clientAddress(): Matcher<String?> = present()
+
+    override fun requestScheme(): Matcher<String?> = equalTo("http")
 }

--- a/http4k-server-undertow/src/main/kotlin/org/http4k/server/Undertow.kt
+++ b/http4k-server-undertow/src/main/kotlin/org/http4k/server/Undertow.kt
@@ -36,7 +36,7 @@ class HttpUndertowHandler(handler: HttpHandler) : io.undertow.server.HttpHandler
             .headers(requestHeaders
                 .flatMap { header -> header.map { header.headerName.toString() to it } })
             .body(inputStream, requestHeaders.getFirst("Content-Length").safeLong())
-            .source(RequestSource(sourceAddress.hostString, sourceAddress.port))
+            .source(RequestSource(sourceAddress.hostString, sourceAddress.port, requestScheme))
 
     override fun handleRequest(exchange: HttpServerExchange) = safeHandler(exchange.asRequest()).into(exchange)
 }

--- a/http4k-server-undertow/src/test/kotlin/org/http4k/server/UndertowTest.kt
+++ b/http4k-server-undertow/src/test/kotlin/org/http4k/server/UndertowTest.kt
@@ -1,5 +1,9 @@
 package org.http4k.server
 
+import com.natpryce.hamkrest.Matcher
+import com.natpryce.hamkrest.equalTo
 import org.http4k.client.ApacheClient
 
-class UndertowTest : ServerContract({ Undertow(it) }, ApacheClient())
+class UndertowTest : ServerContract({ Undertow(it) }, ApacheClient()) {
+    override fun requestScheme(): Matcher<String?> = equalTo("http")
+}


### PR DESCRIPTION
This PR adds a `scheme` property to the `RequestSource` object, allowing the inference of HTTPS use where HTTPS is handled directly on the server. Do note that not all servers expose this (e.g. Netty), therefore it's only supported by a subset of servers, returning `null` if not supported.