### PR TITLE
Add websocket support to Netty

### DIFF
--- a/http4k-core/src/test/kotlin/org/http4k/websocket/WebsocketServerContract.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/websocket/WebsocketServerContract.kt
@@ -3,6 +3,7 @@ package org.http4k.websocket
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.present
+import com.natpryce.hamkrest.throws
 import org.http4k.client.WebsocketClient
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
@@ -19,6 +20,7 @@ import org.http4k.routing.websockets
 import org.http4k.server.Http4kServer
 import org.http4k.server.WsServerConfig
 import org.http4k.server.asServer
+import org.java_websocket.exceptions.WebsocketNotConnectedException
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -170,5 +172,13 @@ abstract class WebsocketServerContract(private val serverConfig: (Int) -> WsServ
         }
 
         latch.await()
+    }
+
+    @Test
+    fun `should fail on invalid url`() {
+        val client = WebsocketClient.blocking(Uri.of("ws://localhost:$port/aaa"))
+        assertThat({
+            client.send(WsMessage("hello"))
+        }, throws<WebsocketNotConnectedException>())
     }
 }

--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/Http4kWsChannelHandler.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/Http4kWsChannelHandler.kt
@@ -1,0 +1,95 @@
+package org.http4k.server
+
+import io.netty.buffer.ByteBufInputStream
+import io.netty.buffer.Unpooled
+import io.netty.channel.ChannelFutureListener
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.channel.SimpleChannelInboundHandler
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame
+import io.netty.handler.codec.http.websocketx.WebSocketFrame
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler
+import org.http4k.core.Body
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.RequestSource
+import org.http4k.core.StreamBody
+import org.http4k.core.Uri
+import org.http4k.websocket.PushPullAdaptingWebSocket
+import org.http4k.websocket.WsConsumer
+import org.http4k.websocket.WsHandler
+import org.http4k.websocket.WsMessage
+import org.http4k.websocket.WsStatus
+import java.lang.Exception
+import java.net.InetSocketAddress
+
+class Http4kWsHandshakeListener(private val wsHandler: WsHandler) : ChannelInboundHandlerAdapter() {
+    @Throws(Exception::class)
+    override fun userEventTriggered(ctx: ChannelHandlerContext, evt: Any) {
+        if(evt is WebSocketServerProtocolHandler.HandshakeComplete) {
+            val address = ctx.channel().remoteAddress() as InetSocketAddress
+            val upgradeRequest = evt.asHttp4kRequest(address)
+            val wsConsumer = wsHandler(upgradeRequest)
+
+            if(wsConsumer != null) {
+                ctx.pipeline().addAfter(
+                    ctx.name(),
+                    Http4kWsChannelHandler::class.java.name,
+                    Http4kWsChannelHandler(wsConsumer, upgradeRequest)
+                )
+            }
+        }
+    }
+}
+
+class Http4kWebSocketAdapter(private val innerSocket: PushPullAdaptingWebSocket) {
+    fun onError(throwable: Throwable) = innerSocket.triggerError(throwable)
+    fun onClose(statusCode: Int, reason: String?) = innerSocket.triggerClose(
+        WsStatus(statusCode, reason
+            ?: "<unknown>")
+    )
+
+    fun onMessage(body: Body) = innerSocket.triggerMessage(WsMessage(body))
+}
+
+class Http4kWsChannelHandler(private val wSocket: WsConsumer, private val upgradeRequest: Request): SimpleChannelInboundHandler<WebSocketFrame>() {
+    private var websocket: Http4kWebSocketAdapter? = null
+
+    override fun handlerAdded(ctx: ChannelHandlerContext) {
+        websocket = Http4kWebSocketAdapter(object : PushPullAdaptingWebSocket(upgradeRequest) {
+            override fun send(message: WsMessage) {
+                when (message.body) {
+                    is StreamBody -> ctx.writeAndFlush(BinaryWebSocketFrame(message.body.stream.use { Unpooled.wrappedBuffer(it.readBytes()) }))
+                    else -> ctx.writeAndFlush(TextWebSocketFrame(message.bodyString()))
+                }
+            }
+
+            override fun close(status: WsStatus) {
+                ctx.writeAndFlush(CloseWebSocketFrame()).addListener(ChannelFutureListener.CLOSE)
+            }
+        }.apply(wSocket))
+    }
+
+    override fun handlerRemoved(ctx: ChannelHandlerContext?) {
+        websocket = null
+    }
+
+    override fun channelRead0(ctx: ChannelHandlerContext, msg: WebSocketFrame) {
+        if(msg is TextWebSocketFrame) {
+            websocket?.onMessage(Body(msg.text()))
+        } else if (msg is BinaryWebSocketFrame) {
+            websocket?.onMessage(Body(ByteBufInputStream(msg.content())))
+        }
+    }
+
+    override fun exceptionCaught(ctx: ChannelHandlerContext, cause: Throwable) {
+        websocket?.onError(cause)
+    }
+}
+
+internal fun WebSocketServerProtocolHandler.HandshakeComplete.asHttp4kRequest(address: InetSocketAddress) =
+    Request(Method.GET, Uri.of(requestUri()))
+        .headers(requestHeaders().map { it.key to it.value })
+        .source(RequestSource(address.address.hostAddress, address.port))

--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/Http4kWsChannelHandler.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/Http4kWsChannelHandler.kt
@@ -4,44 +4,19 @@ import io.netty.buffer.ByteBufInputStream
 import io.netty.buffer.Unpooled
 import io.netty.channel.ChannelFutureListener
 import io.netty.channel.ChannelHandlerContext
-import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.channel.SimpleChannelInboundHandler
 import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame
 import io.netty.handler.codec.http.websocketx.TextWebSocketFrame
 import io.netty.handler.codec.http.websocketx.WebSocketFrame
-import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler
 import org.http4k.core.Body
-import org.http4k.core.Method
 import org.http4k.core.Request
-import org.http4k.core.RequestSource
 import org.http4k.core.StreamBody
-import org.http4k.core.Uri
 import org.http4k.websocket.PushPullAdaptingWebSocket
 import org.http4k.websocket.WsConsumer
-import org.http4k.websocket.WsHandler
 import org.http4k.websocket.WsMessage
 import org.http4k.websocket.WsStatus
-import java.net.InetSocketAddress
 
-class Http4kWsHandshakeListener(private val wsHandler: WsHandler) : ChannelInboundHandlerAdapter() {
-    @Throws(Exception::class)
-    override fun userEventTriggered(ctx: ChannelHandlerContext, evt: Any) {
-        if(evt is WebSocketServerProtocolHandler.HandshakeComplete) {
-            val address = ctx.channel().remoteAddress() as InetSocketAddress
-            val upgradeRequest = evt.asHttp4kRequest(address)
-            val wsConsumer = wsHandler(upgradeRequest)
-
-            if(wsConsumer != null) {
-                ctx.pipeline().addAfter(
-                    ctx.name(),
-                    Http4kWsChannelHandler::class.java.name,
-                    Http4kWsChannelHandler(wsConsumer, upgradeRequest)
-                )
-            }
-        }
-    }
-}
 
 class Http4kWebSocketAdapter(private val innerSocket: PushPullAdaptingWebSocket) {
     fun onError(throwable: Throwable) = innerSocket.triggerError(throwable)
@@ -55,7 +30,6 @@ class Http4kWsChannelHandler(private val wSocket: WsConsumer, private val upgrad
     private var normalClose = false;
 
     override fun handlerAdded(ctx: ChannelHandlerContext) {
-        println("A")
         websocket = Http4kWebSocketAdapter(object : PushPullAdaptingWebSocket(upgradeRequest) {
             override fun send(message: WsMessage) {
                 when (message.body) {
@@ -74,9 +48,8 @@ class Http4kWsChannelHandler(private val wSocket: WsConsumer, private val upgrad
     }
 
     override fun handlerRemoved(ctx: ChannelHandlerContext) {
-        if(ctx.channel().isActive) {
+        if(!normalClose) {
             ctx.writeAndFlush(Unpooled.EMPTY_BUFFER).addListeners(ChannelFutureListener {
-                normalClose = true;
                 websocket?.onClose(WsStatus.NOCODE)
             }, ChannelFutureListener.CLOSE)
         }
@@ -94,6 +67,7 @@ class Http4kWsChannelHandler(private val wSocket: WsConsumer, private val upgrad
             is CloseWebSocketFrame -> {
                 msg.retain()
                 ctx.writeAndFlush(msg).addListeners(ChannelFutureListener {
+                    normalClose = true
                     websocket?.onClose(WsStatus(msg.statusCode(), msg.reasonText()))
                 }, ChannelFutureListener.CLOSE)
             }
@@ -104,8 +78,3 @@ class Http4kWsChannelHandler(private val wSocket: WsConsumer, private val upgrad
         websocket?.onError(cause)
     }
 }
-
-internal fun WebSocketServerProtocolHandler.HandshakeComplete.asHttp4kRequest(address: InetSocketAddress) =
-    Request(Method.GET, Uri.of(requestUri()))
-        .headers(requestHeaders().map { it.key to it.value })
-        .source(RequestSource(address.address.hostAddress, address.port))

--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
@@ -21,7 +21,6 @@ import io.netty.handler.codec.http.HttpObjectAggregator
 import io.netty.handler.codec.http.HttpResponseStatus
 import io.netty.handler.codec.http.HttpServerCodec
 import io.netty.handler.codec.http.HttpServerKeepAliveHandler
-import io.netty.handler.codec.http.HttpUtil
 import io.netty.handler.codec.http.HttpVersion.HTTP_1_1
 import io.netty.handler.codec.http.LastHttpContent
 import io.netty.handler.stream.ChunkedStream
@@ -37,6 +36,7 @@ import org.http4k.core.safeLong
 import org.http4k.core.then
 import org.http4k.core.toParametersMap
 import org.http4k.filter.ServerFilters
+import org.http4k.websocket.WsHandler
 import java.net.InetSocketAddress
 
 
@@ -44,7 +44,6 @@ import java.net.InetSocketAddress
  * Exposed to allow for insertion into a customised Netty server instance
  */
 class Http4kChannelHandler(handler: HttpHandler) : SimpleChannelInboundHandler<FullHttpRequest>() {
-
     private val safeHandler = ServerFilters.CatchAll().then(handler)
 
     override fun channelRead0(ctx: ChannelHandlerContext, request: FullHttpRequest) {
@@ -69,8 +68,8 @@ class Http4kChannelHandler(handler: HttpHandler) : SimpleChannelInboundHandler<F
             .source(RequestSource(address.address.hostAddress, address.port))
 }
 
-data class Netty(val port: Int = 8000) : ServerConfig {
-    override fun toServer(httpHandler: HttpHandler): Http4kServer = object : Http4kServer {
+data class Netty(val port: Int = 8000)   : WsServerConfig  {
+    override fun toServer(httpHandler: HttpHandler?, wsHandler: WsHandler?): Http4kServer = object : Http4kServer {
         private val masterGroup = NioEventLoopGroup()
         private val workerGroup = NioEventLoopGroup()
         private var closeFuture: ChannelFuture? = null
@@ -85,8 +84,18 @@ data class Netty(val port: Int = 8000) : ServerConfig {
                         ch.pipeline().addLast("codec", HttpServerCodec())
                         ch.pipeline().addLast("keepAlive", HttpServerKeepAliveHandler())
                         ch.pipeline().addLast("aggregator", HttpObjectAggregator(Int.MAX_VALUE))
+
+
+                        ch.pipeline().addLast("websocket", WebSocketServerHandler())
+                        if(wsHandler != null) {
+                            ch.pipeline().addLast("wsHandler", Http4kWsHandshakeListener(wsHandler))
+                        }
+
+
                         ch.pipeline().addLast("streamer", ChunkedWriteHandler())
-                        ch.pipeline().addLast("handler", Http4kChannelHandler(httpHandler))
+                        if(httpHandler != null) {
+                            ch.pipeline().addLast("httpHandler", Http4kChannelHandler(httpHandler))
+                        }
                     }
                 })
                 .option(ChannelOption.SO_BACKLOG, 1000)
@@ -106,3 +115,4 @@ data class Netty(val port: Int = 8000) : ServerConfig {
         override fun port(): Int = if (port > 0) port else address.port
     }
 }
+

--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/Netty.kt
@@ -85,12 +85,9 @@ data class Netty(val port: Int = 8000)   : WsServerConfig  {
                         ch.pipeline().addLast("keepAlive", HttpServerKeepAliveHandler())
                         ch.pipeline().addLast("aggregator", HttpObjectAggregator(Int.MAX_VALUE))
 
-
-                        ch.pipeline().addLast("websocket", WebSocketServerHandler())
                         if(wsHandler != null) {
-                            ch.pipeline().addLast("wsHandler", Http4kWsHandshakeListener(wsHandler))
+                            ch.pipeline().addLast("websocket", WebSocketServerHandler(wsHandler))
                         }
-
 
                         ch.pipeline().addLast("streamer", ChunkedWriteHandler())
                         if(httpHandler != null) {

--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/WebSocketServerHandler.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/WebSocketServerHandler.kt
@@ -2,27 +2,61 @@ package org.http4k.server
 
 import io.netty.channel.ChannelHandlerContext
 import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.handler.codec.http.DefaultFullHttpResponse
 import io.netty.handler.codec.http.HttpHeaderNames
 import io.netty.handler.codec.http.HttpHeaderValues
 import io.netty.handler.codec.http.HttpRequest
+import io.netty.handler.codec.http.HttpResponseStatus
+import io.netty.handler.codec.http.HttpVersion
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolConfig
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.RequestSource
+import org.http4k.core.Uri
+import org.http4k.websocket.WsHandler
+import java.net.InetSocketAddress
 
-class WebSocketServerHandler : ChannelInboundHandlerAdapter() {
+class WebSocketServerHandler(private val wsHandler: WsHandler) : ChannelInboundHandlerAdapter() {
     override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
         if (msg is HttpRequest) {
             if (requiresUpgrade(msg)) {
-                val config= WebSocketServerProtocolConfig.newBuilder()
-                    .handleCloseFrames(false)
-                    .websocketPath("/")
-                    .checkStartsWith(true)
-                    .build()
+                val address = ctx.channel().remoteAddress() as InetSocketAddress
+                val upgradeRequest = msg.asRequest(address)
+                val wsConsumer = wsHandler(upgradeRequest)
 
-                ctx.pipeline().addAfter(
-                    ctx.name(),
-                    WebSocketServerProtocolHandler::class.java.name,
-                    WebSocketServerProtocolHandler(config)
-                )
+                if(wsConsumer != null) {
+                    val config= WebSocketServerProtocolConfig.newBuilder()
+                        .handleCloseFrames(false)
+                        .websocketPath("/")
+                        .checkStartsWith(true)
+                        .build()
+
+                    ctx.pipeline().addAfter(
+                        ctx.name(),
+                        "handshakeListener",
+                        object: ChannelInboundHandlerAdapter() {
+                            override fun userEventTriggered(ctx: ChannelHandlerContext, evt: Any) {
+                                if(evt is WebSocketServerProtocolHandler.HandshakeComplete) {
+                                    ctx.pipeline().addAfter(
+                                        ctx.name(),
+                                        Http4kWsChannelHandler::class.java.name,
+                                        Http4kWsChannelHandler(wsConsumer, upgradeRequest)
+                                    )
+                                }
+                            }
+                        }
+                    )
+
+                    ctx.pipeline().addAfter(
+                        ctx.name(),
+                        WebSocketServerProtocolHandler::class.java.name,
+                        WebSocketServerProtocolHandler(config)
+                    )
+                } else {
+                    ctx.write(DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.SERVICE_UNAVAILABLE))
+                }
+
                 ctx.fireChannelRead(msg)
             } else {
                 ctx.fireChannelRead(msg)
@@ -45,4 +79,9 @@ class WebSocketServerHandler : ChannelInboundHandlerAdapter() {
                 true
             )
     }
+
+    private fun HttpRequest.asRequest(address: InetSocketAddress) =
+        Request(Method.valueOf(method().name()), Uri.of(uri()))
+            .headers(headers().map { it.key to it.value })
+            .source(RequestSource(address.address.hostAddress, address.port))
 }

--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/WebSocketServerHandler.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/WebSocketServerHandler.kt
@@ -5,16 +5,23 @@ import io.netty.channel.ChannelInboundHandlerAdapter
 import io.netty.handler.codec.http.HttpHeaderNames
 import io.netty.handler.codec.http.HttpHeaderValues
 import io.netty.handler.codec.http.HttpRequest
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolConfig
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler
 
 class WebSocketServerHandler : ChannelInboundHandlerAdapter() {
     override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
         if (msg is HttpRequest) {
             if (requiresUpgrade(msg)) {
+                val config= WebSocketServerProtocolConfig.newBuilder()
+                    .handleCloseFrames(false)
+                    .websocketPath("/")
+                    .checkStartsWith(true)
+                    .build()
+
                 ctx.pipeline().addAfter(
                     ctx.name(),
                     WebSocketServerProtocolHandler::class.java.name,
-                    WebSocketServerProtocolHandler("", true)
+                    WebSocketServerProtocolHandler(config)
                 )
                 ctx.fireChannelRead(msg)
             } else {

--- a/http4k-server-netty/src/main/kotlin/org/http4k/server/WebSocketServerHandler.kt
+++ b/http4k-server-netty/src/main/kotlin/org/http4k/server/WebSocketServerHandler.kt
@@ -1,0 +1,41 @@
+package org.http4k.server
+
+import io.netty.channel.ChannelHandlerContext
+import io.netty.channel.ChannelInboundHandlerAdapter
+import io.netty.handler.codec.http.HttpHeaderNames
+import io.netty.handler.codec.http.HttpHeaderValues
+import io.netty.handler.codec.http.HttpRequest
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler
+
+class WebSocketServerHandler : ChannelInboundHandlerAdapter() {
+    override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
+        if (msg is HttpRequest) {
+            if (requiresUpgrade(msg)) {
+                ctx.pipeline().addAfter(
+                    ctx.name(),
+                    WebSocketServerProtocolHandler::class.java.name,
+                    WebSocketServerProtocolHandler("", true)
+                )
+                ctx.fireChannelRead(msg)
+            } else {
+                ctx.fireChannelRead(msg)
+            }
+        } else {
+            ctx.fireChannelRead(msg)
+        }
+    }
+
+    private fun requiresUpgrade(httpRequest: HttpRequest): Boolean {
+        val headers = httpRequest.headers()
+        return headers.containsValue(
+            HttpHeaderNames.CONNECTION,
+            HttpHeaderValues.UPGRADE,
+            true
+        ) && headers
+            .containsValue(
+                HttpHeaderNames.UPGRADE,
+                HttpHeaderValues.WEBSOCKET,
+                true
+            )
+    }
+}

--- a/http4k-server-netty/src/test/kotlin/org/http4k/websocket/NettyWebsocketTest.kt
+++ b/http4k-server-netty/src/test/kotlin/org/http4k/websocket/NettyWebsocketTest.kt
@@ -1,0 +1,6 @@
+package org.http4k.websocket
+
+import org.http4k.client.JavaHttpClient
+import org.http4k.server.Netty
+
+class NettyWebsocketTest : WebsocketServerContract(::Netty, JavaHttpClient())


### PR DESCRIPTION
Provisional support for WebSockets in Netty - I loved the tests btw.

```
class Http4kWebSocketAdapter(private val innerSocket: PushPullAdaptingWebSocket) {
    fun onError(throwable: Throwable) = innerSocket.triggerError(throwable)
    fun onClose(statusCode: Int, reason: String?) = innerSocket.triggerClose(
        WsStatus(statusCode, reason
            ?: "<unknown>")
    )

    fun onMessage(body: Body) = innerSocket.triggerMessage(WsMessage(body))
}
```
Unsure if `onClose` here refers to the other side closing the connection. This class is also copy pasted  from the Jetty implementation, worth modularizing it?