### PR TITLE
Added support for multiple "cookie" headers

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/cookie/CookieExtensions.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/cookie/CookieExtensions.kt
@@ -25,7 +25,10 @@ fun Request.cookie(new: Cookie): Request = replaceHeader("Cookie", cookies().plu
 
 internal fun String.toCookieList(): List<Cookie> = split(";").map { it.trim() }.filter { it.isNotBlank() }.map { it.split("=", limit = 2).let { Cookie(it.elementAt(0), it.elementAtOrElse(1) { "\"\"" }.unquoted()) } }
 
-fun Request.cookies(): List<Cookie> = header("Cookie")?.toCookieList() ?: listOf()
+fun Request.cookies(): List<Cookie> = headers
+    .filter { it.first.toLowerCase() == "cookie" }
+    .mapNotNull { it.second?.toCookieList() }
+    .fold(listOf()) { acc, current -> acc.plus(current) }
 
 fun Request.cookie(name: String): Cookie? = cookies().filter { it.name == name }.sortedByDescending {
     it.path?.length ?: 0

--- a/http4k-core/src/main/kotlin/org/http4k/core/cookie/CookieExtensions.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/cookie/CookieExtensions.kt
@@ -26,7 +26,7 @@ fun Request.cookie(new: Cookie): Request = replaceHeader("Cookie", cookies().plu
 internal fun String.toCookieList(): List<Cookie> = split(";").map { it.trim() }.filter { it.isNotBlank() }.map { it.split("=", limit = 2).let { Cookie(it.elementAt(0), it.elementAtOrElse(1) { "\"\"" }.unquoted()) } }
 
 fun Request.cookies(): List<Cookie> = headers
-    .filter { it.first.toLowerCase() == "cookie" }
+    .filter { it.first.equals("cookie", true) }
     .mapNotNull { it.second?.toCookieList() }
     .fold(listOf()) { acc, current -> acc.plus(current) }
 

--- a/http4k-core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
@@ -71,6 +71,18 @@ class CookieTest {
     }
 
     @Test
+    fun `cookies can be extracted from a http2 request with multiple cookie headers`() {
+        assertThat(Request(GET, "/")
+            .header("cookie","foo=bar; voo=tar")
+            .header("cookie", "roo=gar")
+            .cookies(),
+            equalTo(listOf(
+                Cookie("foo", "bar"),
+                Cookie("voo", "tar"),
+                Cookie("roo", "gar"))))
+    }
+
+    @Test
     fun `cookies with ending semicolon can be extracted from request`() {
         assertThat(Request(GET, "/").header("cookie", "foo=\"bar\";").cookies(), equalTo(listOf(Cookie("foo", "bar"))))
     }


### PR DESCRIPTION
HTTP/2 [allows multiple `Cookie` headers](https://tools.ietf.org/html/rfc7540#section-8.1.2.5). This changes the `cookies()` extension method to deal with this, rather than just grabbing the first one.