### PR TITLE
Some oauth providers struggle with encoding states as form parameters…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ changes with their rationale when appropriate:
 - [all] Upgrade some dependency versions.
 - [http4k-core] Added `hostDemux()` routing for when you want to select an `HttpHandler` based on the Host header.
 
-
 ### v3.253.0
 - [http4k-core] Replaced implementation of `JavaHttpClient` with one from Java standard library. Should you not yet have access to the Java 11 SDK, we renamed the old implementation to `Java8HttpClient`. Note that some headers that are added by default by the old Java8 implementation will no longer be added.
 - [http4k-core] [Breaking] Change `Body.binary()` lens to use an InputStream instead of a raw `Body`. To fix, just provide the InputStream by calling `Body.stream()` or similar.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ changes with their rationale when appropriate:
 ### v3.254.0
 - [all] Upgrade some dependency versions.
 - [http4k-core] Added `hostDemux()` routing for when you want to select an `HttpHandler` based on the Host header.
+- [http4k-security-oauth] [Breaking] Make the state on oauth requests just be the csrf token and store the originating uri in the oauth persistence layter instead. This will break any inflight oauth requests H/T @tom for the PR.
+
 
 ### v3.253.0
 - [http4k-core] Replaced implementation of `JavaHttpClient` with one from Java standard library. Should you not yet have access to the Java 11 SDK, we renamed the old implementation to `Java8HttpClient`. Note that some headers that are added by default by the old Java8 implementation will no longer be added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ changes with their rationale when appropriate:
 
 ### v3.259.0 (uncut)
 - [all] Upgrade some dependency versions.
+- [http4k-security-oauth] [Breaking] Make the state on oauth requests just be the csrf token and store the originating uri in the oauth persistence layter instead. This will break any inflight oauth requests H/T @tom for the PR.
 
 ### v3.258.0
 - [http4k-testing-kotest] New module! A set of matchers for use with the `kotest` library. H/T @nlochschmidt for the PR.
@@ -29,7 +30,6 @@ changes with their rationale when appropriate:
 ### v3.254.0
 - [all] Upgrade some dependency versions.
 - [http4k-core] Added `hostDemux()` routing for when you want to select an `HttpHandler` based on the Host header.
-- [http4k-security-oauth] [Breaking] Make the state on oauth requests just be the csrf token and store the originating uri in the oauth persistence layter instead. This will break any inflight oauth requests H/T @tom for the PR.
 
 
 ### v3.253.0

--- a/http4k-security-oauth/src/main/kotlin/org/http4k/security/InsecureCookieBasedOAuthPersistence.kt
+++ b/http4k-security-oauth/src/main/kotlin/org/http4k/security/InsecureCookieBasedOAuthPersistence.kt
@@ -3,6 +3,7 @@ package org.http4k.security
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.FORBIDDEN
+import org.http4k.core.Uri
 import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.http4k.core.cookie.invalidateCookie
@@ -24,6 +25,8 @@ class InsecureCookieBasedOAuthPersistence(cookieNamePrefix: String,
 
     private val nonceName = "${cookieNamePrefix}Nonce"
 
+    private val originalUriName = "${cookieNamePrefix}OriginalUri"
+
     private val accessTokenCookieName = "${cookieNamePrefix}AccessToken"
 
     override fun retrieveCsrf(request: Request) = request.cookie(csrfName)?.value?.let(::CrossSiteRequestForgeryToken)
@@ -32,18 +35,25 @@ class InsecureCookieBasedOAuthPersistence(cookieNamePrefix: String,
 
     override fun retrieveNonce(request: Request): Nonce? = request.cookie(nonceName)?.value?.let { Nonce(it) }
 
+    override fun retrieveOriginalUri(request: Request): Uri? = request.cookie(originalUriName)?.value?.let { Uri.of(it) }
+
     override fun assignCsrf(redirect: Response, csrf: CrossSiteRequestForgeryToken) = redirect.cookie(expiring(csrfName, csrf.value))
 
     override fun assignToken(request: Request, redirect: Response, accessToken: AccessToken) = redirect.cookie(expiring(accessTokenCookieName, accessToken.value))
         .invalidateCookie(csrfName)
         .invalidateCookie(nonceName)
+        .invalidateCookie(originalUriName)
 
     override fun assignNonce(redirect: Response, nonce: Nonce): Response = redirect.cookie(expiring(nonceName, nonce.value))
+
+    override fun assignOriginalUri(redirect: Response, originalUri: Uri): Response = redirect.cookie(expiring(originalUriName, originalUri.toString()))
+
 
     override fun authFailureResponse() = Response(FORBIDDEN)
         .invalidateCookie(csrfName)
         .invalidateCookie(accessTokenCookieName)
         .invalidateCookie(nonceName)
+        .invalidateCookie(originalUriName)
 
     private fun expiring(name: String, value: String) = Cookie(name, value, expires = LocalDateTime.ofInstant(clock.instant().plus(cookieValidity), clock.zone), path = "/")
 }

--- a/http4k-security-oauth/src/main/kotlin/org/http4k/security/OAuthPersistence.kt
+++ b/http4k-security-oauth/src/main/kotlin/org/http4k/security/OAuthPersistence.kt
@@ -3,6 +3,7 @@ package org.http4k.security
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.FORBIDDEN
+import org.http4k.core.Uri
 import org.http4k.security.openid.Nonce
 
 /**
@@ -33,6 +34,17 @@ interface OAuthPersistence {
      * Retrieve the stored nonce token for this user request
      */
     fun retrieveNonce(request: Request): Nonce?
+
+    /**
+     * opportunity to store the uri that the request was made before authentication
+     * this will then be redirected back to after auth
+     */
+    fun assignOriginalUri(redirect: Response, originalUri: Uri): Response
+
+    /**
+     * Retrieve the stored original uri for this user request
+     */
+    fun retrieveOriginalUri(request: Request): Uri?
 
     /**
      * Assign the swapped AccessToken returned by the end-service. Opportunity here to modify the

--- a/http4k-security-oauth/src/main/kotlin/org/http4k/security/OAuthRedirectionFilter.kt
+++ b/http4k-security-oauth/src/main/kotlin/org/http4k/security/OAuthRedirectionFilter.kt
@@ -5,7 +5,6 @@ import org.http4k.core.HttpHandler
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.TEMPORARY_REDIRECT
 import org.http4k.core.Uri
-import org.http4k.core.toUrlFormEncoded
 import org.http4k.core.with
 import org.http4k.lens.Header.LOCATION
 import org.http4k.security.CrossSiteRequestForgeryToken.Companion.SECURE_CSRF
@@ -30,7 +29,7 @@ class OAuthRedirectionFilter(
     override fun invoke(next: HttpHandler): HttpHandler = {
         if (oAuthPersistence.retrieveToken(it) != null) next(it) else {
             val csrf = generateCrsf()
-            val state = State(listOf("csrf" to csrf.value, "uri" to it.uri.toString()).toUrlFormEncoded())
+            val state = State(csrf.value)
             val nonce = generateNonceIfRequired()
 
             val authRequest = AuthRequest(
@@ -44,7 +43,7 @@ class OAuthRedirectionFilter(
 
             val redirect = Response(TEMPORARY_REDIRECT)
                 .with(LOCATION of modifyState(redirectionBuilder(providerConfig.authUri, authRequest, state, nonce)))
-            assignNonceIfRequired(oAuthPersistence.assignCsrf(redirect, csrf), nonce)
+            assignNonceIfRequired(oAuthPersistence.assignOriginalUri(oAuthPersistence.assignCsrf(redirect, csrf), it.uri), nonce)
         }
     }
 

--- a/http4k-security-oauth/src/test/kotlin/org/http4k/security/FakeOAuthPersistence.kt
+++ b/http4k-security-oauth/src/test/kotlin/org/http4k/security/FakeOAuthPersistence.kt
@@ -2,6 +2,7 @@ package org.http4k.security
 
 import org.http4k.core.Request
 import org.http4k.core.Response
+import org.http4k.core.Uri
 import org.http4k.security.openid.Nonce
 
 class FakeOAuthPersistence : OAuthPersistence {
@@ -9,6 +10,7 @@ class FakeOAuthPersistence : OAuthPersistence {
     var csrf: CrossSiteRequestForgeryToken? = null
     var nonce: Nonce? = null
     var accessToken: AccessToken? = null
+    var originalUri: Uri? = null
 
     override fun retrieveCsrf(request: Request): CrossSiteRequestForgeryToken? = csrf
 
@@ -23,6 +25,13 @@ class FakeOAuthPersistence : OAuthPersistence {
     }
 
     override fun retrieveNonce(request: Request): Nonce? = nonce
+
+    override fun assignOriginalUri(redirect: Response, originalUri: Uri): Response {
+        this.originalUri = originalUri
+        return redirect.header("action", "assignOriginalUri")
+    }
+
+    override fun retrieveOriginalUri(request: Request): Uri? = originalUri
 
     override fun retrieveToken(request: Request): AccessToken? = accessToken
 

--- a/http4k-security-oauth/src/test/kotlin/org/http4k/security/InsecureCookieBasedOAuthPersistenceTest.kt
+++ b/http4k-security-oauth/src/test/kotlin/org/http4k/security/InsecureCookieBasedOAuthPersistenceTest.kt
@@ -8,6 +8,7 @@ import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.FORBIDDEN
 import org.http4k.core.Status.Companion.TEMPORARY_REDIRECT
+import org.http4k.core.Uri
 import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.http4k.core.cookie.invalidateCookie
@@ -29,7 +30,7 @@ class InsecureCookieBasedOAuthPersistenceTest {
     @Test
     fun `failed response has correct cookies`() {
         assertThat(persistence.authFailureResponse(), equalTo(
-            Response(FORBIDDEN).invalidateCookie("prefixCsrf").invalidateCookie("prefixAccessToken").invalidateCookie("prefixNonce")
+            Response(FORBIDDEN).invalidateCookie("prefixCsrf").invalidateCookie("prefixAccessToken").invalidateCookie("prefixNonce").invalidateCookie("prefixOriginalUri")
         ))
     }
 
@@ -52,6 +53,12 @@ class InsecureCookieBasedOAuthPersistenceTest {
     }
 
     @Test
+    fun `original uri retrieval based on cookie`() {
+        assertThat(persistence.retrieveOriginalUri(Request(GET, "")), absent())
+        assertThat(persistence.retrieveOriginalUri(Request(GET, "").cookie(Cookie("prefixOriginalUri", "http://localhost"))), equalTo(Uri.of("http://localhost")))
+    }
+
+    @Test
     fun `adds csrf as a cookie to the auth redirect`() {
         assertThat(persistence.assignCsrf(Response(TEMPORARY_REDIRECT), CrossSiteRequestForgeryToken("csrfValue")),
             equalTo(Response(TEMPORARY_REDIRECT).cookie(Cookie("prefixCsrf", "csrfValue", expires = expectedCookieExpiry, path = "/"))))
@@ -62,6 +69,7 @@ class InsecureCookieBasedOAuthPersistenceTest {
         assertThat(persistence.assignToken(Request(GET, ""), Response(TEMPORARY_REDIRECT), AccessToken("tokenValue")),
             equalTo(Response(TEMPORARY_REDIRECT).cookie(Cookie("prefixAccessToken", "tokenValue", expires = expectedCookieExpiry, path = "/"))
                 .invalidateCookie("prefixCsrf").invalidateCookie("prefixNonce")
+                .invalidateCookie("prefixOriginalUri").invalidateCookie("prefixOriginalUri")
             ))
     }
 

--- a/http4k-security-oauth/src/test/kotlin/org/http4k/security/OAuthProviderTest.kt
+++ b/http4k-security-oauth/src/test/kotlin/org/http4k/security/OAuthProviderTest.kt
@@ -57,13 +57,13 @@ class OAuthProviderTest {
 
     @Test
     fun `filter - when no accessToken value present, request is redirected to expected location`() {
-        val expectedHeader = """http://authHost/auth?client_id=user&response_type=code&scope=scope1+scope2&redirect_uri=http%3A%2F%2FcallbackHost%2Fcallback&state=csrf%3DrandomCsrf%26uri%3D%252F&response_mode=form_post"""
+        val expectedHeader = """http://authHost/auth?client_id=user&response_type=code&scope=scope1+scope2&redirect_uri=http%3A%2F%2FcallbackHost%2Fcallback&state=randomCsrf&response_mode=form_post"""
         assertThat(oAuth(oAuthPersistence).authFilter.then { Response(OK) }(Request(GET, "/")), hasStatus(TEMPORARY_REDIRECT).and(hasHeader("Location", expectedHeader)))
     }
 
     @Test
     fun `filter - accepts custom request JWT container`() {
-        val expectedHeader = """http://authHost/auth?client_id=user&response_type=code&scope=scope1+scope2&redirect_uri=http%3A%2F%2FcallbackHost%2Fcallback&state=csrf%3DrandomCsrf%26uri%3D%252F&request=myCustomJwt&response_mode=form_post"""
+        val expectedHeader = """http://authHost/auth?client_id=user&response_type=code&scope=scope1+scope2&redirect_uri=http%3A%2F%2FcallbackHost%2Fcallback&state=randomCsrf&request=myCustomJwt&response_mode=form_post"""
 
         val jwts = object : RequestJwts {
             override fun create(authRequest: AuthRequest, state: State, nonce: Nonce?) = RequestJwtContainer("myCustomJwt")
@@ -82,7 +82,7 @@ class OAuthProviderTest {
     private val withCookie = Request(GET, "/").cookie("serviceCsrf", "randomCsrf")
     private val withCode = withCookie.query("code", "value")
     private val withCodeAndInvalidState = withCode.query("state", listOf("csrf" to "notreal").toUrlFormEncoded())
-    private val withCodeAndValidStateButNoUrl = withCode.query("state", listOf("csrf" to "randomCsrf").toUrlFormEncoded())
+    private val withCodeAndValidStateButNoUrl = withCode.query("state", "randomCsrf")
 
     @Test
     fun `callback - when invalid inputs passed, we get forbidden with cookie invalidation`() {

--- a/src/docs/cookbook/custom_oauth_provider/example.kt
+++ b/src/docs/cookbook/custom_oauth_provider/example.kt
@@ -1,22 +1,13 @@
 package cookbook.custom_oauth_provider
 
 import org.http4k.client.ApacheClient
-import org.http4k.core.Credentials
-import org.http4k.core.HttpHandler
+import org.http4k.core.*
 import org.http4k.core.Method.GET
-import org.http4k.core.Request
-import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
-import org.http4k.core.Uri
-import org.http4k.core.then
 import org.http4k.filter.ServerFilters
 import org.http4k.routing.bind
 import org.http4k.routing.routes
-import org.http4k.security.AccessToken
-import org.http4k.security.CrossSiteRequestForgeryToken
-import org.http4k.security.OAuthPersistence
-import org.http4k.security.OAuthProvider
-import org.http4k.security.OAuthProviderConfig
+import org.http4k.security.*
 import org.http4k.security.openid.Nonce
 import org.http4k.server.SunHttp
 import org.http4k.server.asServer
@@ -56,6 +47,7 @@ fun main() {
 class CustomOAuthPersistence : OAuthPersistence {
     var nonce: Nonce? = null
     var csrf: CrossSiteRequestForgeryToken? = null
+    var originalUri: Uri? = null
     var accessToken: AccessToken? = null
 
     override fun retrieveCsrf(request: Request): CrossSiteRequestForgeryToken? = csrf
@@ -71,6 +63,13 @@ class CustomOAuthPersistence : OAuthPersistence {
     }
 
     override fun retrieveNonce(request: Request): Nonce? = nonce
+
+    override fun assignOriginalUri(redirect: Response, originalUri: Uri): Response {
+        this.originalUri = originalUri
+        return redirect.header("action", "assignOriginalUri")
+    }
+
+    override fun retrieveOriginalUri(request: Request): Uri? = originalUri
 
     override fun retrieveToken(request: Request): AccessToken? = accessToken
 


### PR DESCRIPTION
…, so the originating uri has been added to the oauth peristence interface to be stored there and not stored as part of the state parameter