### PR TITLE
Change defaults of SunHttp server and enable reuse of the HttpExchangeHandler

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
@@ -10,7 +10,9 @@ import org.http4k.core.RequestSource
 import org.http4k.core.Response
 import org.http4k.core.Uri
 import org.http4k.core.safeLong
+import java.lang.Runtime.getRuntime
 import java.net.InetSocketAddress
+import java.util.concurrent.Executors.newWorkStealingPool
 
 class HttpExchangeHandler(private val handler: HttpHandler): SunHttpHandler {
     private fun HttpExchange.populate(httpResponse: Response) {
@@ -51,6 +53,7 @@ data class SunHttp(val port: Int = 8000) : ServerConfig {
         private val server = HttpServer.create(InetSocketAddress(port), 0)
         override fun start(): Http4kServer = apply {
             server.createContext("/", HttpExchangeHandler(httpHandler))
+            server.executor = newWorkStealingPool()
             server.start()
         }
 

--- a/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
@@ -50,7 +50,7 @@ data class SunHttp(val port: Int = 8000) : ServerConfig {
     override fun toServer(httpHandler: HttpHandler): Http4kServer = object : Http4kServer {
         override fun port(): Int = if (port > 0) port else server.address.port
 
-        private val server = HttpServer.create(InetSocketAddress(port), 0)
+        private val server = HttpServer.create(InetSocketAddress(port), 1000)
         override fun start(): Http4kServer = apply {
             server.createContext("/", HttpExchangeHandler(httpHandler))
             server.executor = newWorkStealingPool()

--- a/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
@@ -1,6 +1,7 @@
 package org.http4k.server
 
 import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpHandler as SunHttpHandler
 import com.sun.net.httpserver.HttpServer
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method
@@ -11,6 +12,36 @@ import org.http4k.core.Uri
 import org.http4k.core.safeLong
 import java.net.InetSocketAddress
 
+class HttpExchangeHandler(private val handler: HttpHandler): SunHttpHandler {
+    private fun HttpExchange.populate(httpResponse: Response) {
+        httpResponse.headers.forEach { (key, value) -> responseHeaders.add(key, value) }
+        if (requestMethod == "HEAD") {
+            sendResponseHeaders(httpResponse.status.code, -1)
+        } else {
+            sendResponseHeaders(httpResponse.status.code, 0)
+            httpResponse.body.stream.use { input -> responseBody.use { input.copyTo(it) } }
+        }
+    }
+
+    private fun HttpExchange.toRequest(): Request =
+        Request(Method.valueOf(requestMethod),
+            requestURI.rawQuery?.let { Uri.of(requestURI.rawPath).query(requestURI.rawQuery) }
+                ?: Uri.of(requestURI.rawPath))
+            .body(requestBody, requestHeaders.getFirst("Content-Length").safeLong())
+            .headers(requestHeaders.toList().flatMap { (key, values) -> values.map { key to it } })
+            .source(RequestSource(localAddress.address.hostAddress, localAddress.port))
+
+    override fun handle(exchange: HttpExchange) {
+        with(exchange) {
+            try {
+                populate(handler(toRequest()))
+            } catch (e: Exception) {
+                sendResponseHeaders(500, 0)
+            }
+            close()
+        }
+    }
+}
 
 data class SunHttp(val port: Int = 8000) : ServerConfig {
     override fun toServer(httpHandler: HttpHandler): Http4kServer = object : Http4kServer {
@@ -18,35 +49,10 @@ data class SunHttp(val port: Int = 8000) : ServerConfig {
 
         private val server = HttpServer.create(InetSocketAddress(port), 0)
         override fun start(): Http4kServer = apply {
-            server.createContext("/") {
-                try {
-                    it.populate(httpHandler(it.toRequest()))
-                } catch (e: Exception) {
-                    it.sendResponseHeaders(500, 0)
-                }
-                it.close()
-            }
+            server.createContext("/", HttpExchangeHandler(httpHandler))
             server.start()
         }
 
         override fun stop() = apply { server.stop(0) }
     }
 }
-
-private fun HttpExchange.populate(httpResponse: Response) {
-    httpResponse.headers.forEach { (key, value) -> responseHeaders.add(key, value) }
-    if (requestMethod == "HEAD") {
-        sendResponseHeaders(httpResponse.status.code, -1)
-    } else {
-        sendResponseHeaders(httpResponse.status.code, 0)
-        httpResponse.body.stream.use { input -> responseBody.use { input.copyTo(it) } }
-    }
-}
-
-private fun HttpExchange.toRequest(): Request =
-    Request(Method.valueOf(requestMethod),
-        requestURI.rawQuery?.let { Uri.of(requestURI.rawPath).query(requestURI.rawQuery) }
-            ?: Uri.of(requestURI.rawPath))
-        .body(requestBody, requestHeaders.getFirst("Content-Length").safeLong())
-        .headers(requestHeaders.toList().flatMap { (key, values) -> values.map { key to it } })
-        .source(RequestSource(localAddress.address.hostAddress, localAddress.port))

--- a/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/server/SunHttp.kt
@@ -37,8 +37,9 @@ class HttpExchangeHandler(private val handler: HttpHandler): SunHttpHandler {
                 populate(handler(toRequest()))
             } catch (e: Exception) {
                 sendResponseHeaders(500, 0)
+            } finally {
+                close()
             }
-            close()
         }
     }
 }


### PR DESCRIPTION
Included in this MR:

- **Refactoring to allow reuse of the handler** 
Done in a very similar way to the Undertow handler and fixed a potential issue with HttpExchange not getting closed in the rare circumstance that `sendResponseHeaders(500, 0)` inside the `catch` block fails.
- **Enable parallel processing of requests**
Opted for using a work-stealing pool aka (ForkJoinPool) because it doesn't require us to set a fixed limit of threads and instead allows us to set the targeted parallelism which by default is `getRuntime().availableProcessors()`.
- **Set backlog of the server socket to 1000**
This is the same limit that is applied explicitly or through the defaults in the case of Netty, Undertow and ApacheServer

Closes #465 