### PR TITLE
Make it possible to add description to OpenApi schema field

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/AutoJsonToJsonSchema.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/AutoJsonToJsonSchema.kt
@@ -29,47 +29,47 @@ class AutoJsonToJsonSchema<NODE : Any>(
 
     private fun NODE.toSchema(value: Any, objName: String?, topLevel: Boolean) =
         when (val param = json.typeOf(this).toParam()) {
-            ArrayParam -> toArraySchema("", value, false)
-            ObjectParam -> toObjectOrMapSchema(objName, value, false, topLevel)
-            else -> toSchema("", param, false)
+            ArrayParam -> toArraySchema("", value, false, null)
+            ObjectParam -> toObjectOrMapSchema(objName, value, false, topLevel, null)
+            else -> toSchema("", param, false, null)
         }
 
-    private fun NODE.toSchema(name: String, paramMeta: ParamMeta, isNullable: Boolean) =
-        SchemaNode.Primitive(name, paramMeta, isNullable, this)
+    private fun NODE.toSchema(name: String, paramMeta: ParamMeta, isNullable: Boolean, metadata: FieldMetadata?) =
+        SchemaNode.Primitive(name, paramMeta, isNullable, this, metadata)
 
-    private fun NODE.toArraySchema(name: String, obj: Any, isNullable: Boolean): SchemaNode.Array {
+    private fun NODE.toArraySchema(name: String, obj: Any, isNullable: Boolean, metadata: FieldMetadata?): SchemaNode.Array {
         val items = Items(
             json.elements(this)
                 .zip(items(obj)) { node: NODE, value: Any ->
                     value.javaClass.enumConstants?.let {
-                        node.toEnumSchema("", it[0], json.typeOf(node).toParam(), it, false)
+                        node.toEnumSchema("", it[0], json.typeOf(node).toParam(), it, false, null)
                     } ?: node.toSchema(value, null, false)
                 }
         )
 
-        return SchemaNode.Array(name, isNullable, items, this)
+        return SchemaNode.Array(name, isNullable, items, this, metadata)
     }
 
     private fun NODE.toEnumSchema(fieldName: String, obj: Any, param: ParamMeta,
-                                  enumConstants: Array<Any>, isNullable: Boolean): SchemaNode =
+                                  enumConstants: Array<Any>, isNullable: Boolean, metadata: FieldMetadata?): SchemaNode =
         SchemaNode.Reference(fieldName, "#/$refPrefix/${modelNamer(obj)}",
-            SchemaNode.Enum(modelNamer(obj), param, isNullable, this, enumConstants.map { it.toString() }))
+            SchemaNode.Enum(modelNamer(obj), param, isNullable, this, enumConstants.map { it.toString() }, null), metadata)
 
 
-    private fun NODE.toObjectOrMapSchema(objName: String?, obj: Any, isNullable: Boolean, topLevel: Boolean) =
-        if (obj is Map<*, *>) toMapSchema(objName, obj, isNullable, topLevel) else toObjectSchema(objName, obj, isNullable, topLevel)
+    private fun NODE.toObjectOrMapSchema(objName: String?, obj: Any, isNullable: Boolean, topLevel: Boolean, metadata: FieldMetadata?) =
+        if (obj is Map<*, *>) toMapSchema(objName, obj, isNullable, topLevel, metadata) else toObjectSchema(objName, obj, isNullable, topLevel, metadata)
 
-    private fun NODE.toObjectSchema(objName: String?, obj: Any, isNullable: Boolean, topLevel: Boolean): SchemaNode.Reference {
+    private fun NODE.toObjectSchema(objName: String?, obj: Any, isNullable: Boolean, topLevel: Boolean, metadata: FieldMetadata?): SchemaNode.Reference {
         val properties = json.fields(this)
             .map { Triple(it.first, it.second, fieldRetrieval(obj, it.first)) }
             .map { (fieldName, field, kField) ->
                 when (val param = json.typeOf(field).toParam()) {
-                    ArrayParam -> field.toArraySchema(fieldName, kField.value, kField.isNullable)
-                    ObjectParam -> field.toObjectOrMapSchema(fieldName, kField.value, kField.isNullable, false)
+                    ArrayParam -> field.toArraySchema(fieldName, kField.value, kField.isNullable, kField.metadata)
+                    ObjectParam -> field.toObjectOrMapSchema(fieldName, kField.value, kField.isNullable, false, kField.metadata)
                     else -> with(field) {
                         kField.value.javaClass.enumConstants
-                            ?.let { toEnumSchema(fieldName, kField.value, param, it, kField.isNullable) }
-                            ?: toSchema(fieldName, param, kField.isNullable)
+                            ?.let { toEnumSchema(fieldName, kField.value, param, it, kField.isNullable, kField.metadata) }
+                            ?: toSchema(fieldName, param, kField.isNullable, kField.metadata)
                     }
                 }
             }
@@ -79,21 +79,21 @@ class AutoJsonToJsonSchema<NODE : Any>(
 
         return SchemaNode.Reference(objName
             ?: modelNamer(obj), "#/$refPrefix/$nameToUseForRef",
-            SchemaNode.Object(nameToUseForRef, isNullable, properties, this))
+            SchemaNode.Object(nameToUseForRef, isNullable, properties, this, null), metadata)
     }
 
-    private fun NODE.toMapSchema(objName: String?, obj: Map<*, *>, isNullable: Boolean, topLevel: Boolean): SchemaNode {
+    private fun NODE.toMapSchema(objName: String?, obj: Map<*, *>, isNullable: Boolean, topLevel: Boolean, metadata: FieldMetadata?): SchemaNode {
         val objWithStringKeys = obj.mapKeys { it.key?.let(::toJsonKey) }
         val properties = json.fields(this)
             .map { Triple(it.first, it.second, objWithStringKeys[it.first]!!) }
             .map { (fieldName, field, value) ->
                 when (val param = json.typeOf(field).toParam()) {
-                    ArrayParam -> field.toArraySchema(fieldName, value, false)
-                    ObjectParam -> field.toObjectOrMapSchema(fieldName, value, false, false)
+                    ArrayParam -> field.toArraySchema(fieldName, value, false, null)
+                    ObjectParam -> field.toObjectOrMapSchema(fieldName, value, false, false, null)
                     else -> with(field) {
                         value.javaClass.enumConstants?.let {
-                            toEnumSchema(fieldName, value, param, it, false)
-                        } ?: toSchema(fieldName, param, false)
+                            toEnumSchema(fieldName, value, param, it, false, null)
+                        } ?: toSchema(fieldName, param, false, null)
                     }
                 }
             }
@@ -101,11 +101,10 @@ class AutoJsonToJsonSchema<NODE : Any>(
 
         return if (topLevel && objName != null) {
             SchemaNode.Reference(objName, "#/$refPrefix/$objName",
-                SchemaNode.Object(objName, isNullable, properties, this)
-            )
+                SchemaNode.Object(objName, isNullable, properties, this, null), metadata)
         } else
             SchemaNode.MapType(objName ?: modelNamer(obj), isNullable,
-                SchemaNode.Object(modelNamer(obj), isNullable, properties, this))
+                SchemaNode.Object(modelNamer(obj), isNullable, properties, this, null), metadata)
     }
 
     private fun toJsonKey(it: Any): String {
@@ -159,7 +158,9 @@ private sealed class SchemaNode(
     private val _name: String,
     private val _paramMeta: ParamMeta,
     private val isNullable: Boolean,
-    val example: Any?) {
+    val example: Any?,
+    private val metadata: FieldMetadata?
+) {
     abstract fun definitions(): Iterable<SchemaNode>
 
     fun name() = _name
@@ -167,22 +168,24 @@ private sealed class SchemaNode(
     fun paramMeta() = _paramMeta
     abstract fun arrayItem(): ArrayItem
 
-    class Primitive(name: String, paramMeta: ParamMeta, isNullable: Boolean, example: Any?) :
-        SchemaNode(name, paramMeta, isNullable, example) {
+    val description = metadata?.description
+
+    class Primitive(name: String, paramMeta: ParamMeta, isNullable: Boolean, example: Any?, metadata: FieldMetadata?) :
+        SchemaNode(name, paramMeta, isNullable, example, metadata) {
         val type = paramMeta().value
         override fun arrayItem() = ArrayItem.NonObject(paramMeta())
         override fun definitions() = emptyList<SchemaNode>()
     }
 
-    class Enum(name: String, paramMeta: ParamMeta, isNullable: Boolean, example: Any?, val enum: List<String>) :
-        SchemaNode(name, paramMeta, isNullable, example) {
+    class Enum(name: String, paramMeta: ParamMeta, isNullable: Boolean, example: Any?, val enum: List<String>, metadata: FieldMetadata?) :
+        SchemaNode(name, paramMeta, isNullable, example, metadata) {
         val type = paramMeta().value
         override fun arrayItem() = ArrayItem.Ref(name())
         override fun definitions() = emptyList<SchemaNode>()
     }
 
-    class Array(name: String, isNullable: Boolean, val items: Items, example: Any?) :
-        SchemaNode(name, ArrayParam, isNullable, example) {
+    class Array(name: String, isNullable: Boolean, val items: Items, example: Any?, metadata: FieldMetadata?) :
+        SchemaNode(name, ArrayParam, isNullable, example, metadata) {
         val type = paramMeta().value
 
         override fun arrayItem() = when (paramMeta()) {
@@ -195,7 +198,7 @@ private sealed class SchemaNode(
     }
 
     class Object(name: String, isNullable: Boolean, val properties: Map<String, SchemaNode>,
-                 example: Any?) : SchemaNode(name, ObjectParam, isNullable, example) {
+                 example: Any?, metadata: FieldMetadata?) : SchemaNode(name, ObjectParam, isNullable, example, metadata) {
         val type = paramMeta().value
         val required = properties.filterNot { it.value.isNullable }.keys.sorted()
         override fun arrayItem() = ArrayItem.Ref(name())
@@ -204,12 +207,13 @@ private sealed class SchemaNode(
 
     class Reference(name: String,
                     val `$ref`: String,
-                    private val schemaNode: SchemaNode) : SchemaNode(name, ObjectParam, schemaNode.isNullable, null) {
+                    private val schemaNode: SchemaNode,
+                    metadata: FieldMetadata?) : SchemaNode(name, ObjectParam, schemaNode.isNullable, null, metadata) {
         override fun arrayItem() = ArrayItem.Ref(`$ref`)
         override fun definitions() = listOf(schemaNode) + schemaNode.definitions()
     }
 
-    class MapType(name: String, isNullable: Boolean, val additionalProperties: SchemaNode) : SchemaNode(name, ObjectParam, isNullable, null) {
+    class MapType(name: String, isNullable: Boolean, val additionalProperties: SchemaNode, metadata: FieldMetadata?) : SchemaNode(name, ObjectParam, isNullable, null, metadata) {
         val type = paramMeta().value
         override fun arrayItem() = ArrayItem.Ref(name())
         override fun definitions() = additionalProperties.definitions()

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/FieldRetrievalTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/FieldRetrievalTest.kt
@@ -11,7 +11,7 @@ class FieldRetrievalTest {
         override fun invoke(p1: Any, p2: String) = throw NoFieldFound(p2, p1)
     }
 
-    private val result = Field("hello", true)
+    private val result = Field("hello", true, FieldMetadata.empty)
 
     private val findIt = object : FieldRetrieval {
         override fun invoke(p1: Any, p2: String): Field = result
@@ -26,6 +26,6 @@ class FieldRetrievalTest {
 
     @Test
     fun `field retrieval falls back if none found`() {
-        assertThat(FieldRetrieval.compose(blowUp, findIt)(Beany(), "foo"), equalTo(Field("hello", true)))
+        assertThat(FieldRetrieval.compose(blowUp, findIt)(Beany(), "foo"), equalTo(Field("hello", true, FieldMetadata.empty)))
     }
 }

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/JacksonFieldMetadataRetrievalStrategyTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/JacksonFieldMetadataRetrievalStrategyTest.kt
@@ -1,0 +1,46 @@
+package org.http4k.contract.openapi.v3
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+class JacksonFieldMetadataRetrievalStrategyTest {
+    open class Base(@JsonPropertyDescription("Parent Field Description") val parentField: String = "parent")
+    data class Model(
+        @JsonPropertyDescription("Some Field Description") val someField: String = "hello",
+        val fieldWithoutMeta: String = "world"
+    ) : Base()
+
+    @Test
+    fun `extract description from annotated field`() {
+        assertThat(
+            JacksonFieldMetadataRetrievalStrategy(Model(), "someField"),
+            equalTo(FieldMetadata(description = "Some Field Description"))
+        )
+    }
+
+    @Test
+    fun `extract description from annotated field in base class`() {
+        assertThat(
+            JacksonFieldMetadataRetrievalStrategy(Model(), "parentField"),
+            equalTo(FieldMetadata(description = "Parent Field Description"))
+        )
+    }
+
+    @Test
+    fun `returns empty value when field is not annotated`() {
+        assertThat(
+            JacksonFieldMetadataRetrievalStrategy(Model(), "fieldWithoutMeta"),
+            equalTo(FieldMetadata.empty)
+        )
+    }
+
+    @Test
+    fun `returns empty value when field is not found`() {
+        assertThat(
+            JacksonFieldMetadataRetrievalStrategy(Model(), "unknownField"),
+            equalTo(FieldMetadata.empty)
+        )
+    }
+}

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/JacksonJsonNamingAnnotatedTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/JacksonJsonNamingAnnotatedTest.kt
@@ -23,9 +23,9 @@ internal class JacksonJsonNamingAnnotatedTest {
 
     @Test
     fun `finds value from object`() {
-        assertThat("nonNullable", standard(Renamed(), "RenamedValue"), equalTo(Field("bob", false)))
-        assertThat("nonNullableNoRename", standard(Snake(), "renamedValue"), equalTo(Field("bob", false)))
-        assertThat("nullable", standard(Renamed(), "Nullable"), equalTo(Field("nullable", true)))
+        assertThat("nonNullable", standard(Renamed(), "RenamedValue"), equalTo(Field("bob", false, FieldMetadata.empty)))
+        assertThat("nonNullableNoRename", standard(Snake(), "renamedValue"), equalTo(Field("bob", false, FieldMetadata.empty)))
+        assertThat("nullable", standard(Renamed(), "Nullable"), equalTo(Field("nullable", true, FieldMetadata.empty)))
     }
 
     @Test
@@ -41,6 +41,6 @@ internal class JacksonJsonNamingAnnotatedTest {
 
     @Test
     fun `use custom Jackson naming strategy`() {
-        assertThat(JacksonJsonNamingAnnotated(CustomJackson)(Snake(), "renamed_value"), equalTo(Field("bob", false)))
+        assertThat(JacksonJsonNamingAnnotated(CustomJackson)(Snake(), "renamed_value"), equalTo(Field("bob", false, FieldMetadata.empty)))
     }
 }

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/JacksonJsonPropertyAnnotatedTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/JacksonJsonPropertyAnnotatedTest.kt
@@ -13,12 +13,12 @@ class JacksonJsonPropertyAnnotatedTest {
 
     @Test
     fun `finds value from object`() {
-        assertThat("nonNullable", JacksonJsonPropertyAnnotated(Beany(), "NEWNAME"), equalTo(Field("hello", false)))
+        assertThat("nonNullable", JacksonJsonPropertyAnnotated(Beany(), "NEWNAME"), equalTo(Field("hello", false, FieldMetadata.empty)))
     }
 
     @Test
     fun `finds value from superclass object`() {
-        assertThat("superValue", JacksonJsonPropertyAnnotated(Beany(), "SUPERNEWNAME"), equalTo(Field("bob", false)))
+        assertThat("superValue", JacksonJsonPropertyAnnotated(Beany(), "SUPERNEWNAME"), equalTo(Field("bob", false, FieldMetadata.empty)))
     }
 
     @Test

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/SimpleLookupTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/SimpleLookupTest.kt
@@ -1,5 +1,6 @@
 package org.http4k.contract.openapi.v3
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.throws
@@ -7,12 +8,22 @@ import org.junit.jupiter.api.Test
 
 class SimpleLookupTest {
 
-    data class Beany(val nonNullable: String = "hello", val aNullable: String? = "aNullable")
+    data class Beany(
+        val nonNullable: String = "hello",
+        @JsonPropertyDescription("A field description")
+        val withMeta: String = "withMeta",
+        val aNullable: String? = "aNullable"
+    )
 
     @Test
     fun `finds value from object`() {
-        assertThat("nonNullable", SimpleLookup()(Beany(), "nonNullable"), equalTo(Field("hello", false)))
-        assertThat("aNullable", SimpleLookup()(Beany(), "aNullable"), equalTo(Field("aNullable", true)))
+        assertThat("nonNullable", SimpleLookup()(Beany(), "nonNullable"), equalTo(Field("hello", false, FieldMetadata.empty)))
+        assertThat("aNullable", SimpleLookup()(Beany(), "aNullable"), equalTo(Field("aNullable", true, FieldMetadata.empty)))
+        assertThat(
+            "withMeta",
+            SimpleLookup(metadataRetrievalStrategy = JacksonFieldMetadataRetrievalStrategy)(Beany(), "withMeta"),
+            equalTo(Field("withMeta", false, FieldMetadata(description = "A field description")))
+        )
     }
 
     @Test

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.can override definition id for a map.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.can override definition id for a map.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/customPrefix/foobar",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -13,10 +14,12 @@
               "properties": {
                 "key": {
                   "example": "value",
+                  "description": null,
                   "type": "string"
                 },
                 "key2": {
                   "example": 123,
+                  "description": null,
                   "type": "number"
                 },
                 "key3": {
@@ -24,6 +27,7 @@
                     "properties": {
                       "inner": {
                         "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+                        "description": null,
                         "example": null
                       }
                     },
@@ -32,11 +36,13 @@
                         "uri": "foobar"
                       }
                     },
+                    "description": null,
                     "type": "object",
                     "required": [
                       "inner"
                     ]
                   },
+                  "description": null,
                   "example": null,
                   "type": "object"
                 }
@@ -50,6 +56,7 @@
                   }
                 }
               },
+              "description": null,
               "type": "object",
               "required": [
                 "key",
@@ -57,6 +64,7 @@
                 "key3"
               ]
             },
+            "description": null,
             "example": null,
             "type": "object"
           }
@@ -72,6 +80,7 @@
             }
           }
         },
+        "description": null,
         "type": "object",
         "required": [
           "value"
@@ -84,12 +93,14 @@
         "properties": {
           "uri": {
             "example": "foobar",
+            "description": null,
             "type": "string"
           }
         },
         "example": {
           "uri": "foobar"
         },
+        "description": null,
         "type": "object",
         "required": [
           "uri"

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.can override definition id for a raw map.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.can override definition id for a raw map.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/customPrefix/foobar",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -10,10 +11,12 @@
         "properties": {
           "key": {
             "example": "value",
+            "description": null,
             "type": "string"
           },
           "key2": {
             "example": 123,
+            "description": null,
             "type": "number"
           },
           "key3": {
@@ -21,6 +24,7 @@
               "properties": {
                 "inner": {
                   "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+                  "description": null,
                   "example": null
                 }
               },
@@ -29,11 +33,13 @@
                   "uri": "foobar"
                 }
               },
+              "description": null,
               "type": "object",
               "required": [
                 "inner"
               ]
             },
+            "description": null,
             "example": null,
             "type": "object"
           }
@@ -47,6 +53,7 @@
             }
           }
         },
+        "description": null,
         "type": "object",
         "required": [
           "key",
@@ -61,12 +68,14 @@
         "properties": {
           "uri": {
             "example": "foobar",
+            "description": null,
             "type": "string"
           }
         },
         "example": {
           "uri": "foobar"
         },
+        "description": null,
         "type": "object",
         "required": [
           "uri"

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.can override definition id.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.can override definition id.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/customPrefix/foobar",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -10,34 +11,42 @@
         "properties": {
           "string": {
             "example": "string",
+            "description": null,
             "type": "string"
           },
           "boolean": {
             "example": false,
+            "description": null,
             "type": "boolean"
           },
           "int": {
             "example": 2147483647,
+            "description": null,
             "type": "number"
           },
           "long": {
             "example": -9223372036854775808,
+            "description": null,
             "type": "number"
           },
           "double": {
             "example": 9.9999999999,
+            "description": null,
             "type": "number"
           },
           "float": {
             "example": -10.0,
+            "description": null,
             "type": "number"
           },
           "bigInt": {
             "example": 92233720368547758079223372036854775807,
+            "description": null,
             "type": "number"
           },
           "bigDecimal": {
             "example": 1.7976931348623157E+308111,
+            "description": null,
             "type": "number"
           }
         },
@@ -51,6 +60,7 @@
           "bigInt": 92233720368547758079223372036854775807,
           "bigDecimal": 1.7976931348623157E+308111
         },
+        "description": null,
         "type": "object",
         "required": [
           "bigDecimal",

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for custom json mapping.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for custom json mapping.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/components/schemas/ArbObjectHolder",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -19,6 +20,7 @@
             "example": [
               "foobar"
             ],
+            "description": null,
             "type": "array"
           }
         },
@@ -27,6 +29,7 @@
             "foobar"
           ]
         },
+        "description": null,
         "type": "object",
         "required": [
           "inner"

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for field with description.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for field with description.approved
@@ -1,0 +1,36 @@
+{
+  "node": {
+    "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.JacksonFieldWithMetadata",
+    "description": null,
+    "example": null
+  },
+  "definitions": [
+    {
+      "first": "org.http4k.contract.openapi.v3.JacksonFieldWithMetadata",
+      "second": {
+        "properties": {
+          "field1": {
+            "example": "field1",
+            "description": "Field 1 description",
+            "type": "string"
+          },
+          "field2": {
+            "example": "field2",
+            "description": null,
+            "type": "string"
+          }
+        },
+        "example": {
+          "field1": "field1",
+          "field2": "field2"
+        },
+        "description": null,
+        "type": "object",
+        "required": [
+          "field1",
+          "field2"
+        ]
+      }
+    }
+  ]
+}

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for freeform map field.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for freeform map field.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.MapHolder",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -14,10 +15,12 @@
               },
               "example": {
               },
+              "description": null,
               "type": "object",
               "required": [
               ]
             },
+            "description": null,
             "example": null,
             "type": "object"
           }
@@ -26,6 +29,7 @@
           "value": {
           }
         },
+        "description": null,
         "type": "object",
         "required": [
           "value"

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for holder with generic list.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for holder with generic list.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.GenericListHolder",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -67,6 +68,7 @@
                 "uri": "foobar"
               }
             ],
+            "description": null,
             "type": "array"
           }
         },
@@ -120,6 +122,7 @@
             }
           ]
         },
+        "description": null,
         "type": "object",
         "required": [
           "value"
@@ -132,6 +135,7 @@
         "properties": {
           "child": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+            "description": null,
             "example": null
           },
           "list": {
@@ -150,6 +154,7 @@
                 "uri": "foobar"
               }
             ],
+            "description": null,
             "type": "array"
           },
           "nestedList": {
@@ -177,10 +182,12 @@
                 }
               ]
             ],
+            "description": null,
             "type": "array"
           },
           "nullableChild": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+            "description": null,
             "example": null
           },
           "stringList": {
@@ -195,6 +202,7 @@
               "hello",
               "goodbye"
             ],
+            "description": null,
             "type": "array"
           },
           "anyList": {
@@ -233,10 +241,12 @@
                 }
               ]
             ],
+            "description": null,
             "type": "array"
           },
           "enumVal": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.Foo",
+            "description": null,
             "example": null
           }
         },
@@ -283,6 +293,7 @@
           ],
           "enumVal": "value2"
         },
+        "description": null,
         "type": "object",
         "required": [
           "anyList",
@@ -299,12 +310,14 @@
         "properties": {
           "uri": {
             "example": "foobar",
+            "description": null,
             "type": "string"
           }
         },
         "example": {
           "uri": "foobar"
         },
+        "description": null,
         "type": "object",
         "required": [
           "uri"
@@ -319,6 +332,7 @@
           "value1",
           "value2"
         ],
+        "description": null,
         "type": "string"
       }
     }

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for list of enums.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for list of enums.approved
@@ -11,6 +11,7 @@
       "value1",
       "value2"
     ],
+    "description": null,
     "type": "array"
   },
   "definitions": [
@@ -22,6 +23,7 @@
           "value1",
           "value2"
         ],
+        "description": null,
         "type": "string"
       }
     }

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for map field.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for map field.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.MapHolder",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -13,10 +14,12 @@
               "properties": {
                 "key": {
                   "example": "value",
+                  "description": null,
                   "type": "string"
                 },
                 "key2": {
                   "example": 123,
+                  "description": null,
                   "type": "number"
                 },
                 "key3": {
@@ -24,6 +27,7 @@
                     "properties": {
                       "inner": {
                         "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+                        "description": null,
                         "example": null
                       }
                     },
@@ -32,16 +36,19 @@
                         "uri": "foobar"
                       }
                     },
+                    "description": null,
                     "type": "object",
                     "required": [
                       "inner"
                     ]
                   },
+                  "description": null,
                   "example": null,
                   "type": "object"
                 },
                 "key4": {
                   "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+                  "description": null,
                   "example": null
                 }
               },
@@ -57,6 +64,7 @@
                   "uri": "foobar"
                 }
               },
+              "description": null,
               "type": "object",
               "required": [
                 "key",
@@ -65,6 +73,7 @@
                 "key4"
               ]
             },
+            "description": null,
             "example": null,
             "type": "object"
           }
@@ -83,6 +92,7 @@
             }
           }
         },
+        "description": null,
         "type": "object",
         "required": [
           "value"
@@ -95,12 +105,14 @@
         "properties": {
           "uri": {
             "example": "foobar",
+            "description": null,
             "type": "string"
           }
         },
         "example": {
           "uri": "foobar"
         },
+        "description": null,
         "type": "object",
         "required": [
           "uri"

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for nested arbitrary objects.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for nested arbitrary objects.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -10,6 +11,7 @@
         "properties": {
           "child": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+            "description": null,
             "example": null
           },
           "list": {
@@ -28,6 +30,7 @@
                 "uri": "foobar"
               }
             ],
+            "description": null,
             "type": "array"
           },
           "nestedList": {
@@ -55,10 +58,12 @@
                 }
               ]
             ],
+            "description": null,
             "type": "array"
           },
           "nullableChild": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+            "description": null,
             "example": null
           },
           "stringList": {
@@ -73,6 +78,7 @@
               "hello",
               "goodbye"
             ],
+            "description": null,
             "type": "array"
           },
           "anyList": {
@@ -111,10 +117,12 @@
                 }
               ]
             ],
+            "description": null,
             "type": "array"
           },
           "enumVal": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.Foo",
+            "description": null,
             "example": null
           }
         },
@@ -161,6 +169,7 @@
           ],
           "enumVal": "value2"
         },
+        "description": null,
         "type": "object",
         "required": [
           "anyList",
@@ -177,12 +186,14 @@
         "properties": {
           "uri": {
             "example": "foobar",
+            "description": null,
             "type": "string"
           }
         },
         "example": {
           "uri": "foobar"
         },
+        "description": null,
         "type": "object",
         "required": [
           "uri"
@@ -197,6 +208,7 @@
           "value1",
           "value2"
         ],
+        "description": null,
         "type": "string"
       }
     }

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for non-string-keyed map field.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for non-string-keyed map field.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.MapHolder",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -13,10 +14,12 @@
               "properties": {
                 "value1": {
                   "example": "value",
+                  "description": null,
                   "type": "string"
                 },
                 "1970-01-01": {
                   "example": "value",
+                  "description": null,
                   "type": "string"
                 }
               },
@@ -24,12 +27,14 @@
                 "value1": "value",
                 "1970-01-01": "value"
               },
+              "description": null,
               "type": "object",
               "required": [
                 "1970-01-01",
                 "value1"
               ]
             },
+            "description": null,
             "example": null,
             "type": "object"
           }
@@ -40,6 +45,7 @@
             "1970-01-01": "value"
           }
         },
+        "description": null,
         "type": "object",
         "required": [
           "value"

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for raw map field.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for raw map field.approved
@@ -4,10 +4,12 @@
       "properties": {
         "key": {
           "example": "value",
+          "description": null,
           "type": "string"
         },
         "key2": {
           "example": 123,
+          "description": null,
           "type": "number"
         },
         "key3": {
@@ -15,6 +17,7 @@
             "properties": {
               "inner": {
                 "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+                "description": null,
                 "example": null
               }
             },
@@ -23,16 +26,19 @@
                 "uri": "foobar"
               }
             },
+            "description": null,
             "type": "object",
             "required": [
               "inner"
             ]
           },
+          "description": null,
           "example": null,
           "type": "object"
         },
         "key4": {
           "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+          "description": null,
           "example": null
         },
         "key5": {
@@ -94,10 +100,12 @@
               "enumVal": "value2"
             }
           ],
+          "description": null,
           "type": "array"
         },
         "key6": {
           "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.GenericListHolder",
+          "description": null,
           "example": null
         }
       },
@@ -211,6 +219,7 @@
           ]
         }
       },
+      "description": null,
       "type": "object",
       "required": [
         "key",
@@ -221,6 +230,7 @@
         "key6"
       ]
     },
+    "description": null,
     "example": null,
     "type": "object"
   },
@@ -231,12 +241,14 @@
         "properties": {
           "uri": {
             "example": "foobar",
+            "description": null,
             "type": "string"
           }
         },
         "example": {
           "uri": "foobar"
         },
+        "description": null,
         "type": "object",
         "required": [
           "uri"
@@ -249,6 +261,7 @@
         "properties": {
           "child": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+            "description": null,
             "example": null
           },
           "list": {
@@ -267,6 +280,7 @@
                 "uri": "foobar"
               }
             ],
+            "description": null,
             "type": "array"
           },
           "nestedList": {
@@ -294,10 +308,12 @@
                 }
               ]
             ],
+            "description": null,
             "type": "array"
           },
           "nullableChild": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+            "description": null,
             "example": null
           },
           "stringList": {
@@ -312,6 +328,7 @@
               "hello",
               "goodbye"
             ],
+            "description": null,
             "type": "array"
           },
           "anyList": {
@@ -350,10 +367,12 @@
                 }
               ]
             ],
+            "description": null,
             "type": "array"
           },
           "enumVal": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.Foo",
+            "description": null,
             "example": null
           }
         },
@@ -400,6 +419,7 @@
           ],
           "enumVal": "value2"
         },
+        "description": null,
         "type": "object",
         "required": [
           "anyList",
@@ -418,6 +438,7 @@
           "value1",
           "value2"
         ],
+        "description": null,
         "type": "string"
       }
     },
@@ -484,6 +505,7 @@
                 "enumVal": "value2"
               }
             ],
+            "description": null,
             "type": "array"
           }
         },
@@ -537,6 +559,7 @@
             }
           ]
         },
+        "description": null,
         "type": "object",
         "required": [
           "value"

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for recursive objects.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for recursive objects.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.RecursiveObject",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -22,6 +23,7 @@
                 ]
               }
             ],
+            "description": null,
             "type": "array"
           }
         },
@@ -33,6 +35,7 @@
             }
           ]
         },
+        "description": null,
         "type": "object",
         "required": [
           "children"

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for top level generic list.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for top level generic list.approved
@@ -58,6 +58,7 @@
         "uri": "foobar"
       }
     ],
+    "description": null,
     "type": "array"
   },
   "definitions": [
@@ -67,6 +68,7 @@
         "properties": {
           "child": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+            "description": null,
             "example": null
           },
           "list": {
@@ -85,6 +87,7 @@
                 "uri": "foobar"
               }
             ],
+            "description": null,
             "type": "array"
           },
           "nestedList": {
@@ -112,10 +115,12 @@
                 }
               ]
             ],
+            "description": null,
             "type": "array"
           },
           "nullableChild": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+            "description": null,
             "example": null
           },
           "stringList": {
@@ -130,6 +135,7 @@
               "hello",
               "goodbye"
             ],
+            "description": null,
             "type": "array"
           },
           "anyList": {
@@ -168,10 +174,12 @@
                 }
               ]
             ],
+            "description": null,
             "type": "array"
           },
           "enumVal": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.Foo",
+            "description": null,
             "example": null
           }
         },
@@ -218,6 +226,7 @@
           ],
           "enumVal": "value2"
         },
+        "description": null,
         "type": "object",
         "required": [
           "anyList",
@@ -234,12 +243,14 @@
         "properties": {
           "uri": {
             "example": "foobar",
+            "description": null,
             "type": "string"
           }
         },
         "example": {
           "uri": "foobar"
         },
+        "description": null,
         "type": "object",
         "required": [
           "uri"
@@ -254,6 +265,7 @@
           "value1",
           "value2"
         ],
+        "description": null,
         "type": "string"
       }
     }

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for top level list.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for top level list.approved
@@ -52,6 +52,7 @@
         "enumVal": "value2"
       }
     ],
+    "description": null,
     "type": "array"
   },
   "definitions": [
@@ -61,6 +62,7 @@
         "properties": {
           "child": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+            "description": null,
             "example": null
           },
           "list": {
@@ -79,6 +81,7 @@
                 "uri": "foobar"
               }
             ],
+            "description": null,
             "type": "array"
           },
           "nestedList": {
@@ -106,10 +109,12 @@
                 }
               ]
             ],
+            "description": null,
             "type": "array"
           },
           "nullableChild": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.ArbObject2",
+            "description": null,
             "example": null
           },
           "stringList": {
@@ -124,6 +129,7 @@
               "hello",
               "goodbye"
             ],
+            "description": null,
             "type": "array"
           },
           "anyList": {
@@ -162,10 +168,12 @@
                 }
               ]
             ],
+            "description": null,
             "type": "array"
           },
           "enumVal": {
             "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.Foo",
+            "description": null,
             "example": null
           }
         },
@@ -212,6 +220,7 @@
           ],
           "enumVal": "value2"
         },
+        "description": null,
         "type": "object",
         "required": [
           "anyList",
@@ -228,12 +237,14 @@
         "properties": {
           "uri": {
             "example": "foobar",
+            "description": null,
             "type": "string"
           }
         },
         "example": {
           "uri": "foobar"
         },
+        "description": null,
         "type": "object",
         "required": [
           "uri"
@@ -248,6 +259,7 @@
           "value1",
           "value2"
         ],
+        "description": null,
         "type": "string"
       }
     }

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for various json primitives.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for various json primitives.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.JsonPrimitives",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -10,34 +11,42 @@
         "properties": {
           "string": {
             "example": "string",
+            "description": null,
             "type": "string"
           },
           "boolean": {
             "example": false,
+            "description": null,
             "type": "boolean"
           },
           "int": {
             "example": 2147483647,
+            "description": null,
             "type": "number"
           },
           "long": {
             "example": -9223372036854775808,
+            "description": null,
             "type": "number"
           },
           "double": {
             "example": 9.9999999999,
+            "description": null,
             "type": "number"
           },
           "float": {
             "example": -10.0,
+            "description": null,
             "type": "number"
           },
           "bigInt": {
             "example": 92233720368547758079223372036854775807,
+            "description": null,
             "type": "number"
           },
           "bigDecimal": {
             "example": 1.7976931348623157E+308111,
+            "description": null,
             "type": "number"
           }
         },
@@ -51,6 +60,7 @@
           "bigInt": 92233720368547758079223372036854775807,
           "bigDecimal": 1.7976931348623157E+308111
         },
+        "description": null,
         "type": "object",
         "required": [
           "bigDecimal",

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for when cannot find entry.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/AutoJsonToJsonSchemaTest.renders schema for when cannot find entry.approved
@@ -1,6 +1,7 @@
 {
   "node": {
     "$ref": "#/customPrefix/org.http4k.contract.openapi.v3.JacksonFieldAnnotated",
+    "description": null,
     "example": null
   },
   "definitions": [
@@ -10,12 +11,14 @@
         "properties": {
           "OTHERNAME": {
             "example": "foobar",
+            "description": null,
             "type": "string"
           }
         },
         "example": {
           "OTHERNAME": "foobar"
         },
+        "description": null,
         "type": "object",
         "required": [
           "OTHERNAME"

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
@@ -100,17 +100,20 @@
                   "properties": {
                     "foo": {
                       "example": 123,
+                      "description": null,
                       "type": "number"
                     }
                   },
                   "example": {
                     "foo": 123
                   },
+                  "description": null,
                   "type": "object",
                   "required": [
                     "foo"
                   ]
                 },
+                "description": null,
                 "example": null,
                 "type": "object"
               }
@@ -154,6 +157,7 @@
               },
               "schema": {
                 "$ref": "#/components/schemas/someOtherId",
+                "description": null,
                 "example": null
               }
             }
@@ -190,6 +194,7 @@
               },
               "schema": {
                 "$ref": "#/components/schemas/ArbObject3",
+                "description": null,
                 "example": null
               }
             }
@@ -219,6 +224,7 @@
                       "anotherString": "bing"
                     }
                   ],
+                  "description": null,
                   "type": "array"
                 }
               }
@@ -251,10 +257,12 @@
                 "oneOf": [
                   {
                     "$ref": "#/components/schemas/ArbObject1",
+                    "description": null,
                     "example": null
                   },
                   {
                     "$ref": "#/components/schemas/ArbObject3",
+                    "description": null,
                     "example": null
                   }
                 ]
@@ -294,6 +302,7 @@
                 },
                 "schema": {
                   "$ref": "#/components/schemas/ArbObject1",
+                  "description": null,
                   "example": null
                 }
               }
@@ -307,10 +316,12 @@
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/ArbObject1",
+                      "description": null,
                       "example": null
                     },
                     {
                       "$ref": "#/components/schemas/ArbObject3",
+                      "description": null,
                       "example": null
                     }
                   ]
@@ -347,10 +358,12 @@
                   "oneOf": [
                     {
                       "$ref": "#/components/schemas/impl1",
+                      "description": null,
                       "example": null
                     },
                     {
                       "$ref": "#/components/schemas/impl2",
+                      "description": null,
                       "example": null
                     }
                   ]
@@ -1015,10 +1028,12 @@
         "properties": {
           "string": {
             "example": "s",
+            "description": null,
             "type": "string"
           },
           "child": {
             "$ref": "#/components/schemas/ArbObject1",
+            "description": null,
             "example": null
           },
           "numbers": {
@@ -1032,10 +1047,12 @@
             "example": [
               1
             ],
+            "description": null,
             "type": "array"
           },
           "bool": {
             "example": true,
+            "description": null,
             "type": "boolean"
           }
         },
@@ -1049,6 +1066,7 @@
           ],
           "bool": true
         },
+        "description": null,
         "type": "object",
         "required": [
           "bool",
@@ -1060,12 +1078,14 @@
         "properties": {
           "anotherString": {
             "$ref": "#/components/schemas/Foo",
+            "description": null,
             "example": null
           }
         },
         "example": {
           "anotherString": "bing"
         },
+        "description": null,
         "type": "object",
         "required": [
           "anotherString"
@@ -1077,12 +1097,14 @@
           "bar",
           "bing"
         ],
+        "description": null,
         "type": "string"
       },
       "ArbObject3": {
         "properties": {
           "uri": {
             "example": "http://foowang",
+            "description": null,
             "type": "string"
           },
           "additional": {
@@ -1090,17 +1112,20 @@
               "properties": {
                 "foo": {
                   "example": 123,
+                  "description": null,
                   "type": "number"
                 }
               },
               "example": {
                 "foo": 123
               },
+              "description": null,
               "type": "object",
               "required": [
                 "foo"
               ]
             },
+            "description": null,
             "example": null,
             "type": "object"
           }
@@ -1111,6 +1136,7 @@
             "foo": 123
           }
         },
+        "description": null,
         "type": "object",
         "required": [
           "additional",
@@ -1121,6 +1147,7 @@
         "properties": {
           "obj": {
             "$ref": "#/components/schemas/Impl1",
+            "description": null,
             "example": null
           }
         },
@@ -1129,6 +1156,7 @@
             "value": "bob"
           }
         },
+        "description": null,
         "type": "object",
         "required": [
           "obj"
@@ -1138,12 +1166,14 @@
         "properties": {
           "value": {
             "example": "bob",
+            "description": null,
             "type": "string"
           }
         },
         "example": {
           "value": "bob"
         },
+        "description": null,
         "type": "object",
         "required": [
           "value"
@@ -1153,6 +1183,7 @@
         "properties": {
           "obj": {
             "$ref": "#/components/schemas/Impl2",
+            "description": null,
             "example": null
           }
         },
@@ -1161,6 +1192,7 @@
             "value": 123
           }
         },
+        "description": null,
         "type": "object",
         "required": [
           "obj"
@@ -1170,12 +1202,14 @@
         "properties": {
           "value": {
             "example": 123,
+            "description": null,
             "type": "number"
           }
         },
         "example": {
           "value": 123
         },
+        "description": null,
         "type": "object",
         "required": [
           "value"


### PR DESCRIPTION
Description can be added by annotating the class field with `@JsonPropertyDescription`. Fixes https://github.com/http4k/http4k/issues/464