### PR TITLE
Documentation: permalink added at the end of pages titles

### DIFF
--- a/src/docs/css/main.css
+++ b/src/docs/css/main.css
@@ -104,6 +104,16 @@ h4,
   font-weight: 700;
 }
 
+.headerlink {
+    font-size: 1.5rem;
+    display: none;
+    padding-left: .3em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}
+
 p {
   opacity: 0.8;
   font-size: 1.2rem;

--- a/src/mkdocs.yml
+++ b/src/mkdocs.yml
@@ -18,6 +18,9 @@ google_analytics: ['UA-125143867-1', 'auto']
 markdown_extensions:
   - meta
   - codehilite
+  - toc:
+      permalink: True
+      separator: "_"
 extra_css:
   - ./css/site.css
 extra:


### PR DESCRIPTION
Why:
I find usefull to be able to give someone a precise link to a specific part of a page of the documentation.

What:
The modifcation adds a ¶ at the end of pages' titles when the mouse is over it that is a link to that specific title.

How:
I activated the mkdocs toc/permalinks extenesion and added some css.

Result:
![image](https://user-images.githubusercontent.com/745873/96793875-737a9880-13fd-11eb-9ef3-ce25e575c4c1.png)
