### PR TITLE
Markdown content type

### DIFF
--- a/http4k-core/src/main/resources/META-INF/org/http4k/core/mime.types
+++ b/http4k-core/src/main/resources/META-INF/org/http4k/core/mime.types
@@ -675,6 +675,7 @@ text/calendar					ics ifb
 text/css					css
 text/csv					csv
 text/html					html htm HTML HTM
+text/markdown				md markdown MD MARKDOWN
 text/n3						n3
 text/plain					txt text conf def list log in TXT TEXT
 text/prs.lines.tag				dsc

--- a/http4k-core/src/main/resources/META-INF/org/http4k/core/mime.types
+++ b/http4k-core/src/main/resources/META-INF/org/http4k/core/mime.types
@@ -675,7 +675,7 @@ text/calendar					ics ifb
 text/css					css
 text/csv					csv
 text/html					html htm HTML HTM
-text/markdown				md markdown MD MARKDOWN
+text/markdown				md markdown
 text/n3						n3
 text/plain					txt text conf def list log in TXT TEXT
 text/prs.lines.tag				dsc


### PR DESCRIPTION
No big deal but realised afterwards that there's no need for the uppercase version as in code is done a toLowerCase.