### PR TITLE
fix: css for hiding headers link when mouse not over it

### DIFF
--- a/src/docs/css/site.css
+++ b/src/docs/css/site.css
@@ -56,3 +56,13 @@ ul.statusLink li {
     margin: 4px 2px;
     border-radius: 5px;
 }
+
+.headerlink {
+    font-size: 1.5rem;
+    display: none;
+    padding-left: .3em;
+}
+
+h1:hover .headerlink, h2:hover .headerlink, h3:hover .headerlink, h4:hover .headerlink, h5:hover .headerlink, h6:hover .headerlink{
+    display:inline-block;
+}


### PR DESCRIPTION
On the first PR I added these css in the main.css that was overridden. 
In fact I guess it was not the right place to put them, site.css seems more adequate.

Now the ending ¶ at the end of titles will no longer be visible if the mouse is not over the title.