### PR TITLE
Start ApacheAsyncClient by default if not started yet

### DIFF
--- a/http4k-client/apache-async/src/main/kotlin/org/http4k/client/ApacheAsyncClient.kt
+++ b/http4k-client/apache-async/src/main/kotlin/org/http4k/client/ApacheAsyncClient.kt
@@ -11,6 +11,7 @@ import org.apache.hc.core5.concurrent.FutureCallback
 import org.apache.hc.core5.http.ContentType
 import org.apache.hc.core5.http.Header
 import org.apache.hc.core5.http.HttpResponse
+import org.apache.hc.core5.reactor.IOReactorStatus.INACTIVE
 import org.http4k.core.Body
 import org.http4k.core.Headers
 import org.http4k.core.Request
@@ -23,7 +24,10 @@ import java.net.SocketTimeoutException
 
 object ApacheAsyncClient {
     operator fun invoke(
-        client: CloseableHttpAsyncClient = defaultApacheAsyncHttpClient()): AsyncHttpClient {
+        client: CloseableHttpAsyncClient = defaultApacheAsyncHttpClient()
+    ): AsyncHttpClient {
+        if (client.status == INACTIVE) client.start()
+
         return object : AsyncHttpClient {
             override fun close() = client.close()
 

--- a/http4k-client/apache-async/src/test/kotlin/org/http4k/client/ApacheAsyncClientTest.kt
+++ b/http4k-client/apache-async/src/test/kotlin/org/http4k/client/ApacheAsyncClientTest.kt
@@ -31,7 +31,7 @@ class ApacheAsyncClientTest : AsyncHttpClientContract({ SunHttp(it) }, ApacheAsy
     ApacheAsyncClient(HttpAsyncClients.custom()
         .setIOReactorConfig(IOReactorConfig.custom()
             .setSoTimeout(100, TimeUnit.MILLISECONDS)
-            .build()).build().apply { start() })) {
+            .build()).build())) {
     @Test
     fun `connect timeout is handled`() {
 


### PR DESCRIPTION
I noticed that the `ApacheAsyncClient` requires a different kind of initialisation compared to the `Apache4AsyncClient`. Before supplying a client to the constructor of the ApacheAsyncClient it needs to be started with the function `client.start()`. This additional call is however not needed when using the `Apache4AsyncClient`.

Although it not a big deal to call the additional start method, but it just caught my attention and that the configuration is not similar. I analysed the source code and discovered that the `Apache4AsyncClient` calls internally `if (!client.isRunning) client.start()` on line number 34. This part is missing within the `ApacheAsyncClient`, but it is easy to include.