### PR TITLE
Fixed wrong swagger.json path (cookbook)

### DIFF
--- a/src/docs/cookbook/typesafe_http_contracts/index.md
+++ b/src/docs/cookbook/typesafe_http_contracts/index.md
@@ -6,7 +6,7 @@ This contract example shows:
 - 2 endpoints with typesafe contracts (marshalling of path parameters and bodies)
 - Custom filters (reporting latency)
 - API key security via a typesafe Query parameter (this can be a header or a body parameter as well)
-- OpenApi v3 documentation - Run this example and point a browser [here](https://http4k.org/openapi3?url=http://localhost:8000/context/swagger.json)
+- OpenApi v3 documentation - Run this example and point a browser [here](https://http4k.org/openapi3?url=http://localhost:8000/context/docs/swagger.json)
 
 ### Gradle setup
 

--- a/src/docs/cookbook/typesafe_http_contracts/index.md
+++ b/src/docs/cookbook/typesafe_http_contracts/index.md
@@ -6,7 +6,7 @@ This contract example shows:
 - 2 endpoints with typesafe contracts (marshalling of path parameters and bodies)
 - Custom filters (reporting latency)
 - API key security via a typesafe Query parameter (this can be a header or a body parameter as well)
-- OpenApi v3 documentation - Run this example and point a browser [here](https://http4k.org/openapi3?url=http://localhost:8000/context/docs/swagger.json)
+- OpenApi v3 documentation - Run this example and point a browser [here](https://http4k.org/openapi3?url=http%3A%2F%2Flocalhost%3A8000%2Fcontext%2Fdocs%2Fswagger.json)
 
 ### Gradle setup
 


### PR DESCRIPTION
see 

```
val contract = contract {
        renderer = OpenApi3(ApiInfo("my great api", "v1.0"), Jackson)
        descriptionPath = "/docs/swagger.json"
```