### PR TITLE
AccessTokenFetcher initializes all AccessToken fields.

### DIFF
--- a/http4k-security-oauth/src/main/kotlin/org/http4k/security/AccessTokenFetcher.kt
+++ b/http4k-security-oauth/src/main/kotlin/org/http4k/security/AccessTokenFetcher.kt
@@ -51,7 +51,7 @@ class AccessTokenFetcher(
                 ?.let {
                     when {
                         APPLICATION_JSON.equalsIgnoringDirectives(it) -> with(accessTokenResponseBody(msg)) {
-                            AccessTokenDetails(AccessToken(accessToken), idToken?.let(::IdToken))
+                            AccessTokenDetails(toAccessToken(), idToken?.let(::IdToken))
                         }
                         APPLICATION_FORM_URLENCODED.equalsIgnoringDirectives(it) -> responseForm(msg)
                         else -> null
@@ -61,6 +61,15 @@ class AccessTokenFetcher(
 
     private fun Request.authenticate(accessTokenFetcherAuthenticator: AccessTokenFetcherAuthenticator): Request =
         accessTokenFetcherAuthenticator.authenticate(this)
+
+    private fun AccessTokenResponse.toAccessToken(): AccessToken =
+        AccessToken(
+            accessToken,
+            type = tokenType ?: "Bearer",
+            expiresIn = expiresIn,
+            scope = scope,
+            refreshToken = refreshToken?.let(::RefreshToken)
+        )
 
     companion object {
         object Forms {

--- a/http4k-security-oauth/src/test/kotlin/org/http4k/security/AccessTokenFetcherTest.kt
+++ b/http4k-security-oauth/src/test/kotlin/org/http4k/security/AccessTokenFetcherTest.kt
@@ -31,11 +31,27 @@ internal class AccessTokenFetcherTest {
     @Test
     fun `can get access token from json body`() {
         //see https://tools.ietf.org/html/rfc6749#section-4.1.4
-        val api = { _: Request -> Response(OK).with(accessTokenResponseBody of AccessTokenResponse("some-access-token")) }
+        val token = AccessToken(
+            value = "some-access-token",
+            type = "Bearer",
+            expiresIn = 42,
+            scope = "all, the, scopes",
+            refreshToken = RefreshToken("some-refresh-token")
+        )
+
+        val response = AccessTokenResponse(
+            accessToken = token.value,
+            tokenType = token.type,
+            expiresIn = token.expiresIn,
+            scope = token.scope,
+            refreshToken = token.refreshToken?.value,
+        )
+
+        val api = { _: Request -> Response(OK).with(accessTokenResponseBody of response) }
 
         val fetcher = AccessTokenFetcher(api, Uri.of("irrelevant"), config, accessTokenFetcherAuthenticator)
 
-        assertThat(fetcher.fetch("some-code"), equalTo(AccessTokenDetails(AccessToken("some-access-token"))))
+        assertThat(fetcher.fetch("some-code"), equalTo(AccessTokenDetails(token)))
     }
 
     @Test


### PR DESCRIPTION
We were ignoring fields like the refresh token.