### PR TITLE
See_Other (303) is a special case of redirection.

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ClientFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ClientFilters.kt
@@ -1,6 +1,7 @@
 package org.http4k.filter
 
 import org.http4k.base64Encode
+import org.http4k.core.Body.Companion.EMPTY
 import org.http4k.core.Credentials
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
@@ -8,6 +9,7 @@ import org.http4k.core.Method.GET
 import org.http4k.core.Method.HEAD
 import org.http4k.core.Request
 import org.http4k.core.Response
+import org.http4k.core.Status.Companion.SEE_OTHER
 import org.http4k.core.Uri
 import org.http4k.core.cookie.cookie
 import org.http4k.core.cookie.cookies
@@ -118,7 +120,11 @@ object ClientFilters {
                 if (it.isRedirection()) {
                     if (attempt == 10) throw IllegalStateException("Too many redirection")
                     it.assureBodyIsConsumed()
-                    makeRequest(next, request.toNewLocation(it.location()), attempt + 1)
+                    if (it.status == SEE_OTHER) {
+                        makeRequest(next, request.body(EMPTY).toNewLocation(it.location()), attempt + 1)
+                    } else {
+                        makeRequest(next, request.toNewLocation(it.location()), attempt + 1)
+                    }
                 } else it
             }
 

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ClientFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ClientFiltersTest.kt
@@ -7,6 +7,7 @@ import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.isA
 import com.natpryce.hamkrest.present
 import org.http4k.core.Body
+import org.http4k.core.Body.Companion.EMPTY
 import org.http4k.core.Credentials
 import org.http4k.core.MemoryRequest
 import org.http4k.core.MemoryResponse
@@ -58,7 +59,9 @@ class ClientFiltersTest {
 
     @Test
     fun `see other redirect doesn't forward any payload`() {
-        assertThat(followRedirects(Request(GET, "/see-other").body("body here")), equalTo(Response(OK)))
+        val response = followRedirects(Request(GET, "/see-other").body("body here"))
+        assertThat(response.status, equalTo(OK))
+        assertThat(response.body, equalTo(EMPTY))
     }
 
     @Test
@@ -219,20 +222,20 @@ class ClientFiltersTest {
         @Test
         fun `in-memory empty bodies are not encoded`() {
             val handler = ClientFilters.GZip().then {
-                assertThat(it, hasBody(equalTo<Body>(Body.EMPTY)).and(!hasHeader("content-encoding", "gzip")))
-                Response(OK).body(Body.EMPTY)
+                assertThat(it, hasBody(equalTo<Body>(EMPTY)).and(!hasHeader("content-encoding", "gzip")))
+                Response(OK).body(EMPTY)
             }
 
-            assertThat(handler(Request(GET, "/").body(Body.EMPTY)), hasStatus(OK))
+            assertThat(handler(Request(GET, "/").body(EMPTY)), hasStatus(OK))
         }
 
         @Test
         fun `in-memory encoded empty responses are handled`() {
             val handler = ClientFilters.GZip().then {
-                Response(OK).header("content-encoding", "gzip").body(Body.EMPTY)
+                Response(OK).header("content-encoding", "gzip").body(EMPTY)
             }
 
-            assertThat(handler(Request(GET, "/").body(Body.EMPTY)), hasStatus(OK))
+            assertThat(handler(Request(GET, "/").body(EMPTY)), hasStatus(OK))
         }
 
         @Test
@@ -248,20 +251,20 @@ class ClientFiltersTest {
         @Test
         fun `streaming empty bodies are not encoded`() {
             val handler = ClientFilters.GZip(Streaming).then {
-                assertThat(it, hasBody(equalTo<Body>(Body.EMPTY)).and(!hasHeader("content-encoding", "gzip")))
-                Response(OK).body(Body.EMPTY)
+                assertThat(it, hasBody(equalTo<Body>(EMPTY)).and(!hasHeader("content-encoding", "gzip")))
+                Response(OK).body(EMPTY)
             }
 
-            assertThat(handler(Request(GET, "/").body(Body.EMPTY)), hasStatus(OK))
+            assertThat(handler(Request(GET, "/").body(EMPTY)), hasStatus(OK))
         }
 
         @Test
         fun `streaming encoded empty responses are handled`() {
             val handler = ClientFilters.GZip(Streaming).then {
-                Response(OK).header("content-encoding", "gzip").body(Body.EMPTY)
+                Response(OK).header("content-encoding", "gzip").body(EMPTY)
             }
 
-            assertThat(handler(Request(GET, "/").body(Body.EMPTY)), hasStatus(OK))
+            assertThat(handler(Request(GET, "/").body(EMPTY)), hasStatus(OK))
         }
 
         @Test
@@ -300,16 +303,16 @@ class ClientFiltersTest {
         @Test
         fun `in-memory encoded empty responses are handled`() {
             val handler = ClientFilters.AcceptGZip().then {
-                Response(OK).header("content-encoding", "gzip").body(Body.EMPTY)
+                Response(OK).header("content-encoding", "gzip").body(EMPTY)
             }
 
-            assertThat(handler(Request(GET, "/").body(Body.EMPTY)), hasStatus(OK).and(hasBody("")))
+            assertThat(handler(Request(GET, "/").body(EMPTY)), hasStatus(OK).and(hasBody("")))
         }
 
         @Test
         fun `streaming encoded empty responses are handled`() {
             val handler = ClientFilters.AcceptGZip(Streaming).then {
-                Response(OK).header("content-encoding", "gzip").body(Body.EMPTY)
+                Response(OK).header("content-encoding", "gzip").body(EMPTY)
             }
 
             assertThat(handler(Request(GET, "/")), hasStatus(OK).and(hasBody("")))


### PR DESCRIPTION
A special case of redirection should be taken into account for See_Other (303).
See_Other should be followed by a GET and as per RFC a GET with body has no defined semantics. See below:

https://tools.ietf.org/html/rfc7231#page-24
_A payload within a GET request message has no defined semantics;
sending a payload body on a GET request might cause some existing
implementations to reject the request._

This PR intends to strips out payload coming from a POST requests that is followed by a GET
