### PR TITLE
#541 Generate javax.validation schema for annotated data classes^2

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/AutoJsonToJsonSchema.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/AutoJsonToJsonSchema.kt
@@ -1,5 +1,6 @@
 package org.http4k.contract.openapi.v3
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter
 import org.http4k.format.AutoMarshallingJson
 import org.http4k.format.JsonType
 import org.http4k.lens.ParamMeta
@@ -205,6 +206,9 @@ private sealed class SchemaNode(
     abstract fun arrayItem(): ArrayItem
 
     val description = metadata?.description
+
+    @get:JsonAnyGetter
+    val extra: Map<String, Any>? = metadata?.extra
 
     class Primitive(name: String, paramMeta: ParamMeta, isNullable: Boolean, example: Any?, metadata: FieldMetadata?) :
         SchemaNode(name, paramMeta, isNullable, example, metadata) {

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/jacksonExt.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/jacksonExt.kt
@@ -68,7 +68,7 @@ object JacksonFieldMetadataRetrievalStrategy : FieldMetadataRetrievalStrategy {
     override fun invoke(target: Any, fieldName: String): FieldMetadata =
         FieldMetadata(description = target.javaClass.findPropertyDescription(fieldName))
 
-    private fun Class<Any>.findPropertyDescription(name: String): String? =
+    fun Class<Any>.findPropertyDescription(name: String): String? =
         kotlin.constructors.first().parameters
             .firstOrNull { p -> p.kind == KParameter.Kind.VALUE && p.name == name }
             ?.let { p ->

--- a/http4k-javax-validation/build.gradle
+++ b/http4k-javax-validation/build.gradle
@@ -1,0 +1,13 @@
+description = 'Http4k javax-validation support'
+
+dependencies {
+    api project(":http4k-core")
+    api project(":http4k-server-jetty")
+    api project(":http4k-contract")
+    api project(":http4k-format-jackson")
+
+    implementation "javax.validation:validation-api:2.0.1.Final"
+    implementation "io.swagger.core.v3:swagger-annotations:2.1.7"
+    testImplementation project(path: ":http4k-core", configuration: 'testArtifacts')
+    testImplementation Config.TestDependencies
+}

--- a/http4k-javax-validation/build.gradle
+++ b/http4k-javax-validation/build.gradle
@@ -2,9 +2,11 @@ description = 'Http4k javax-validation support'
 
 dependencies {
     api project(":http4k-core")
-    api project(":http4k-server-jetty")
     api project(":http4k-contract")
     api project(":http4k-format-jackson")
+
+    // TODO remove with demo
+    api project(":http4k-server-jetty")
 
     implementation "javax.validation:validation-api:2.0.1.Final"
     implementation "io.swagger.core.v3:swagger-annotations:2.1.7"

--- a/http4k-javax-validation/src/main/kotlin/org/http4k/javaxvalidation/JavaXValidationFieldRetrievalStrategy.kt
+++ b/http4k-javax-validation/src/main/kotlin/org/http4k/javaxvalidation/JavaXValidationFieldRetrievalStrategy.kt
@@ -1,0 +1,48 @@
+package org.http4k.javaxvalidation
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import io.swagger.v3.oas.annotations.media.Schema
+import org.http4k.contract.openapi.v3.FieldMetadata
+import org.http4k.contract.openapi.v3.FieldMetadataRetrievalStrategy
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+import kotlin.reflect.KCallable
+import kotlin.reflect.KClass
+import kotlin.reflect.KParameter
+import kotlin.reflect.KProperty
+import kotlin.reflect.jvm.javaGetter
+
+object JavaXValidationFieldRetrievalStrategy : FieldMetadataRetrievalStrategy {
+    override fun invoke(target: Any, fieldName: String): FieldMetadata =
+        FieldMetadata(
+            description = target.javaClass.findPropertyDescription(fieldName),
+            extra = extractJavaXValidationAnnotationMetadata(target::class, fieldName),
+        )
+
+    private fun Class<Any>.findPropertyDescription(name: String): String? =
+        kotlin.constructors.first().parameters
+            .firstOrNull { p -> p.kind == KParameter.Kind.VALUE && p.name == name }
+            ?.let { p ->
+                // Note that http4k expects the description to be given with @JsonPropertyDescription,
+                // which is NOT compatible with SpringDoc generating OpenApi3 docs. We need to use
+                // Swagger3/Schema to be compatible.
+                p.annotations.filterIsInstance<JsonPropertyDescription>().firstOrNull()?.value
+                    ?: p.annotations.filterIsInstance<Schema>().firstOrNull()?.description
+            } ?: superclass?.findPropertyDescription(name)
+
+    private inline fun <reified T : Annotation> KCallable<*>.findGetterAnnotation(): T? =
+        (this as KProperty<*>).javaGetter!!.annotations.find { it.annotationClass == T::class } as T?
+
+    private fun extractJavaXValidationAnnotationMetadata(kClass: KClass<out Any>, name: String): Map<String, Any> {
+        val field: KCallable<*> = kClass.members.find { it.name == name }!!
+        return mapOf(
+            "minLength" to field.findGetterAnnotation<Size>()?.min,
+            "maxLength" to field.findGetterAnnotation<Size>()?.max,
+            "min" to field.findGetterAnnotation<Min>()?.value,
+            "max" to field.findGetterAnnotation<Max>()?.value,
+            "pattern" to field.findGetterAnnotation<Pattern>()?.regexp,
+        ).filter { it.value != null } as Map<String, Any>
+    }
+}

--- a/http4k-javax-validation/src/main/kotlin/org/http4k/javaxvalidation/OpenApiDemo.kt
+++ b/http4k-javax-validation/src/main/kotlin/org/http4k/javaxvalidation/OpenApiDemo.kt
@@ -1,0 +1,87 @@
+package org.http4k.javaxvalidation
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import io.swagger.v3.oas.annotations.media.Schema
+import org.http4k.contract.ContractRoute
+import org.http4k.contract.contract
+import org.http4k.contract.meta
+import org.http4k.contract.openapi.ApiInfo
+import org.http4k.contract.openapi.ApiRenderer
+import org.http4k.contract.openapi.v3.AutoJsonToJsonSchema
+import org.http4k.contract.openapi.v3.FieldRetrieval
+import org.http4k.contract.openapi.v3.OpenApi3
+import org.http4k.contract.openapi.v3.SimpleLookup
+import org.http4k.core.Body
+import org.http4k.core.Method
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.format.Jackson
+import org.http4k.format.Jackson.auto
+import org.http4k.routing.ResourceLoader
+import org.http4k.routing.bind
+import org.http4k.routing.routes
+import org.http4k.routing.static
+import org.http4k.routing.webJars
+import org.http4k.server.Jetty
+import org.http4k.server.asServer
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+
+// https://gitlab.com/gooutnet/backend/uploads/cc83a4874817194b05d844e61748fef4/Screenshot_2020-12-22_at_12.43.24.png
+// https://gitlab.com/gooutnet/issuetracker/-/merge_requests/15337/diffs
+fun main() {
+    val API_DESCRIPTION_PATH = "/v3/api-docs"
+    routes(
+        routes(
+            "/docs" bind Method.GET to {
+                Response(Status.FOUND).header("Location", "/docs/index.html?url=$API_DESCRIPTION_PATH")
+            },
+            "/docs" bind static(ResourceLoader.Classpath("META-INF/resources/webjars/swagger-ui/3.44.0")),
+            webJars()
+        ),
+        contract {
+            renderer = OpenApi3(
+                ApiInfo("GoOut Locations API", "1.0"),
+                Jackson,
+                listOf(),
+                ApiRenderer.Auto(
+                    Jackson,
+                    AutoJsonToJsonSchema(
+                        Jackson,
+                        FieldRetrieval.compose(
+                            SimpleLookup(metadataRetrievalStrategy = JavaXValidationFieldRetrievalStrategy),
+                        ),
+                    )
+                )
+            )
+            descriptionPath = API_DESCRIPTION_PATH
+            routes += demo()
+        }
+    )
+        .asServer(Jetty(8080))
+        .start()
+        .block()
+}
+
+data class DemoBody(
+    @Schema(description = "Name of the entity.")
+    @get:Size(min = 0, max = 64)
+    val name: String,
+    @get:Size(min = 0, max = 512)
+    val bio: String,
+    @get:Size(min = 2, max = 32)
+    val path: String,
+    @get:Min(30)
+    @get:Max(50)
+    val num: Int,
+    @get:Pattern(regexp = "[a-z]+@[a-z+.]")
+    val email: String,
+)
+
+val bodyLens = Body.auto<DemoBody>().toLens()
+
+fun demo(): ContractRoute = "/demo" meta {
+    receiving(bodyLens to DemoBody("Foo", "Bar", "path", 40, "foo@bar.cz"))
+} bindContract Method.POST to { request -> Response(Status.OK) }

--- a/http4k-javax-validation/src/test/kotlin/org/http4k/javaxvalidation/JavaXValidationFieldRetrievalStrategyTest.kt
+++ b/http4k-javax-validation/src/test/kotlin/org/http4k/javaxvalidation/JavaXValidationFieldRetrievalStrategyTest.kt
@@ -1,0 +1,49 @@
+package org.http4k.javaxvalidation
+
+import com.fasterxml.jackson.annotation.JsonPropertyDescription
+import io.swagger.v3.oas.annotations.media.Schema
+import org.http4k.contract.openapi.v3.FieldMetadata
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
+import javax.validation.constraints.Pattern
+import javax.validation.constraints.Size
+
+internal class JavaXValidationFieldRetrievalStrategyTest {
+
+    @Test
+    fun testJacksonDescription() {
+        data class NameWithJacksonDescription(@JsonPropertyDescription("Just a description") val name: String)
+        val result = JavaXValidationFieldRetrievalStrategy.invoke(NameWithJacksonDescription("Jane Doe"), NameWithJacksonDescription::name.name)
+        assertEquals(FieldMetadata("Just a description", emptyMap()), result)
+    }
+
+    @Test
+    fun testSwagger3Description() {
+        data class NameWithSwagger3Description(@Schema(description = "Just a description") val name: String)
+        val result = JavaXValidationFieldRetrievalStrategy.invoke(NameWithSwagger3Description("Jane Doe"), NameWithSwagger3Description::name.name)
+        assertEquals(FieldMetadata("Just a description", emptyMap()), result)
+    }
+
+    @Test
+    fun testLength() {
+        data class NameWithSize(@get:Size(min = 2, max = 64) val name: String)
+        val result = JavaXValidationFieldRetrievalStrategy.invoke(NameWithSize("Jane Doe"), NameWithSize::name.name)
+        assertEquals(mapOf("minLength" to 2, "maxLength" to 64), result.extra)
+    }
+
+    @Test
+    fun testMinMaxNumber() {
+        data class IntBounded(@get:Min(30) @get:Max(50) val count: Int)
+        val result = JavaXValidationFieldRetrievalStrategy.invoke(IntBounded(40), IntBounded::count.name)
+        assertEquals(mapOf("min" to 30L, "max" to 50L), result.extra)
+    }
+
+    @Test
+    fun testPattern() {
+        data class StringWithPattern(@get:Pattern(regexp = "[a-z]+@[a-z+.]") val email: String)
+        val result = JavaXValidationFieldRetrievalStrategy.invoke(StringWithPattern("jane@doe.com"), StringWithPattern::email.name)
+        assertEquals(mapOf("pattern" to "[a-z]+@[a-z+.]"), result.extra)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -69,6 +69,7 @@ include("http4k-contract")
 }
 include("http4k-graphql")
 include("http4k-incubator")
+include("http4k-javax-validation")
 include("http4k-jsonrpc")
 include("http4k-metrics-micrometer")
 include("http4k-multipart")


### PR DESCRIPTION
This is a follow up MR for https://github.com/http4k/http4k/pull/564, please review by individual commits.

Based on @daviddenton's suggestion for FieldMetadataRetrieval, I refactored the previous code. Probably the only remaining issue is flattening the `SchemaNode.extra` so that its contents become directly part of the `SchemaNode`.

Now the resulting node looks like:

```json
"bio": {
   "example": "Bar",
   "description": null,
   "extra": {
        "minLength": 0,
        "maxLength": 512
    },
    "type": "string"
},
```

but to be compliant, it should look like:

```json
"bio": {
   "example": "Bar",
   "description": null,
   "minLength": 0,
   "maxLength": 512,
   "type": "string"
},
```

CC @goodhoko 