### PR TITLE
Added interfaces to allow extending RoutedRequest and RoutedResponse via delegates

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/HttpTransaction.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/HttpTransaction.kt
@@ -1,6 +1,7 @@
 package org.http4k.core
 
-import org.http4k.routing.RoutedRequest
+import org.http4k.routing.RequestWithRoute
+import org.http4k.routing.ResponseWithRoute
 import org.http4k.routing.RoutedResponse
 import java.time.Duration
 
@@ -9,8 +10,8 @@ data class HttpTransaction(
     val response: Response,
     val duration: Duration,
     val labels: Map<String, String> = when {
-        response is RoutedResponse -> mapOf(ROUTING_GROUP_LABEL to response.xUriTemplate.toString())
-        request is RoutedRequest -> mapOf(ROUTING_GROUP_LABEL to request.xUriTemplate.toString())
+        response is ResponseWithRoute -> mapOf(ROUTING_GROUP_LABEL to response.xUriTemplate.toString())
+        request is RequestWithRoute -> mapOf(ROUTING_GROUP_LABEL to request.xUriTemplate.toString())
         else -> emptyMap()
     }
 ) {

--- a/http4k-core/src/main/kotlin/org/http4k/routing/extensions.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/routing/extensions.kt
@@ -15,7 +15,7 @@ fun ((Request) -> Boolean).asRouter(): Router = object : Router {
 }
 
 fun Request.path(name: String): String? = when (this) {
-    is RoutedRequest -> xUriTemplate.extract(uri.path)[name]
+    is RequestWithRoute -> xUriTemplate.extract(uri.path)[name]
     else -> throw IllegalStateException("Request was not routed, so no uri-template present")
 }
 

--- a/http4k-core/src/main/kotlin/org/http4k/routing/messages.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/routing/messages.kt
@@ -9,7 +9,15 @@ import org.http4k.core.Uri
 import org.http4k.core.UriTemplate
 import java.io.InputStream
 
-data class RoutedRequest(private val delegate: Request, val xUriTemplate: UriTemplate) : Request by delegate {
+interface RequestWithRoute : Request {
+    val xUriTemplate: UriTemplate
+}
+
+interface ResponseWithRoute : Response {
+    val xUriTemplate: UriTemplate
+}
+
+data class RoutedRequest(private val delegate: Request, override val xUriTemplate: UriTemplate) : Request by delegate, RequestWithRoute {
     override fun equals(other: Any?): Boolean = delegate == other
 
     override fun hashCode(): Int = delegate.hashCode()
@@ -37,7 +45,7 @@ data class RoutedRequest(private val delegate: Request, val xUriTemplate: UriTem
     override fun body(body: InputStream, length: Long?): Request = RoutedRequest(delegate.body(body, length), xUriTemplate)
 }
 
-class RoutedResponse(private val delegate: Response, val xUriTemplate: UriTemplate) : Response by delegate {
+class RoutedResponse(private val delegate: Response, override val xUriTemplate: UriTemplate) : Response by delegate, ResponseWithRoute {
     override fun equals(other: Any?): Boolean = delegate == other
 
     override fun hashCode(): Int = delegate.hashCode()

--- a/http4k-core/src/test/kotlin/org/http4k/core/HttpTransactionTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/HttpTransactionTest.kt
@@ -4,6 +4,9 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.http4k.core.Method.GET
 import org.http4k.core.Status.Companion.OK
+import org.http4k.routing.RequestWithRoute
+import org.http4k.routing.ResponseWithRoute
+import org.http4k.routing.RoutedRequest
 import org.http4k.routing.RoutedResponse
 import org.junit.jupiter.api.Test
 import java.time.Duration.ZERO
@@ -19,5 +22,18 @@ class HttpTransactionTest {
     fun `can get the routing group from a RoutedResponse`() {
         val response = RoutedResponse(Response(OK), UriTemplate.from("hello"))
         assertThat(HttpTransaction(Request(GET, Uri.of("/")), response, ZERO).routingGroup, equalTo("hello"))
+    }
+
+    @Test
+    fun `can create with request and response extensions`() {
+        class ExtendedRequest(val delegate: RoutedRequest) : RequestWithRoute by delegate
+
+        class ExtendedResponse(val delegate: RoutedResponse) : ResponseWithRoute by delegate
+
+        val request = ExtendedRequest(RoutedRequest(Request(GET, "/the-path"), UriTemplate.from("request")))
+        assertThat(HttpTransaction(request, Response(OK), ZERO).labels, equalTo(mapOf("routingGroup" to "request")))
+
+        val response = ExtendedResponse(RoutedResponse(Response(OK, "/the-path"), UriTemplate.from("response")))
+        assertThat(HttpTransaction(request, response, ZERO).labels, equalTo(mapOf("routingGroup" to "response")))
     }
 }

--- a/http4k-core/src/test/kotlin/org/http4k/routing/RoutedMessageTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/routing/RoutedMessageTest.kt
@@ -1,6 +1,7 @@
 package org.http4k.routing
 
 import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.isA
 import org.http4k.core.Body
 import org.http4k.core.HttpMessage
@@ -9,12 +10,40 @@ import org.http4k.core.Method.POST
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.NOT_FOUND
+import org.http4k.core.Status.Companion.OK
 import org.http4k.core.Uri
 import org.http4k.core.UriTemplate.Companion.from
 import org.junit.jupiter.api.Test
 
 class RoutedMessageTest {
     private val template = from("an-uri-template")
+
+    @Test
+    fun `routed request can be extended`() {
+        class ExtendedRequest(val delegate: RoutedRequest) : RequestWithRoute by delegate {
+            override fun query(name: String, value: String?): ExtendedRequest =
+                ExtendedRequest(delegate.query(name, value) as RoutedRequest)
+        }
+
+        val request = ExtendedRequest(RoutedRequest(Request(GET, "/the-path"), from("/{pathParam}")))
+
+        assertThat(request.path("pathParam"), equalTo("the-path"))
+        assertThat(request.query("name","value"), isA<ExtendedRequest>())
+
+        checkMessageFields<RoutedRequest>(request)
+    }
+
+    @Test
+    fun `routed response can be extended`() {
+        class ExtendedResponse(val delegate: RoutedResponse) : ResponseWithRoute by delegate {
+            override fun header(name: String, value: String?): ExtendedResponse =
+                ExtendedResponse(delegate.header(name, value) as RoutedResponse)
+        }
+
+        val response = ExtendedResponse(RoutedResponse(Response(OK, "/the-path"), from("/{pathParam}")))
+
+        assertThat(response.header("name","value"), isA<ExtendedResponse>())
+    }
 
     @Test
     fun `request manipulations maintain the same type`() {


### PR DESCRIPTION
This PR adds interfaces `RequestWithRoute` and `ResponseWithRoute` to `RoutedRequest` and `RoutedResponse`. This allows extending the capabilities of the `RoutedRequest / RoutedResponse` via delegates such as:

```
class ExtendedRequest(val delegate: RoutedRequest) : RequestWithRoute by delegate {
  ...
}
```

Without these interfaces, extensions such as Request.path would fail to identify that such request is a wrapper around a RoutedRequest that supports path extraction.
