### PR TITLE
update "nestable routes" docs

### DIFF
--- a/src/docs/cookbook/nestable_routes/index.md
+++ b/src/docs/cookbook/nestable_routes/index.md
@@ -12,6 +12,31 @@ This is a fairly comprehensive example of the core-routing logic available:
 - Serving of static content using a `Classpath` resource loader
 - Support for Single Page Applications using a `singlePageApp()` block - resources loaded from here are loaded from the underlying `ResourceLoader` or fallback to `/` (and passed to the SPA code)
 
+### Dynamic Paths / Path Variables
+As you would expect, http4k allows routes to include dynamic or variable elements in the matching path, and allows you to reference the variable in the Handler. For example:
+```
+"/book/{title}" bind GET to { req -> Response.invoke(Status.OK).body(GetBookDetails(req.path("title")) }
+"/author/{name}/latest" bind GET to { req -> Response.invoke(Status.OK).body(GetAllBooks(author = req.path("name")).last()) }
+```
+
+By default, the variable(s) will match anything. However you can append the variable name with a RegEx expression to limit the matches.
+```
+// will match /book/978-3-16-148410-0 (i.e. only digits and dashes)
+// /book/A%20Confederacy%20Of%20Dunces would return a 404 (Not Found)
+"/book/{isbn:[\\d-]+}"
+
+// will NOT match /sales/south or /sales/usa
+"/sales/{region:(?:northeast|southeast|west|international)}" 
+```
+
+Unlike some frameworks, there are no pre-defined types such as `int` or `path` but these are easy to replicate with RegEx's:
+- string (excluding slashes) : `[^\\/]+` (note that Kotlin requires backslashes to be escaped, so `\w` in RegEx is expressed as `\\w` in Kotlin)
+- int : `\\d+`
+- float : `[+-]?([0-9]*[.])?[0-9]+` (this will match basic floats. Does not match exponents, or scientific notation)
+- path : `.*`
+
+Note that paths, not strings, will match by default. `"/news/{date}"` will match `www.example.com/news/2018/05/26`, making `request.path("date")` equal to `2018/05/26`. This may be exactly what you want, or it may produce unexpected results, depending on how your URLs are structured.
+
 ### Gradle setup
 
 ```groovy


### PR DESCRIPTION
Variables in paths are covered in the docs but I didn't find anything about restricting them via Regex. I wanted to clarify and add a few examples for people who aren't familiar with Regex's or who might be coming from a framework (Flask, Bottle) which has pre-defined types. Please feel free to edit/modify any of the docs or examples to better match with http4k's existing documentation style. Or, if this is already covered, replace the whole thing with a link.