### PR TITLE
fix(http4k-aws): add x-amz-content-sha256 to SignedHeaders

### DIFF
--- a/http4k-aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
+++ b/http4k-aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
@@ -42,6 +42,7 @@ fun ClientFilters.AwsAuth(scope: AwsCredentialScope,
 
             val fullRequest = it
                 .replaceHeader("host", it.uri.host)
+                .replaceHeader("x-amz-content-sha256", payload.hash)
                 .replaceHeader("x-amz-date", date.full).let {
                     if (it.method.allowsContent) {
                         it.replaceHeader("content-length", payload.length.toString())
@@ -58,7 +59,6 @@ fun ClientFilters.AwsAuth(scope: AwsCredentialScope,
 
             val signedRequest = fullRequest
                 .replaceHeader("Authorization", buildAuthHeader(scope, credentials, canonicalRequest, date))
-                .replaceHeader("x-amz-content-sha256", payload.hash)
 
             next(signedRequest)
         }

--- a/http4k-aws/src/test/kotlin/org/http4k/aws/AwsAuthClientFilterTest.kt
+++ b/http4k-aws/src/test/kotlin/org/http4k/aws/AwsAuthClientFilterTest.kt
@@ -33,7 +33,7 @@ class AwsClientFilterTest {
         client(Request(GET, "http://amazon/test").header("host", "foobar").header("content-length", "0"))
 
         assertThat(audit.captured?.header("Authorization"),
-            equalTo("AWS4-HMAC-SHA256 Credential=access/20160127/us-east/s3/aws4_request, SignedHeaders=content-length;host;x-amz-date, Signature=8afa7ee258c3eaa39b2764cbd52144fd7bbbe401876d4c9f359318963b82244d"))
+            equalTo("AWS4-HMAC-SHA256 Credential=access/20160127/us-east/s3/aws4_request, SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, Signature=80641a5d87dd9aad7a993b341c98a04cdefa58ecf09f1df4af93cec0268a8eca"))
     }
 
     @Test
@@ -43,7 +43,7 @@ class AwsClientFilterTest {
         client(Request(GET, "http://amazon/test").header("host", "foobar").header("content-length", "0"))
 
         assertThat(audit.captured?.header("Authorization"),
-            equalTo("AWS4-HMAC-SHA256 Credential=access/20160127/us-east/s3/aws4_request, SignedHeaders=content-length;host;x-amz-date;x-amz-security-token, Signature=f1cdc542e6d40d595876d461baa7f4ac6c9e5ef02b5f94bd983c493f677dcf41"))
+            equalTo("AWS4-HMAC-SHA256 Credential=access/20160127/us-east/s3/aws4_request, SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=f0522e59ba6c8d851970a1d4fb510cc37bb18330b66958992f653fc8966a2137"))
     }
 
     @Test


### PR DESCRIPTION
Hello!

This PR is a quick fix for custom domain usage of the module `http4k-connect` which uses `http4k-aws`: https://github.com/http4k/http4k-connect/issues/17
Unfortunately, I cannot try with a real `amazonaws.com` s3 service since I don't have any at my disposal, but I tried this fix on our on-premise internal installation and it works.