### PR TITLE
#595 implementing thenIf and thenIfNot extensions to have conditional filter

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ConditionalFilter.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ConditionalFilter.kt
@@ -1,0 +1,27 @@
+package org.http4k.filter
+
+import org.http4k.core.Filter
+import org.http4k.core.Request
+
+typealias RequestPredicate = (Request) -> Boolean
+
+class PATH_STARTS_WITH(val urlPrefix: String) : RequestPredicate {
+    override fun invoke(request: Request): Boolean {
+        return request.uri.path.startsWith(urlPrefix)
+    }
+}
+
+fun Filter.thenIf(predicate: RequestPredicate, filter: Filter): Filter {
+    return Filter { next ->
+        { request ->
+            if (predicate(request))
+                filter(next)(request)
+            else
+                next(request)
+        }
+    }
+}
+
+fun Filter.thenIfNot(predicate: RequestPredicate, filter: Filter): Filter {
+    return thenIf({ !predicate(it) }, filter)
+}

--- a/http4k-template/core/src/test/kotlin/org/http4k/filter/ConditionalFilterTest.kt
+++ b/http4k-template/core/src/test/kotlin/org/http4k/filter/ConditionalFilterTest.kt
@@ -1,0 +1,73 @@
+package org.http4k.filter
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.core.Filter
+import org.http4k.core.Method.GET
+import org.http4k.core.NoOp
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.OK
+import org.http4k.core.Status.Companion.UNAUTHORIZED
+import org.http4k.core.then
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ConditionalFilterTest {
+    internal class thenIf {
+        private val UserAgentFilter = Filter { next ->
+            {
+                next(it).header("isBrowser", "true")
+            }
+        }
+        val handler = Filter.NoOp
+            .thenIf({ it.header("referrer") != null }, UserAgentFilter)
+            .then { Response(OK) }
+
+        @Test
+        fun `should run filter when condition is satisfied`() {
+            val request = Request(GET, "/employee/1").header("referrer", "firefox")
+            val response = handler(request)
+
+            assertThat(response.header("isBrowser"), equalTo("true"))
+        }
+
+        @Test
+        fun `should not run filter when condition is not satisfied`() {
+            val request = Request(GET, "/employee/1")
+            val response = handler(request)
+
+            assertNull(response.header("isBrowser"))
+        }
+    }
+
+    internal class thenIfNot {
+        private val UnauthorizedUserFilter = Filter { next ->
+            {
+                next(it).status(UNAUTHORIZED)
+            }
+        }
+
+        private val authorized: (Request) -> Boolean = { it.query("userName") == "admin" }
+
+        val handler = Filter.NoOp
+            .thenIfNot(authorized, UnauthorizedUserFilter)
+            .then { Response(OK) }
+
+        @Test
+        fun `should run filter when condition is not satisfied`() {
+            val request = Request(GET, "/get/sensitive/data").query("userName", "invalid user")
+            val response = handler(request)
+
+            assertThat(response.status, equalTo(UNAUTHORIZED))
+        }
+
+        @Test
+        fun `should not run filter when condition is satisfied`() {
+            val request = Request(GET, "/get/sensitive/data").query("userName", "admin")
+            val response = handler(request)
+
+            assertThat(response.status, equalTo(OK))
+        }
+    }
+}


### PR DESCRIPTION
Fixes #595 
This will enable the http4k framework to run the filter conditionally.

I've implemented the basic functions  `thenIf` and `thenIfNot` which accept a `condition` and `filter` and run them accordingly. If this looks good ok to the reviewers, i can go ahead and implement some more basic convenience methods are  for common cases such as URL matching

- thenIfPathStartsWith
- thenIfPathNotStartsWith
- thenIfPathMatches
- thenIfPathNotMatches