### PR TITLE
MemoryBody takes offset and limit of ByteBuffer into account.

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/KotlinExtensions.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/KotlinExtensions.kt
@@ -4,7 +4,9 @@ import java.net.URLEncoder
 import java.nio.ByteBuffer
 import java.util.Base64
 
-fun ByteBuffer.asString(): String = String(array())
+fun ByteBuffer.length() = limit() - position()
+
+fun ByteBuffer.asString(): String = String(array(), position(), length())
 
 fun String.asByteBuffer(): ByteBuffer = ByteBuffer.wrap(toByteArray())
 

--- a/http4k-core/src/main/kotlin/org/http4k/core/http.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/http.kt
@@ -52,7 +52,7 @@ interface Body : Closeable {
 data class MemoryBody(override val payload: ByteBuffer) : Body {
     constructor(payload: String) : this(ByteBuffer.wrap(payload.toByteArray()))
     constructor(payload: ByteArray) : this(ByteBuffer.wrap(payload))
-    
+
     override val length get() = payload.length().toLong()
     override fun close() {}
     override val stream get() = payload.array().inputStream(payload.position(), payload.length())

--- a/http4k-core/src/main/kotlin/org/http4k/core/http.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/http.kt
@@ -42,7 +42,7 @@ interface Body : Closeable {
         operator fun invoke(body: InputStream, length: Long? = null): Body = StreamBody(body, length)
 
         @JvmField
-        val EMPTY: Body = MemoryBody(ByteArray(0))
+        val EMPTY: Body = MemoryBody(ByteBuffer.allocate(0))
     }
 }
 

--- a/http4k-core/src/main/kotlin/org/http4k/core/http.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/http.kt
@@ -3,6 +3,7 @@ package org.http4k.core
 import org.http4k.asString
 import org.http4k.core.Body.Companion.EMPTY
 import org.http4k.core.HttpMessage.Companion.HTTP_1_1
+import org.http4k.length
 import org.http4k.lens.WebForm
 import org.http4k.routing.RoutedRequest
 import java.io.Closeable
@@ -41,7 +42,7 @@ interface Body : Closeable {
         operator fun invoke(body: InputStream, length: Long? = null): Body = StreamBody(body, length)
 
         @JvmField
-        val EMPTY: Body = MemoryBody("")
+        val EMPTY: Body = MemoryBody(ByteArray(0))
     }
 }
 
@@ -51,10 +52,10 @@ interface Body : Closeable {
 data class MemoryBody(override val payload: ByteBuffer) : Body {
     constructor(payload: String) : this(ByteBuffer.wrap(payload.toByteArray()))
     constructor(payload: ByteArray) : this(ByteBuffer.wrap(payload))
-
-    override val length by lazy { payload.array().size.toLong() }
+    
+    override val length get() = payload.length().toLong()
     override fun close() {}
-    override val stream get() = payload.array().inputStream()
+    override val stream get() = payload.array().inputStream(payload.position(), payload.length())
     override fun toString() = payload.asString()
 }
 

--- a/http4k-core/src/test/kotlin/org/http4k/core/BodyTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/BodyTest.kt
@@ -62,10 +62,44 @@ class BodyTest {
     }
 
     @Test
-    fun `can construct with non-array backed ByteBuffer`() {
+    fun `can construct with read only array backed ByteBuffer`() {
         val body = Body(ByteBuffer.wrap("abc".toByteArray()).asReadOnlyBuffer())
         assertThat(body.length, equalTo(3L))
         assertThat(body.toString(), equalTo("abc"))
         assertThat(body.stream.bufferedReader().use { it.readText() }, equalTo("abc"))
+    }
+    
+    @Test
+    fun `can construct with non-array backed ByteBuffer`() {
+        val bytes = "abc".toByteArray()
+        val buf = ByteBuffer.allocateDirect(bytes.size)
+        buf.put(bytes)
+        buf.flip()
+        
+        val body = Body(buf)
+        assertThat(body.length, equalTo(3L))
+        assertThat(body.toString(), equalTo("abc"))
+        assertThat(body.stream.bufferedReader().use { it.readText() }, equalTo("abc"))
+    }
+    
+    @Test
+    fun `correct length and bytes when created from ByteBuffer`() {
+        val bytes = ByteArray(16) { it.toByte() }
+        val buf = ByteBuffer.wrap(bytes, 4, 8)
+        val body = Body(buf)
+    
+        assertThat("body length", body.length, equalTo(8))
+        
+        val bodyContents = body.stream.readAllBytes()
+        
+        assertThat("body contents", bodyContents.toList(), equalTo(byteArrayOf(4,5,6,7,8,9,10,11).toList()))
+    }
+    
+    @Test
+    fun `correct string contents when created from ByteBuffer`() {
+        val bytes = "abcdefghij".toByteArray(Charsets.UTF_8)
+        val body = Body(ByteBuffer.wrap(bytes, 2, 4))
+        
+        assertThat("body to string", body.toString(), equalTo("cdef"))
     }
 }

--- a/http4k-core/src/test/kotlin/org/http4k/core/BodyTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/BodyTest.kt
@@ -68,38 +68,38 @@ class BodyTest {
         assertThat(body.toString(), equalTo("abc"))
         assertThat(body.stream.bufferedReader().use { it.readText() }, equalTo("abc"))
     }
-    
+
     @Test
     fun `can construct with non-array backed ByteBuffer`() {
         val bytes = "abc".toByteArray()
         val buf = ByteBuffer.allocateDirect(bytes.size)
         buf.put(bytes)
         buf.flip()
-        
+
         val body = Body(buf)
         assertThat(body.length, equalTo(3L))
         assertThat(body.toString(), equalTo("abc"))
         assertThat(body.stream.bufferedReader().use { it.readText() }, equalTo("abc"))
     }
-    
+
     @Test
     fun `correct length and bytes when created from ByteBuffer`() {
         val bytes = ByteArray(16) { it.toByte() }
         val buf = ByteBuffer.wrap(bytes, 4, 8)
         val body = Body(buf)
-    
+
         assertThat("body length", body.length, equalTo(8))
-        
+
         val bodyContents = body.stream.readAllBytes()
-        
+
         assertThat("body contents", bodyContents.toList(), equalTo(byteArrayOf(4,5,6,7,8,9,10,11).toList()))
     }
-    
+
     @Test
     fun `correct string contents when created from ByteBuffer`() {
         val bytes = "abcdefghij".toByteArray(Charsets.UTF_8)
         val body = Body(ByteBuffer.wrap(bytes, 2, 4))
-        
+
         assertThat("body to string", body.toString(), equalTo("cdef"))
     }
 }


### PR DESCRIPTION
Fixes a bug in MemoryBody: when a ByteBuffer was created with a nonzero offset and/or length shorter than the size of the underlying array, the entire array was used as the content of the body.