### PR TITLE
trimSlashes should not be accessible outside UriTemplate

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/UriTemplate.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/UriTemplate.kt
@@ -15,8 +15,9 @@ data class UriTemplate private constructor(private val template: String) {
         private val URI_TEMPLATE_FORMAT = "\\{([^}]+?)(?::([^}]+))?\\}".toRegex() // ignore redundant warning #100
         fun from(template: String) = UriTemplate(template.trimSlashes())
 
-        fun String.trimSlashes() = "^(/)?(.*?)(/)?$".toRegex().replace(this) { result -> result.groupValues[2] }
+        private fun String.trimSlashes() = "^(/)?(.*?)(/)?$".toRegex().replace(this) { result -> result.groupValues[2] }
     }
+
 
     fun matches(uri: String): Boolean = templateRegex.matches(uri.trimSlashes())
 


### PR DESCRIPTION
In `UriTemplate` the function `trimSlashes()` is defined as a public extension on String. However, it should only be accessible inside `UriTemplate`