### PR TITLE
be resilient to extra space in Digest challenge header value

### DIFF
--- a/http4k-security/digest/src/main/kotlin/org/http4k/security/digest/ParameterizedHeader.kt
+++ b/http4k-security/digest/src/main/kotlin/org/http4k/security/digest/ParameterizedHeader.kt
@@ -6,7 +6,7 @@ data class ParameterizedHeader(
 
     companion object {
         fun parse(headerValue: String): ParameterizedHeader {
-            val (prefix, parameterList) = headerValue.split(" ", limit = 2)
+            val (prefix, parameterList) = headerValue.trim().split(" ", limit = 2)
 
             val parameters = parameterList
                 .split(",")

--- a/http4k-security/digest/src/test/kotlin/org/http4k/security/digest/DigestChallengeTest.kt
+++ b/http4k-security/digest/src/test/kotlin/org/http4k/security/digest/DigestChallengeTest.kt
@@ -1,0 +1,33 @@
+package org.http4k.security.digest
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.security.Nonce
+import org.junit.jupiter.api.Test
+
+class DigestChallengeTest {
+
+    @Test
+    fun `process basic challenge for header with extra space`() {
+        val challenge = DigestChallenge.parse(" Digest realm=\"server\", nonce=\"6a4363b9256176c8c225ee70d191a620\"")
+        assertThat(challenge, equalTo(DigestChallenge(
+            realm = "server",
+            nonce = Nonce("6a4363b9256176c8c225ee70d191a620"),
+            algorithm = null,
+            opaque = null,
+            qop = emptyList()
+        )))
+    }
+
+    @Test
+    fun `process auth challenge`() {
+        val challenge = DigestChallenge.parse("Digest realm=\"http4k\", nonce=\"1234abcd\", algorithm=MD5, qop=\"auth\"")
+        assertThat(challenge, equalTo(DigestChallenge(
+            realm = "http4k",
+            nonce = Nonce("1234abcd"),
+            algorithm = "MD5",
+            opaque = null,
+            qop = listOf(Qop.Auth)
+        )))
+    }
+}


### PR DESCRIPTION
Ran into this issue while trying to adapt the client filter for authorization over RTSP.  Still good to be resilient to minor issues like this in any case.