### PR TITLE
Fix #638

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
@@ -69,6 +69,8 @@ fun Uri.removeQueries(prefix: String) = copy(query = query.toParameters().filter
 
 fun Uri.query(name: String, value: String?): Uri = copy(query = query.toParameters().plus(name to value).toUrlFormEncoded())
 
+// Use the older encode/decode methods here - this maintains compatibility
+// with JDK-8
 fun String.toPathEncoded() = URLEncoder.encode(this, "UTF-8")
 fun String.toPathDecoded() = URLDecoder.decode(this, "UTF-8")
 

--- a/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
@@ -69,8 +69,8 @@ fun Uri.removeQueries(prefix: String) = copy(query = query.toParameters().filter
 
 fun Uri.query(name: String, value: String?): Uri = copy(query = query.toParameters().plus(name to value).toUrlFormEncoded())
 
-fun String.toPathEncoded() = URLEncoder.encode(this, UTF_8)
-fun String.toPathDecoded() = URLDecoder.decode(this, UTF_8)
+fun String.toPathEncoded() = URLEncoder.encode(this, "UTF-8")
+fun String.toPathDecoded() = URLDecoder.decode(this, "UTF-8")
 
 fun Uri.extend(uri: Uri): Uri =
     appendToPath(uri.path).copy(query = (query.toParameters() + uri.query.toParameters()).toUrlFormEncoded())


### PR DESCRIPTION
Recent changes in `Uri.kt` use static methods in `URLEncoder` and `URLDecoder` that are unavailable in Java 8 and 9:

https://github.com/http4k/http4k/blob/85cbcbe338be0dd1590d16da148e343cbcfc7447/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt#L73

compare the available [methods in `URLDecoder` in Java 8](https://docs.oracle.com/javase/8/docs/api/java/net/URLDecoder.html#method.summary) with those [available in Java 10](https://docs.oracle.com/javase/10/docs/api/java/net/URLDecoder.html#method.summary) - Java 8 does not have

```
decode​(String s, Charset charset)
```

This change was part of the fix for issue #536 (see these two commits: [1](https://github.com/http4k/http4k/commit/afb40bb6d68d57493d7963e9a6a3457e1da179fa#diff-62011af7fd9e5e46ddd49d70c687cbd6c5e09abd6f5080e36ad5f3e3883e8942), [2](https://github.com/http4k/http4k/commit/a2f023eb1fc799d375e7199bf81f63eeadc35b8d#diff-62011af7fd9e5e46ddd49d70c687cbd6c5e09abd6f5080e36ad5f3e3883e8942)).

When running http4k using Java 8, this causes the following error:

```
java.lang.NoSuchMethodError: java.net.URLDecoder.decode(Ljava/lang/String;Ljava/nio/charset/Charset;)Ljava/lang/String;
        at org.http4k.core.UriKt.toPathDecoded(Uri.kt:73)
	at org.http4k.contract.ContractRouteKt$extract$1$1.invoke(ContractRoute.kt:92)
	at org.http4k.contract.ContractRouteKt$extract$1$1.invoke(ContractRoute.kt)
	at org.http4k.contract.ContractRouteKt.invoke(ContractRoute.kt:87)
	at org.http4k.contract.ContractRouteKt.extract(ContractRoute.kt:92)
	at org.http4k.contract.ContractRouteKt.access$extract(ContractRoute.kt:1)
	at org.http4k.contract.ContractRoute$toRouter$1.match(ContractRoute.kt:45)
	at org.http4k.contract.ContractRoutingHttpHandler.match(ContractRoutingHttpHandler.kt:91)
	at org.http4k.routing.OrRouter.match(Router.kt:78)
	at org.http4k.routing.RouterBasedHttpHandler.match(RouterBasedHttpHandler.kt)
	at org.http4k.routing.RouterBasedHttpHandler.invoke(RouterBasedHttpHandler.kt:19)
	at org.http4k.routing.RouterBasedHttpHandler.invoke(RouterBasedHttpHandler.kt:13)
```

The fix is simple enough: revert to using the original encode/decode methods:

```kotlin
fun String.toPathEncoded() = URLEncoder.encode(this, "UTF-8")
fun String.toPathDecoded() = URLDecoder.decode(this, "UTF-8")
```