### PR TITLE
SpanCreationMutator now takes the request, so you can respond to request attributes

### DIFF
--- a/http4k-opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
+++ b/http4k-opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
@@ -62,7 +62,7 @@ fun ServerFilters.OpenTelemetryTracing(
     openTelemetry: OpenTelemetry = GlobalOpenTelemetry.get(),
     spanNamer: (Request) -> String = { it.uri.toString() },
     error: (Request, Throwable) -> String = { _, t -> t.localizedMessage },
-    spanCreationMutator: (SpanBuilder) -> SpanBuilder = { it },
+    spanCreationMutator: (SpanBuilder, Request) -> SpanBuilder = { spanBuilder, _ -> spanBuilder },
     spanCompletionMutator: (Span, Request, Response) -> Unit = { _, _, _ -> },
 ): Filter {
     val tracer = openTelemetry.tracerProvider.get(INSTRUMENTATION_NAME)
@@ -75,7 +75,7 @@ fun ServerFilters.OpenTelemetryTracing(
             with(tracer.spanBuilder(spanNamer(req))
                 .setParent(textMapPropagator.extract(Context.current(), req, getter))
                 .setSpanKind(SERVER)
-                .let { spanCreationMutator(it) }
+                .let { spanCreationMutator(it, req) }
                 .startSpan()) {
                 makeCurrent().use {
                     try {

--- a/http4k-opentelemetry/src/test/kotlin/org/http4k/filter/OpenTelemetryTracingTest.kt
+++ b/http4k-opentelemetry/src/test/kotlin/org/http4k/filter/OpenTelemetryTracingTest.kt
@@ -106,8 +106,8 @@ class OpenTelemetryTracingTest {
 
         var createdContext: SpanData? = null
 
-        val app = ServerFilters.OpenTelemetryTracing(spanCreationMutator = {
-            it.setAttribute(creationValue, "test-value")
+        val app = ServerFilters.OpenTelemetryTracing(spanCreationMutator = { spanBuilder, request ->
+            spanBuilder.setAttribute(creationValue, request.header("x-its-a-me") ?: "no-its-a-not")
         })
             .then(routes("/foo/{id}" bind GET to {
                 createdContext = (Span.current() as ReadableSpan).toSpanData()
@@ -119,10 +119,11 @@ class OpenTelemetryTracingTest {
                 .header("x-b3-traceid", sentTraceId)
                 .header("x-b3-spanid", parentSpanId)
                 .header("x-b3-sampled", "1")
+                .header("x-its-a-me", "mario")
         )
 
         with(createdContext!!) {
-            assertThat(attributes.get(creationValue), equalTo("test-value"))
+            assertThat(attributes.get(creationValue), equalTo("mario"))
         }
     }
 


### PR DESCRIPTION
I'm sure this won't be a surprise, but I'm an idiot. The span creation mutator now takes the request so you can actally respond to elements of the request (e.g. headers), rather than just spinning in the void 🤦 