### PR TITLE
Set the query parameter to empty string if it's value is null, instead of "null"

### DIFF
--- a/http4k-aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
+++ b/http4k-aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
@@ -35,7 +35,7 @@ internal data class AwsCanonicalRequest(val value: String, val signedHeaders: St
 
         private fun Request.canonicalQueryString(): String =
             uri.query.toParameters()
-                .map { (first, second) -> first.urlEncoded() + "=" + second?.urlEncoded() }
+                .map { (first, second) -> first.urlEncoded() + "=" + second?.urlEncoded().orEmpty() }
                 .sorted()
                 .joinToString("&")
 

--- a/http4k-aws/src/test/kotlin/org/http4k/aws/AwsCanonicalRequestTest.kt
+++ b/http4k-aws/src/test/kotlin/org/http4k/aws/AwsCanonicalRequestTest.kt
@@ -27,6 +27,18 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""))
     }
 
     @Test
+    fun `creates canonical version of request with null parameter`() {
+        val canonical = AwsCanonicalRequest.of(Request(GET, "http://www.google.com/a/b").query("foo", null), canonicalPayload)
+        assertThat(canonical.value, equalTo("""GET
+/a/b
+foo=
+
+
+
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""))
+    }
+
+    @Test
     fun `normalises path`() {
         val canonical = AwsCanonicalRequest.of(Request(GET, "http://www.google.com/a:b:c/d e/f"), canonicalPayload)
         assertThat(canonical.value, equalTo("""GET


### PR DESCRIPTION
Hi @daviddenton,

Simple PR to fix an incorrect signature generated on requests where no query value is needed.

e.g., GET /?lifecycle on the bucket

    "lifecycle=" instead of "lifecycle=null" 

https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketLifecycleConfiguration.html