### PR TITLE
Downgrade graphql-java and fix Graphql reference example

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -37,7 +37,7 @@ version.com.google.cloud.functions..functions-framework-api=1.0.4
 
 version.com.google.code.gson..gson=2.8.7
 
-version.com.graphql-java..graphql-java=17.0
+version.com.graphql-java..graphql-java=16.2
 
 version.com.microsoft.azure.functions..azure-functions-java-library=1.4.2
 


### PR DESCRIPTION
Downgrade graphql-java to 16.2 for compatibility with graphql-kotlin-schema-generator 4.1.1

Wait for 5.0.0 of graphql-kotlin-schema-generator or if they release a fix upgrade to 4.1.1 before going back to 17.0