### PR TITLE
Servers in contracts

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
@@ -52,12 +52,12 @@ class OpenApi3<NODE : Any>(
     private val apiInfo: ApiInfo,
     private val json: Json<NODE>,
     private val extensions: List<OpenApiExtension> = emptyList(),
-    private val servers: List<ApiServer> = emptyList(),
+    private val apiRenderer: ApiRenderer<Api<NODE>, NODE> = OpenApi3ApiRenderer(json),
     // note that this is the basic OpenApi renderer - if you want reflective Schema generation
     // then you want to use ApiRenderer.Auto() instead with a compatible JSON instance
-    private val apiRenderer: ApiRenderer<Api<NODE>, NODE> = OpenApi3ApiRenderer(json),
     private val securityRenderer: SecurityRenderer = OpenApi3SecurityRenderer,
-    private val errorResponseRenderer: ErrorResponseRenderer = JsonErrorResponseRenderer(json)
+    private val errorResponseRenderer: ErrorResponseRenderer = JsonErrorResponseRenderer(json),
+    private val servers: List<ApiServer> = emptyList()
 ) : ContractRenderer, ErrorResponseRenderer by errorResponseRenderer {
     private data class PathAndMethod<NODE>(val path: String, val method: Method, val pathSpec: ApiPath<NODE>)
 
@@ -66,7 +66,7 @@ class OpenApi3<NODE : Any>(
         json: AutoMarshallingJson<NODE>,
         extensions: List<OpenApiExtension> = emptyList(),
         servers: List<ApiServer> = emptyList(),
-    ) : this(apiInfo, json, extensions, servers, ApiRenderer.Auto(json))
+    ) : this(apiInfo, json, extensions, ApiRenderer.Auto(json), servers = servers)
 
     override fun description(contractRoot: PathSegments, security: Security?, routes: List<ContractRoute>, tags: Set<Tag>): Response {
         val allSecurities = routes.map { it.meta.security } + listOfNotNull(security)

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
@@ -52,6 +52,7 @@ class OpenApi3<NODE : Any>(
     private val apiInfo: ApiInfo,
     private val json: Json<NODE>,
     private val extensions: List<OpenApiExtension> = emptyList(),
+    private val servers: List<ApiServer> = emptyList(),
     // note that this is the basic OpenApi renderer - if you want reflective Schema generation
     // then you want to use ApiRenderer.Auto() instead with a compatible JSON instance
     private val apiRenderer: ApiRenderer<Api<NODE>, NODE> = OpenApi3ApiRenderer(json),
@@ -63,8 +64,9 @@ class OpenApi3<NODE : Any>(
     constructor(
         apiInfo: ApiInfo,
         json: AutoMarshallingJson<NODE>,
-        extensions: List<OpenApiExtension> = emptyList()
-    ) : this(apiInfo, json, extensions, ApiRenderer.Auto(json))
+        extensions: List<OpenApiExtension> = emptyList(),
+        servers: List<ApiServer> = emptyList(),
+    ) : this(apiInfo, json, extensions, servers, ApiRenderer.Auto(json))
 
     override fun description(contractRoot: PathSegments, security: Security?, routes: List<ContractRoute>, tags: Set<Tag>): Response {
         val allSecurities = routes.map { it.meta.security } + listOfNotNull(security)
@@ -83,7 +85,8 @@ class OpenApi3<NODE : Any>(
                 Components(
                     json.obj(paths.flatMap { it.pathSpec.definitions() }),
                     json(allSecurities.filterNotNull().combineFull())
-                )
+                ),
+                servers
             )
         )
 

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3ApiRenderer.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3ApiRenderer.kt
@@ -36,7 +36,7 @@ class OpenApi3ApiRenderer<NODE : Any>(private val json: Json<NODE>) : ApiRendere
 
     private fun ApiServer.asJson() = json {
         obj(
-            "url" to string(url),
+            "url" to string(url.toString()),
             "description" to string(description ?: "")
         )
     }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3ApiRenderer.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3ApiRenderer.kt
@@ -30,7 +30,7 @@ class OpenApi3ApiRenderer<NODE : Any>(private val json: Json<NODE>) : ApiRendere
                     "tags" to array(tags.map { it.asJson() }),
                     "paths" to paths.asJson(),
                     "components" to components.asJson(),
-                    "servers" to array(servers.ifEmpty { listOf(ApiServer(Uri.of("/"))) }.map { it.asJson() })
+                    "servers" to array(servers.map { it.asJson() })
                 )
             }
         }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3ApiRenderer.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3ApiRenderer.kt
@@ -30,8 +30,7 @@ class OpenApi3ApiRenderer<NODE : Any>(private val json: Json<NODE>) : ApiRendere
                     "tags" to array(tags.map { it.asJson() }),
                     "paths" to paths.asJson(),
                     "components" to components.asJson(),
-                    "servers" to array(servers.ifEmpty { listOf(ApiServer(Uri.of("/"))) }.map { it.asJson() }
-                    )
+                    "servers" to array(servers.ifEmpty { listOf(ApiServer(Uri.of("/"))) }.map { it.asJson() })
                 )
             }
         }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3ApiRenderer.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3ApiRenderer.kt
@@ -28,10 +28,18 @@ class OpenApi3ApiRenderer<NODE : Any>(private val json: Json<NODE>) : ApiRendere
                     "info" to info.asJson(),
                     "tags" to array(tags.map { it.asJson() }),
                     "paths" to paths.asJson(),
-                    "components" to components.asJson()
+                    "components" to components.asJson(),
+                    "servers" to array(servers.map { it.asJson() })
                 )
             }
         }
+
+    private fun ApiServer.asJson() = json {
+        obj(
+            "url" to string(url),
+            "description" to string(description ?: "")
+        )
+    }
 
     private fun Tag.asJson(): NODE =
         json {
@@ -140,7 +148,8 @@ class OpenApi3ApiRenderer<NODE : Any>(private val json: Json<NODE>) : ApiRendere
             it.key to
                 obj(
                     "description" to it.value.description.asJson(),
-                    "content" to it.value.content.asJson())
+                    "content" to it.value.content.asJson()
+                )
         })
     }
 

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3ApiRenderer.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3ApiRenderer.kt
@@ -9,6 +9,7 @@ import org.http4k.contract.openapi.v3.BodyContent.OneOfSchemaContent
 import org.http4k.contract.openapi.v3.BodyContent.SchemaContent
 import org.http4k.contract.openapi.v3.RequestParameter.PrimitiveParameter
 import org.http4k.contract.openapi.v3.RequestParameter.SchemaParameter
+import org.http4k.core.Uri
 import org.http4k.format.Json
 import org.http4k.util.JsonSchema
 
@@ -29,7 +30,8 @@ class OpenApi3ApiRenderer<NODE : Any>(private val json: Json<NODE>) : ApiRendere
                     "tags" to array(tags.map { it.asJson() }),
                     "paths" to paths.asJson(),
                     "components" to components.asJson(),
-                    "servers" to array(servers.map { it.asJson() })
+                    "servers" to array(servers.ifEmpty { listOf(ApiServer(Uri.of("/"))) }.map { it.asJson() }
+                    )
                 )
             }
         }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/jacksonExt.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/jacksonExt.kt
@@ -18,7 +18,7 @@ import kotlin.reflect.full.createInstance
  * Defaults for configuring OpenApi3 with Jackson
  */
 fun OpenApi3(apiInfo: ApiInfo, json: ConfigurableJackson = OpenAPIJackson, extensions: List<OpenApiExtension> = emptyList(), servers: List<ApiServer> = emptyList()) =
-    OpenApi3(apiInfo, json, extensions, servers, ApiRenderer.Auto(json, AutoJsonToJsonSchema(json)))
+    OpenApi3(apiInfo, json, extensions, ApiRenderer.Auto(json, AutoJsonToJsonSchema(json)), servers = servers)
 
 fun AutoJsonToJsonSchema(json: ConfigurableJackson) = AutoJsonToJsonSchema(
     json,

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/jacksonExt.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/jacksonExt.kt
@@ -17,7 +17,8 @@ import kotlin.reflect.full.createInstance
 /**
  * Defaults for configuring OpenApi3 with Jackson
  */
-fun OpenApi3(apiInfo: ApiInfo, json: ConfigurableJackson = OpenAPIJackson, extensions: List<OpenApiExtension> = emptyList()) = OpenApi3(apiInfo, json, extensions, ApiRenderer.Auto(json, AutoJsonToJsonSchema(json)))
+fun OpenApi3(apiInfo: ApiInfo, json: ConfigurableJackson = OpenAPIJackson, extensions: List<OpenApiExtension> = emptyList(), servers: List<ApiServer> = emptyList()) =
+    OpenApi3(apiInfo, json, extensions, servers, ApiRenderer.Auto(json, AutoJsonToJsonSchema(json)))
 
 fun AutoJsonToJsonSchema(json: ConfigurableJackson) = AutoJsonToJsonSchema(
     json,

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/model.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/model.kt
@@ -2,6 +2,7 @@ package org.http4k.contract.openapi.v3
 
 import org.http4k.contract.Tag
 import org.http4k.contract.openapi.ApiInfo
+import org.http4k.core.Uri
 import org.http4k.lens.Meta
 import org.http4k.lens.ParamMeta
 import org.http4k.util.JsonSchema
@@ -22,7 +23,7 @@ data class Components<NODE>(
 )
 
 data class ApiServer(
-    val url: String,
+    val url: Uri,
     val description: String? = null
 )
 

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/model.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/model.kt
@@ -7,13 +7,26 @@ import org.http4k.lens.Meta
 import org.http4k.lens.ParamMeta
 import org.http4k.util.JsonSchema
 
-data class Api<NODE>(
+data class Api<NODE> private constructor(
     val info: ApiInfo,
     val tags: List<Tag>,
+    val servers: List<ApiServer>,
     val paths: Map<String, Map<String, ApiPath<NODE>>>,
-    val components: Components<NODE>,
-    val servers: List<ApiServer>
+    val components: Components<NODE>
 ) {
+    init {
+        require(servers.isNotEmpty())
+        { "openAPI spec requires not-null and non-empty servers. See: https://swagger.io/specification/#openapi-object " }
+    }
+
+    constructor(
+        info: ApiInfo,
+        tags: List<Tag>,
+        paths: Map<String, Map<String, ApiPath<NODE>>>,
+        components: Components<NODE>,
+        servers: List<ApiServer>
+    ) : this(info, tags, servers.ifEmpty { listOf(ApiServer(Uri.of("/"))) }, paths, components)
+
     val openapi = "3.0.0"
 }
 
@@ -76,7 +89,8 @@ sealed class BodyContent {
 
     data class NoSchema<NODE : Any>(val schema: NODE, val example: String? = null) : BodyContent()
 
-    class SchemaContent<NODE : Any>(private val jsonSchema: JsonSchema<NODE>?, val example: NODE?) : BodyContent(), HasSchema<NODE> {
+    class SchemaContent<NODE : Any>(private val jsonSchema: JsonSchema<NODE>?, val example: NODE?) : BodyContent(),
+        HasSchema<NODE> {
         val schema = jsonSchema?.node
         override fun definitions() = jsonSchema?.definitions ?: emptySet()
     }
@@ -118,17 +132,25 @@ class RequestContents<NODE>(val content: Map<String, BodyContent>? = null) : Has
     val required = content != null
 }
 
-class ResponseContents<NODE>(val description: String?, val content: Map<String, BodyContent> = emptyMap()) : HasSchema<NODE> {
+class ResponseContents<NODE>(val description: String?, val content: Map<String, BodyContent> = emptyMap()) :
+    HasSchema<NODE> {
     override fun definitions() = content.values
         .filterIsInstance<HasSchema<NODE>>()
         .flatMap { it.definitions() }.toSet()
 }
 
-sealed class RequestParameter<NODE>(val `in`: String, val name: String, val required: Boolean, val description: String?) {
-    class SchemaParameter<NODE>(meta: Meta, private val jsonSchema: JsonSchema<NODE>?) : RequestParameter<NODE>(meta.location, meta.name, meta.required, meta.description), HasSchema<NODE> {
+sealed class RequestParameter<NODE>(
+    val `in`: String,
+    val name: String,
+    val required: Boolean,
+    val description: String?
+) {
+    class SchemaParameter<NODE>(meta: Meta, private val jsonSchema: JsonSchema<NODE>?) :
+        RequestParameter<NODE>(meta.location, meta.name, meta.required, meta.description), HasSchema<NODE> {
         val schema: NODE? = jsonSchema?.node
         override fun definitions() = jsonSchema?.definitions ?: emptySet()
     }
 
-    class PrimitiveParameter<NODE>(meta: Meta, val schema: NODE) : RequestParameter<NODE>(meta.location, meta.name, meta.required, meta.description)
+    class PrimitiveParameter<NODE>(meta: Meta, val schema: NODE) :
+        RequestParameter<NODE>(meta.location, meta.name, meta.required, meta.description)
 }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/model.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/model.kt
@@ -10,7 +10,8 @@ data class Api<NODE>(
     val info: ApiInfo,
     val tags: List<Tag>,
     val paths: Map<String, Map<String, ApiPath<NODE>>>,
-    val components: Components<NODE>
+    val components: Components<NODE>,
+    val servers: List<ApiServer>
 ) {
     val openapi = "3.0.0"
 }
@@ -18,6 +19,11 @@ data class Api<NODE>(
 data class Components<NODE>(
     val schemas: NODE,
     val securitySchemes: NODE
+)
+
+data class ApiServer(
+    val url: String,
+    val description: String? = null
 )
 
 sealed class ApiPath<NODE>(

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3AutoTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3AutoTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import org.http4k.contract.ContractRendererContract
 import org.http4k.contract.openapi.AddSimpleFieldToRootNode
 import org.http4k.contract.openapi.ApiInfo
+import org.http4k.core.Uri
 import org.http4k.format.Jackson
 
 class OpenApi3AutoTest : ContractRendererContract<JsonNode>(
@@ -12,6 +13,6 @@ class OpenApi3AutoTest : ContractRendererContract<JsonNode>(
         ApiInfo("title", "1.2", "module description"),
         Jackson,
         listOf(AddSimpleFieldToRootNode),
-        listOf(ApiServer("localhost:8000", "a very simple API"))
+        listOf(ApiServer(Uri.of("localhost:8000"), "a very simple API"))
     )
 )

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3AutoTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3AutoTest.kt
@@ -13,6 +13,6 @@ class OpenApi3AutoTest : ContractRendererContract<JsonNode>(
         ApiInfo("title", "1.2", "module description"),
         Jackson,
         listOf(AddSimpleFieldToRootNode),
-        listOf(ApiServer(Uri.of("localhost:8000"), "a very simple API"))
+        listOf(ApiServer(Uri.of("http://localhost:8000"), "a very simple API"))
     )
 )

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3AutoTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3AutoTest.kt
@@ -6,5 +6,12 @@ import org.http4k.contract.openapi.AddSimpleFieldToRootNode
 import org.http4k.contract.openapi.ApiInfo
 import org.http4k.format.Jackson
 
-class OpenApi3AutoTest : ContractRendererContract<JsonNode>(Jackson,
-    OpenApi3(ApiInfo("title", "1.2", "module description"), Jackson, listOf(AddSimpleFieldToRootNode)))
+class OpenApi3AutoTest : ContractRendererContract<JsonNode>(
+    Jackson,
+    OpenApi3(
+        ApiInfo("title", "1.2", "module description"),
+        Jackson,
+        listOf(AddSimpleFieldToRootNode),
+        listOf(ApiServer("localhost:8000", "a very simple API"))
+    )
+)

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.kt
@@ -1,0 +1,15 @@
+package org.http4k.contract.openapi.v3
+
+import argo.jdom.JsonNode
+import org.http4k.contract.ContractRendererContract
+import org.http4k.contract.openapi.AddSimpleFieldToRootNode
+import org.http4k.contract.openapi.ApiInfo
+import org.http4k.format.Argo
+
+class OpenApi3ServersDefaultTest : ContractRendererContract<JsonNode>(
+    Argo, OpenApi3(
+        ApiInfo("title", "1.2", "module description"),
+        Argo,
+        listOf(AddSimpleFieldToRootNode)
+    )
+)

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3Test.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3Test.kt
@@ -4,11 +4,12 @@ import argo.jdom.JsonNode
 import org.http4k.contract.ContractRendererContract
 import org.http4k.contract.openapi.AddSimpleFieldToRootNode
 import org.http4k.contract.openapi.ApiInfo
+import org.http4k.core.Uri
 import org.http4k.format.Argo
 
 class OpenApi3Test : ContractRendererContract<JsonNode>(Argo, OpenApi3(
     ApiInfo("title", "1.2", "module description"),
     Argo,
     listOf(AddSimpleFieldToRootNode),
-    listOf(ApiServer("localhost:8000"))
+    listOf(ApiServer(Uri.of("localhost:8000")))
 ))

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3Test.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3Test.kt
@@ -11,5 +11,5 @@ class OpenApi3Test : ContractRendererContract<JsonNode>(Argo, OpenApi3(
     ApiInfo("title", "1.2", "module description"),
     Argo,
     listOf(AddSimpleFieldToRootNode),
-    servers = listOf(ApiServer(Uri.of("localhost:8000")))
+    servers = listOf(ApiServer(Uri.of("https://localhost:8000")))
 ))

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3Test.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3Test.kt
@@ -11,5 +11,5 @@ class OpenApi3Test : ContractRendererContract<JsonNode>(Argo, OpenApi3(
     ApiInfo("title", "1.2", "module description"),
     Argo,
     listOf(AddSimpleFieldToRootNode),
-    listOf(ApiServer(Uri.of("localhost:8000")))
+    servers = listOf(ApiServer(Uri.of("localhost:8000")))
 ))

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3Test.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3Test.kt
@@ -9,5 +9,6 @@ import org.http4k.format.Argo
 class OpenApi3Test : ContractRendererContract<JsonNode>(Argo, OpenApi3(
     ApiInfo("title", "1.2", "module description"),
     Argo,
-    listOf(AddSimpleFieldToRootNode)
+    listOf(AddSimpleFieldToRootNode),
+    listOf(ApiServer("localhost:8000"))
 ))

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
@@ -1331,7 +1331,7 @@
   },
   "servers": [
     {
-      "url": "localhost:8000",
+      "url": "http://localhost:8000",
       "description": "a very simple API"
     }
   ],

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
@@ -1329,6 +1329,12 @@
       }
     }
   },
+  "servers": [
+    {
+      "url": "localhost:8000",
+      "description": "a very simple API"
+    }
+  ],
   "openapi": "3.0.0",
   "x-extension": [
     "extensionField"

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.when enabled renders description including its own path.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.when enabled renders description including its own path.approved
@@ -61,6 +61,12 @@
       }
     }
   },
+  "servers": [
+    {
+      "url": "localhost:8000",
+      "description": "a very simple API"
+    }
+  ],
   "openapi": "3.0.0",
   "x-extension": [
     "extensionField"

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.when enabled renders description including its own path.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.when enabled renders description including its own path.approved
@@ -63,7 +63,7 @@
   },
   "servers": [
     {
-      "url": "localhost:8000",
+      "url": "http://localhost:8000",
       "description": "a very simple API"
     }
   ],

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
@@ -1,4 +1,5 @@
 {
+  "openapi": "3.0.0",
   "info": {
     "title": "title",
     "version": "1.2",
@@ -16,12 +17,6 @@
     {
       "name": "tag3",
       "description": "tag3 description"
-    }
-  ],
-  "servers": [
-    {
-      "url": "http://localhost:8000",
-      "description": "a very simple API"
     }
   ],
   "paths": {
@@ -106,26 +101,7 @@
                 "foo": 123
               },
               "schema": {
-                "additionalProperties": {
-                  "properties": {
-                    "foo": {
-                      "example": 123,
-                      "description": null,
-                      "type": "number"
-                    }
-                  },
-                  "example": {
-                    "foo": 123
-                  },
-                  "description": null,
-                  "type": "object",
-                  "required": [
-                    "foo"
-                  ]
-                },
-                "example": null,
-                "description": null,
-                "type": "object"
+                "$ref": "#/components/schemas/object-1898199891"
               }
             }
           },
@@ -166,9 +142,7 @@
                 "bool": true
               },
               "schema": {
-                "$ref": "#/components/schemas/someOtherId",
-                "example": null,
-                "description": null
+                "$ref": "#/components/schemas/someOtherId"
               }
             }
           },
@@ -203,9 +177,7 @@
                 }
               },
               "schema": {
-                "$ref": "#/components/schemas/ArbObject3",
-                "example": null,
-                "description": null
+                "$ref": "#/components/schemas/object-444827817"
               }
             }
           },
@@ -222,16 +194,10 @@
                   }
                 ],
                 "schema": {
+                  "type": "array",
                   "items": {
-                    "$ref": "#/components/schemas/ArbObject1"
-                  },
-                  "example": [
-                    {
-                      "anotherString": "bing"
-                    }
-                  ],
-                  "description": null,
-                  "type": "array"
+                    "$ref": "#/components/schemas/object-841092134"
+                  }
                 }
               }
             }
@@ -262,14 +228,10 @@
               "schema": {
                 "oneOf": [
                   {
-                    "$ref": "#/components/schemas/ArbObject1",
-                    "example": null,
-                    "description": null
+                    "$ref": "#/components/schemas/object-841092134"
                   },
                   {
-                    "$ref": "#/components/schemas/ArbObject3",
-                    "example": null,
-                    "description": null
+                    "$ref": "#/components/schemas/object-444827817"
                   }
                 ]
               }
@@ -307,9 +269,7 @@
                   "anotherString": "bing"
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/ArbObject1",
-                  "example": null,
-                  "description": null
+                  "$ref": "#/components/schemas/object-841092134"
                 }
               }
             }
@@ -321,14 +281,10 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/ArbObject1",
-                      "example": null,
-                      "description": null
+                      "$ref": "#/components/schemas/object-841092134"
                     },
                     {
-                      "$ref": "#/components/schemas/ArbObject3",
-                      "example": null,
-                      "description": null
+                      "$ref": "#/components/schemas/object-444827817"
                     }
                   ]
                 }
@@ -363,14 +319,10 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/impl1",
-                      "example": null,
-                      "description": null
+                      "$ref": "#/components/schemas/impl1"
                     },
                     {
-                      "$ref": "#/components/schemas/impl2",
-                      "example": null,
-                      "description": null
+                      "$ref": "#/components/schemas/impl2"
                     }
                   ]
                 }
@@ -465,7 +417,7 @@
               "schema": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/components/schemas/object1089648089"
+                  "$ref": "#/components/schemas/object540438179"
                 }
               }
             }
@@ -496,7 +448,6 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "example": null,
               "schema": {
               }
             }
@@ -534,7 +485,7 @@
                   "aNumberField": 123
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/object1089648089"
+                  "$ref": "#/components/schemas/object540438179"
                 }
               }
             }
@@ -601,11 +552,7 @@
             "description": "OK",
             "content": {
               "text/plain": {
-                "example": null,
                 "schema": {
-                  "example": "hello from the land of plaintext",
-                  "description": null,
-                  "type": "string"
                 }
               }
             }
@@ -633,8 +580,7 @@
             "text/plain": {
               "schema": {
                 "type": "string"
-              },
-              "example": "hello from the land of plaintext"
+              }
             }
           },
           "required": true
@@ -722,6 +668,15 @@
         "parameters": [
           {
             "schema": {
+              "$ref": "#/components/schemas/e"
+            },
+            "in": "header",
+            "name": "e",
+            "required": false,
+            "description": "enumHeader"
+          },
+          {
+            "schema": {
               "type": "boolean"
             },
             "in": "header",
@@ -746,17 +701,6 @@
             "name": "i",
             "required": false,
             "description": "intHeader"
-          },
-          {
-            "in": "header",
-            "name": "e",
-            "required": false,
-            "description": "enumHeader",
-            "schema": {
-              "$ref": "#/components/schemas/Foo",
-              "example": null,
-              "description": null
-            }
           },
           {
             "schema": {
@@ -902,6 +846,15 @@
         "parameters": [
           {
             "schema": {
+              "$ref": "#/components/schemas/foo"
+            },
+            "in": "path",
+            "name": "foo",
+            "required": true,
+            "description": null
+          },
+          {
+            "schema": {
               "type": "string"
             },
             "in": "path",
@@ -917,17 +870,6 @@
             "name": "age",
             "required": true,
             "description": null
-          },
-          {
-            "in": "path",
-            "name": "foo",
-            "required": true,
-            "description": null,
-            "schema": {
-              "$ref": "#/components/schemas/Foo",
-              "example": null,
-              "description": null
-            }
           }
         ],
         "responses": {
@@ -973,6 +915,15 @@
         "parameters": [
           {
             "schema": {
+              "$ref": "#/components/schemas/e"
+            },
+            "in": "query",
+            "name": "e",
+            "required": false,
+            "description": "enumQuery"
+          },
+          {
+            "schema": {
               "type": "array",
               "items": {
                 "type": "boolean"
@@ -1000,17 +951,6 @@
             "name": "i",
             "required": false,
             "description": "intQuery"
-          },
-          {
-            "in": "query",
-            "name": "e",
-            "required": false,
-            "description": "enumQuery",
-            "schema": {
-              "$ref": "#/components/schemas/Foo",
-              "example": null,
-              "description": null
-            }
           },
           {
             "schema": {
@@ -1052,7 +992,7 @@
                   "aString": "a message of some kind"
                 },
                 "schema": {
-                  "$ref": "#/components/schemas/object-2055192556"
+                  "$ref": "#/components/schemas/object-1104991605"
                 }
               }
             }
@@ -1071,16 +1011,21 @@
   },
   "components": {
     "schemas": {
-      "Foo": {
-        "example": "bing",
-        "enum": [
-          "bar",
-          "bing"
+      "foo": {
+        "type": "object",
+        "required": [
         ],
-        "description": null,
-        "type": "string"
+        "properties": {
+        }
       },
-      "object1089648089": {
+      "e": {
+        "type": "object",
+        "required": [
+        ],
+        "properties": {
+        }
+      },
+      "object540438179": {
         "type": "object",
         "required": [
         ],
@@ -1097,11 +1042,11 @@
         ],
         "properties": {
           "anAnotherObject": {
-            "$ref": "#/components/schemas/object1089648089"
+            "$ref": "#/components/schemas/object540438179"
           }
         }
       },
-      "object-2055192556": {
+      "object-1104991605": {
         "type": "object",
         "required": [
         ],
@@ -1113,182 +1058,61 @@
         }
       },
       "someOtherId": {
-        "properties": {
-          "string": {
-            "example": "s",
-            "description": null,
-            "type": "string"
-          },
-          "child": {
-            "$ref": "#/components/schemas/ArbObject1",
-            "example": null,
-            "description": null
-          },
-          "numbers": {
-            "items": {
-              "type": "number"
-            },
-            "example": [
-              1
-            ],
-            "description": null,
-            "type": "array"
-          },
-          "bool": {
-            "example": true,
-            "description": null,
-            "type": "boolean"
-          }
-        },
-        "example": {
-          "string": "s",
-          "child": {
-            "anotherString": "bar"
-          },
-          "numbers": [
-            1
-          ],
-          "bool": true
-        },
-        "description": null,
         "type": "object",
         "required": [
-          "bool",
-          "numbers",
-          "string"
-        ]
+        ],
+        "properties": {
+        }
       },
-      "ArbObject1": {
+      "object-841092134": {
+        "type": "object",
+        "required": [
+        ],
         "properties": {
           "anotherString": {
-            "$ref": "#/components/schemas/Foo",
-            "example": null,
-            "description": null
+            "type": "string",
+            "example": "bing"
           }
-        },
-        "example": {
-          "anotherString": "bing"
-        },
-        "description": null,
+        }
+      },
+      "object-1898199891": {
         "type": "object",
         "required": [
-          "anotherString"
-        ]
+        ],
+        "properties": {
+          "foo": {
+            "type": "integer",
+            "example": 123
+          }
+        }
       },
-      "ArbObject3": {
+      "object-444827817": {
+        "type": "object",
+        "required": [
+        ],
         "properties": {
           "uri": {
-            "example": "http://foowang",
-            "description": null,
-            "type": "string"
+            "type": "string",
+            "example": "http://foowang"
           },
           "additional": {
-            "additionalProperties": {
-              "properties": {
-                "foo": {
-                  "example": 123,
-                  "description": null,
-                  "type": "number"
-                }
-              },
-              "example": {
-                "foo": 123
-              },
-              "description": null,
-              "type": "object",
-              "required": [
-                "foo"
-              ]
-            },
-            "example": null,
-            "description": null,
-            "type": "object"
+            "$ref": "#/components/schemas/object-1898199891"
           }
-        },
-        "example": {
-          "uri": "http://foowang",
-          "additional": {
-            "foo": 123
-          }
-        },
-        "description": null,
-        "type": "object",
-        "required": [
-          "additional",
-          "uri"
-        ]
+        }
       },
       "impl1": {
-        "properties": {
-          "obj": {
-            "$ref": "#/components/schemas/Impl1",
-            "example": null,
-            "description": null
-          }
-        },
-        "example": {
-          "obj": {
-            "value": "bob"
-          }
-        },
-        "description": null,
         "type": "object",
         "required": [
-          "obj"
-        ]
-      },
-      "Impl1": {
+        ],
         "properties": {
-          "value": {
-            "example": "bob",
-            "description": null,
-            "type": "string"
-          }
-        },
-        "example": {
-          "value": "bob"
-        },
-        "description": null,
-        "type": "object",
-        "required": [
-          "value"
-        ]
+        }
       },
       "impl2": {
-        "properties": {
-          "obj": {
-            "$ref": "#/components/schemas/Impl2",
-            "example": null,
-            "description": null
-          }
-        },
-        "example": {
-          "obj": {
-            "value": 123
-          }
-        },
-        "description": null,
         "type": "object",
         "required": [
-          "obj"
-        ]
-      },
-      "Impl2": {
+        ],
         "properties": {
-          "value": {
-            "example": 123,
-            "description": null,
-            "type": "number"
-          }
-        },
-        "example": {
-          "value": 123
-        },
-        "description": null,
-        "type": "object",
-        "required": [
-          "value"
-        ]
+        }
       }
     },
     "securitySchemes": {
@@ -1335,7 +1159,12 @@
       }
     }
   },
-  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "/",
+      "description": ""
+    }
+  ],
   "x-extension": [
     "extensionField"
   ]

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.when enabled renders description including its own path.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.when enabled renders description including its own path.approved
@@ -1,16 +1,11 @@
 {
+  "openapi": "3.0.0",
   "info": {
     "title": "title",
     "version": "1.2",
     "description": "module description"
   },
   "tags": [
-  ],
-  "servers": [
-    {
-      "url": "http://localhost:8000",
-      "description": "a very simple API"
-    }
   ],
   "paths": {
     "": {
@@ -67,7 +62,12 @@
       }
     }
   },
-  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "/",
+      "description": ""
+    }
+  ],
   "x-extension": [
     "extensionField"
   ]

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
@@ -1161,7 +1161,7 @@
   },
   "servers": [
     {
-      "url": "localhost:8000",
+      "url": "https://localhost:8000",
       "description": ""
     }
   ],

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
@@ -1159,6 +1159,12 @@
       }
     }
   },
+  "servers": [
+    {
+      "url": "localhost:8000",
+      "description": ""
+    }
+  ],
   "x-extension": [
     "extensionField"
   ]

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.when enabled renders description including its own path.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.when enabled renders description including its own path.approved
@@ -62,6 +62,12 @@
       }
     }
   },
+  "servers": [
+    {
+      "url": "localhost:8000",
+      "description": ""
+    }
+  ],
   "x-extension": [
     "extensionField"
   ]

--- a/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.when enabled renders description including its own path.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.when enabled renders description including its own path.approved
@@ -64,7 +64,7 @@
   },
   "servers": [
     {
-      "url": "localhost:8000",
+      "url": "https://localhost:8000",
       "description": ""
     }
   ],

--- a/http4k-testing/chaos/src/test/resources/org/http4k/chaos/ChaosEngineTest.chaos API is available as openapi JSON.approved
+++ b/http4k-testing/chaos/src/test/resources/org/http4k/chaos/ChaosEngineTest.chaos API is available as openapi JSON.approved
@@ -6,6 +6,11 @@
   },
   "tags": [
   ],
+  "servers": [
+    {
+      "url": "/"
+    }
+  ],
   "paths": {
     "/chaos/activate": {
       "post": {

--- a/src/docs/guide/howto/integrate_with_openapi/example.kt
+++ b/src/docs/guide/howto/integrate_with_openapi/example.kt
@@ -16,6 +16,7 @@ import org.http4k.core.HttpTransaction
 import org.http4k.core.Method.GET
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
+import org.http4k.core.Uri
 import org.http4k.core.then
 import org.http4k.core.with
 import org.http4k.filter.CachingFilters.Response.NoCache
@@ -58,7 +59,7 @@ fun main() {
     val mySecurity = ApiKeySecurity(Query.int().required("apiKey"), { it == 42 })
 
     val contract = contract {
-        renderer = OpenApi3(ApiInfo("my great api", "v1.0"), Argo, servers = listOf(ApiServer("http://localhost:8000", "the greatest server")))
+        renderer = OpenApi3(ApiInfo("my great api", "v1.0"), Argo, servers = listOf(ApiServer(Uri.of("http://localhost:8000"), "the greatest server")))
         descriptionPath = "/docs/swagger.json"
         security = mySecurity
 

--- a/src/docs/guide/howto/integrate_with_openapi/example.kt
+++ b/src/docs/guide/howto/integrate_with_openapi/example.kt
@@ -5,6 +5,7 @@ import org.http4k.contract.contract
 import org.http4k.contract.div
 import org.http4k.contract.meta
 import org.http4k.contract.openapi.ApiInfo
+import org.http4k.contract.openapi.v3.ApiServer
 import org.http4k.contract.openapi.v3.OpenApi3
 import org.http4k.contract.security.ApiKeySecurity
 import org.http4k.core.Body
@@ -57,7 +58,7 @@ fun main() {
     val mySecurity = ApiKeySecurity(Query.int().required("apiKey"), { it == 42 })
 
     val contract = contract {
-        renderer = OpenApi3(ApiInfo("my great api", "v1.0"), Argo)
+        renderer = OpenApi3(ApiInfo("my great api", "v1.0"), Argo, servers = listOf(ApiServer("http://localhost:8000", "the greatest server")))
         descriptionPath = "/docs/swagger.json"
         security = mySecurity
 

--- a/src/docs/guide/howto/integrate_with_openapi/example.kt
+++ b/src/docs/guide/howto/integrate_with_openapi/example.kt
@@ -59,7 +59,11 @@ fun main() {
     val mySecurity = ApiKeySecurity(Query.int().required("apiKey"), { it == 42 })
 
     val contract = contract {
-        renderer = OpenApi3(ApiInfo("my great api", "v1.0"), Argo, servers = listOf(ApiServer(Uri.of("http://localhost:8000"), "the greatest server")))
+        renderer = OpenApi3(
+            ApiInfo("my great api", "v1.0"),
+            Argo,
+            servers = listOf(ApiServer(Uri.of("http://localhost:8000"), "the greatest server"))
+        )
         descriptionPath = "/docs/swagger.json"
         security = mySecurity
 


### PR DESCRIPTION
This is my attempt at finishing off @zsambek's https://github.com/http4k/http4k/pull/510. There were some outstanding issues with https://github.com/http4k/http4k/pull/510 this PR hopefully resolves:
- rename ServerObject to ApiServer
- remove wildcard imports
- update examples
- add spec-compliant default
- change url type from `String` to `Uri`

I was uncertain on some formatting around when and where to make newlines for longer lines, let me know if there are any offensive formatting errors.