### PR TITLE
Add URI parser

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/UriTemplate.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/UriTemplate.kt
@@ -4,54 +4,171 @@ import java.net.URLDecoder
 import java.net.URLEncoder
 import java.util.regex.Pattern
 
-data class UriTemplate private constructor(private val template: String) {
-    private val templateRegex = template.replace(URI_TEMPLATE_FORMAT,
-        { notMatched -> Pattern.quote(notMatched) },
-        { matched ->
-            when {
-                matched.groupValues[2].isBlank() -> "([^/]+)"
-                else -> "(${matched.groupValues[2]})"
-            }
-        }).toRegex()
-
-    private val matches = URI_TEMPLATE_FORMAT.findAll(template)
-    private val parameterNames = matches.map { it.groupValues[1] }.toList()
-
+data class UriTemplate private constructor(
+    private val template: String,
+    private val templateRegex: Regex,
+    private val tokens: List<UriToken>,
+) {
     companion object {
-        private val URI_TEMPLATE_FORMAT = "\\{([^}]+?)(?::([^}]+))?\\}".toRegex() // ignore redundant warning #100
-        fun from(template: String) = UriTemplate(template.trimSlashes())
-
-        private fun String.trimSlashes() = "^(/)?(.*?)(/)?$".toRegex().replace(this) { result -> result.groupValues[2] }
+        fun from(template: String): UriTemplate {
+            val trimmedTemplate = template.trim('/')
+            val tokens = parseUriTemplate(trimmedTemplate)
+            return UriTemplate(
+                template = trimmedTemplate,
+                templateRegex = tokens.toRegex(),
+                tokens = tokens
+            )
+        }
     }
 
-    fun matches(uri: String): Boolean = templateRegex.matches(uri.trimSlashes())
+    fun matches(uri: String): Boolean = templateRegex.matches(uri.trim('/'))
 
-    fun extract(uri: String): Map<String, String> =
-        parameterNames.zip(templateRegex.findParameterValues(uri.trimSlashes())).toMap()
-
-    fun generate(parameters: Map<String, String>): String =
-        template.replace(URI_TEMPLATE_FORMAT) { matchResult ->
-            val paramValue = parameters[matchResult.groupValues[1]] ?: ""
-            if (paramValue.contains("/")) paramValue else URLEncoder.encode(paramValue, "UTF-8")
+    fun extract(uri: String): Map<String, String> {
+        val match = templateRegex.find(uri.trim('/')) ?: return mapOf()
+        return tokens.filterIsInstance<ParameterUriSegment>().associate {
+            it.name to URLDecoder.decode(match.groups[it.name]!!.value)
         }
-
-    private fun Regex.findParameterValues(uri: String): List<String> =
-        findAll(uri).first().groupValues.drop(1).map { URLDecoder.decode(it, "UTF-8") }
-
-    private fun String.replace(regex: Regex, notMatched: (String) -> String, matched: (MatchResult) -> String): String {
-        val matches = regex.findAll(this)
-        val builder = StringBuilder()
-        var position = 0
-        for (matchResult in matches) {
-            val before = substring(position, matchResult.range.first)
-            if (before.isNotEmpty()) builder.append(notMatched(before))
-            builder.append(matched(matchResult))
-            position = matchResult.range.last + 1
-        }
-        val after = substring(position, length)
-        if (after.isNotEmpty()) builder.append(notMatched(after))
-        return builder.toString()
     }
+
+    fun generate(parameters: Map<String, String>): String = tokens.toUri(parameters)
 
     override fun toString(): String = template
+}
+
+private sealed interface UriToken
+
+private data class LiteralUriSegment(val text: String) : UriToken
+
+private data class ParameterUriSegment(val name: String, val regex: String?) : UriToken
+
+private fun List<UriToken>.toRegex(): Regex {
+    val pattern = StringBuilder()
+    for (token in this) {
+        when (token) {
+            is LiteralUriSegment -> pattern.append(Pattern.quote(token.text))
+            is ParameterUriSegment -> {
+                val name = token.name.trim()
+                val groupName = if (name.isEmpty()) "" else "?<$name>"
+                val regex = if (token.regex == null || name.isEmpty()) "[^/]+" else token.regex
+                pattern.append("($groupName${regex})")
+            }
+        }
+    }
+    return Regex(pattern.toString())
+}
+
+private fun List<UriToken>.toUri(parameters: Map<String, String>): String {
+    val uri = StringBuilder()
+    for (token in this) {
+        when (token) {
+            is LiteralUriSegment -> uri.append(token.text)
+            is ParameterUriSegment -> {
+                val paramValue = parameters.getOrDefault(token.name, "")
+                if (paramValue.contains("/")) {
+                    uri.append(paramValue)
+                } else {
+                    uri.append(URLEncoder.encode(paramValue, "UTF-8"))
+                }
+            }
+        }
+    }
+    return uri.toString()
+}
+
+private fun parseUriTemplate(template: String): List<UriToken> {
+    val chars = template.iterator()
+    val currentToken = StringBuilder()
+
+    val tokens = ArrayList<UriToken>()
+    while (chars.hasNext()) {
+        var char = chars.next()
+        if (char == '{') {
+            // we found the beginning of a potential path parameter, so store
+            // whatever token we've collected until now as a literal URI segment
+            currentToken.addAsLiteralUriSegmentTo(tokens)
+
+            // attempt to read the full contents of the path parameter
+            var lastChar = char
+            var openBraceCount = 1
+            while (openBraceCount > 0 && chars.hasNext()) {
+                char = chars.next()
+                if (char == '}') {
+                    // if parameter end is escaped we don't count it
+                    if (lastChar != '\\')
+                        openBraceCount--
+                    if (openBraceCount > 0)
+                    // we don't want to keep the very last time we encounter the ending
+                    // character, but everything else we should keep
+                        currentToken.append(char)
+                } else if (char == '{') {
+                    // if parameter start is escaped we don't count it
+                    if (lastChar != '\\')
+                        openBraceCount++
+                    currentToken.append(char)
+                } else {
+                    currentToken.append(char)
+                }
+                lastChar = char
+            }
+            if (openBraceCount == 0) {
+                // the parameter was successfully parsed, so add it as a parameter URI segment
+                currentToken.addAsParameterUriSegmentTo(tokens)
+            } else {
+                // the parameter definition wasn't properly closed, consider it a literal
+                currentToken.insert(0, '{')
+                currentToken.addAsLiteralUriSegmentTo(tokens)
+            }
+        } else {
+            currentToken.append(char)
+        }
+    }
+    // Any remaining token is a literal URI segment
+    currentToken.addAsLiteralUriSegmentTo(tokens)
+
+    // We might have several consecutive segments that were identified as being literal URI segments,
+    // so we collapse them all into one
+    val reducedTokens = ArrayList<UriToken>()
+    for (token in tokens) {
+        if (token is LiteralUriSegment) {
+            val lastIsLiteral = reducedTokens.isNotEmpty() && reducedTokens.last() is LiteralUriSegment
+            if (lastIsLiteral) {
+                val last = reducedTokens.removeLast() as LiteralUriSegment
+                reducedTokens.add(LiteralUriSegment(text = last.text + token.text))
+            } else {
+                reducedTokens.add(token)
+            }
+        } else {
+            reducedTokens.add(token)
+        }
+    }
+    return reducedTokens
+}
+
+private fun StringBuilder.addAsLiteralUriSegmentTo(tokens: MutableList<UriToken>) {
+    if (isEmpty()) return
+
+    val segment = LiteralUriSegment(text = toString())
+    tokens.add(segment)
+
+    clear()
+}
+
+private fun StringBuilder.addAsParameterUriSegmentTo(tokens: MutableList<UriToken>) {
+    if (isEmpty()) return
+
+    val text = toString()
+    val separatorIndex = text.indexOf(':')
+
+    if (separatorIndex >= 0) {
+        tokens.add(
+            ParameterUriSegment(
+                name = text.substring(0, separatorIndex),
+                regex = text.substring(separatorIndex + 1)
+            )
+        )
+    } else {
+        tokens.add(ParameterUriSegment(name = text, regex = null))
+    }
+
+    clear()
 }

--- a/http4k-core/src/test/kotlin/org/http4k/core/UriTemplateTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/UriTemplateTest.kt
@@ -3,7 +3,6 @@ package org.http4k.core
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.http4k.core.UriTemplate.Companion.from
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class UriTemplateTest {
@@ -14,11 +13,13 @@ class UriTemplateTest {
 
         assertThat(
             template.generate(pathParameters(pair("name", "a name with spaces"))),
-            equalTo("properties/a+name+with+spaces"))
+            equalTo("properties/a+name+with+spaces")
+        )
 
         assertThat(
             template.generate(pathParameters(pair("name", "a/name/with/slashes"))),
-            equalTo("properties/a/name/with/slashes"))
+            equalTo("properties/a/name/with/slashes")
+        )
     }
 
     @Test
@@ -28,7 +29,10 @@ class UriTemplateTest {
         val parameters = template.extract("properties/123/bob")
         assertThat(parameters.getValue("id"), equalTo("123"))
         assertThat(parameters.getValue("name"), equalTo("bob"))
-        assertThat(template.generate(pathParameters(pair("id", "123"), pair("name", "bob"))), equalTo("properties/123/bob"))
+        assertThat(
+            template.generate(pathParameters(pair("id", "123"), pair("name", "bob"))),
+            equalTo("properties/123/bob")
+        )
     }
 
     @Test
@@ -134,10 +138,11 @@ class UriTemplateTest {
     }
 
     @Test
-    @Disabled
     fun greedyQualifiersAreNotReplaced() {
-         val patternWithGreedyQualifier = "[a-z]{3}"
-        assertThat(from("/foo/{bar:$patternWithGreedyQualifier}").matches("/foo/abc"), equalTo(true))
+        val patternWithGreedyQualifier = "[a-z]{3}"
+        val template = from("/foo/{bar:$patternWithGreedyQualifier}")
+        assertThat(template.matches("/foo/abc"), equalTo(true))
+        assertThat(template.extract("/foo/abc").getValue("bar"), equalTo("abc"))
     }
 
     private fun pathParameters(vararg pairs: Pair<String, String>): Map<String, String> = mapOf(*pairs)


### PR DESCRIPTION
Replaces the UriTemplate logic by a custom parser that handles complex regular expressions (i.e. regular expressions that contain the delimiters for the path parameters).

The focus is on keeping the public API of the `UriTemplate` 100% compatible with the previous implementation while overhauling its internal handling of regular expressions in path parameters.

This PR is mostly raised as an example of a potential fix for #676, it does not attempt to include everything that is required in terms of quality checks for an actual contribution, although it can be added if needed.