### PR TITLE
add autoBody for ConfigurableJacksonXml

### DIFF
--- a/http4k-format/core/src/main/kotlin/org/http4k/format/AutoMarshallingXml.kt
+++ b/http4k-format/core/src/main/kotlin/org/http4k/format/AutoMarshallingXml.kt
@@ -2,6 +2,7 @@ package org.http4k.format
 
 import org.http4k.asString
 import org.http4k.core.Body
+import org.http4k.core.ContentType
 import org.http4k.core.ContentType.Companion.APPLICATION_XML
 import org.http4k.lens.BiDiBodyLensSpec
 import org.http4k.lens.BiDiWsMessageLensSpec
@@ -20,8 +21,8 @@ abstract class AutoMarshallingXml : AutoMarshalling() {
 
     override fun asFormatString(input: Any): String = input.asXmlString()
 
-    inline fun <reified T : Any> Body.Companion.auto(description: String? = null, contentNegotiation: ContentNegotiation = ContentNegotiation.None): BiDiBodyLensSpec<T> =
-        httpBodyRoot(listOf(Meta(true, "body", ObjectParam, "body", description)), APPLICATION_XML, contentNegotiation)
+    inline fun <reified T : Any> Body.Companion.auto(description: String? = null, contentNegotiation: ContentNegotiation = ContentNegotiation.None, contentType: ContentType = APPLICATION_XML): BiDiBodyLensSpec<T> =
+        httpBodyRoot(listOf(Meta(true, "body", ObjectParam, "body", description)), contentType, contentNegotiation)
             .map({ it.payload.asString() }, { Body(it) })
             .map({ it.asA<T>() }, { it.asXmlString() })
 

--- a/http4k-format/jackson-xml/src/main/kotlin/org/http4k/format/ConfgurableJacksonXml.kt
+++ b/http4k-format/jackson-xml/src/main/kotlin/org/http4k/format/ConfgurableJacksonXml.kt
@@ -3,14 +3,31 @@ package org.http4k.format
 import com.fasterxml.jackson.dataformat.xml.JacksonXmlModule
 import com.fasterxml.jackson.dataformat.xml.XmlMapper
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import org.http4k.asString
+import org.http4k.core.Body
+import org.http4k.core.ContentType
+import org.http4k.lens.BiDiBodyLensSpec
+import org.http4k.lens.ContentNegotiation
+import org.http4k.lens.Meta
+import org.http4k.lens.ParamMeta
+import org.http4k.lens.httpBodyRoot
 import java.io.InputStream
 import kotlin.reflect.KClass
 
-open class ConfigurableJacksonXml(private val mapper: XmlMapper) : AutoMarshallingXml() {
+open class ConfigurableJacksonXml(private val mapper: XmlMapper, val defaultContentType: ContentType = ContentType.APPLICATION_XML) : AutoMarshallingXml() {
     override fun Any.asXmlString(): String = mapper.writeValueAsString(this)
 
     override fun <T : Any> asA(input: String, target: KClass<T>): T = mapper.readValue(input, target.java)
     override fun <T : Any> asA(input: InputStream, target: KClass<T>): T = mapper.readValue(input, target.java)
+
+    inline fun <reified T : Any> autoBody(
+        description: String? = null,
+        contentNegotiation: ContentNegotiation = ContentNegotiation.None,
+        contentType: ContentType = defaultContentType
+    ): BiDiBodyLensSpec<T> =
+        httpBodyRoot(listOf(Meta(true, "body", ParamMeta.ObjectParam, "body", description)), contentType, contentNegotiation)
+            .map({ it.payload.asString() }, { Body(it) })
+            .map({ it.asA<T>() }, { it.asXmlString() })
 }
 
 fun KotlinModule.asConfigurableXml() = asConfigurable(


### PR DESCRIPTION
This adds an `autoBody` method for a `ConfigurableJacksonXml` instance.  This is useful for creating a `Lens` for a custom xml marshaller.

It also lets you override the `ContentType` of `JacksonXml`'s `Body.auto` method.