### PR TITLE
The woff2 font format is now widely supported. https://caniuse.com/woff2

### DIFF
--- a/http4k-core/src/main/resources/META-INF/org/http4k/core/mime.types
+++ b/http4k-core/src/main/resources/META-INF/org/http4k/core/mime.types
@@ -507,6 +507,7 @@ application/x-font-snf				snf
 application/x-font-ttf				ttf ttc
 application/x-font-type1			pfa pfb pfm afm
 application/x-font-woff				woff
+application/x-font-woff2			woff2
 application/x-freearc				arc
 application/x-futuresplash			spl
 application/x-gca-compressed			gca


### PR DESCRIPTION
I can't see a reason why the woff2 format wouldn't be supported out-of-the-box. It's widely supported and has much better compression than woff. See browser support here: https://caniuse.com/woff2