### PR TITLE
Fixed URLPathSegment encoding/decoding based on RFC 3986

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
@@ -14,7 +14,7 @@ import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.Uri
 import org.http4k.core.then
-import org.http4k.core.toPathDecoded
+import org.http4k.core.toPathSegmentDecoded
 import org.http4k.filter.ServerFilters
 import org.http4k.lens.LensFailure
 import org.http4k.lens.PathLens
@@ -89,7 +89,7 @@ private operator fun <T> PathSegments.invoke(index: Int, fn: (String) -> T): T? 
 private fun PathSegments.extract(lenses: List<PathLens<*>>): ExtractedParts? =
     when (toList().size) {
         lenses.size -> ExtractedParts(
-            lenses.mapIndexed { i, lens -> lens to this(i) { lens(it.toPathDecoded()) } }.toMap()
+            lenses.mapIndexed { i, lens -> lens to this(i) { lens(it.toPathSegmentDecoded()) } }.toMap()
         )
         else -> null
     }

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
@@ -39,7 +39,7 @@ class ContractRouteTest {
         val route = pair to { _, _ -> { Response(OK) } }
         val request = route.newRequest(Uri.of("http://rita.com"))
 
-        assertThat(request.with(path1 of 123, path2 of "hello world"), equalTo(Request(GET, "http://rita.com/123/hello+world")))
+        assertThat(request.with(path1 of 123, path2 of "hello world"), equalTo(Request(GET, "http://rita.com/123/hello%20world")))
     }
 
     @Test
@@ -60,7 +60,7 @@ class ContractRouteTest {
             queries += Query.required("")
         } bindContract GET).newRequest(Uri.of("http://rita.com/base"))
 
-        assertThat(request.with(path1 of 123, path2 of "hello world"), equalTo(Request(GET, "http://rita.com/123/hello+world")))
+        assertThat(request.with(path1 of 123, path2 of "hello world"), equalTo(Request(GET, "http://rita.com/123/hello%20world")))
     }
 
     @Test
@@ -71,7 +71,7 @@ class ContractRouteTest {
             queries += Query.required("")
         } bindContract GET).newRequest()
 
-        assertThat(request.with(path1 of 123, path2 of "hello world"), equalTo(Request(GET, "/123/hello+world")))
+        assertThat(request.with(path1 of 123, path2 of "hello world"), equalTo(Request(GET, "/123/hello%20world")))
     }
 
     @Test

--- a/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
@@ -4,7 +4,6 @@ import org.http4k.appendIfNotBlank
 import org.http4k.appendIfPresent
 import java.net.URLDecoder
 import java.net.URLEncoder
-import java.nio.charset.StandardCharsets.UTF_8
 
 data class Uri(val scheme: String, val userInfo: String, val host: String, val port: Int?, val path: String, val query: String, val fragment: String) : Comparable<Uri> {
 
@@ -69,10 +68,31 @@ fun Uri.removeQueries(prefix: String) = copy(query = query.toParameters().filter
 
 fun Uri.query(name: String, value: String?): Uri = copy(query = query.toParameters().plus(name to value).toUrlFormEncoded())
 
-// Use the older encode/decode methods here - this maintains compatibility
-// with JDK-8
-fun String.toPathEncoded() = URLEncoder.encode(this, "UTF-8")
-fun String.toPathDecoded() = URLDecoder.decode(this, "UTF-8")
+/**
+ * @see [RFC 3986, appendix A](https://www.ietf.org/rfc/rfc3986.txt)
+ */
+private val validPathSegmentChars = listOf(
+    // "-", ".", "_"  unreserved but these won't be url encoded, so there is no need to decode them
+    "~",                                              // unreserved
+    "!", "$", "&", "'", "(", ")", "+", ",", ";", "=", // sub-delims
+    ":", "@"                                          // valid
+).map {
+    it to URLEncoder.encode(it, "UTF-8")
+}
+
+fun String.toPathSegmentEncoded(): String = URLEncoder.encode(this, "UTF-8")
+        .replace("+", "%20")
+        .let {
+            validPathSegmentChars.fold(it) { acc, ch ->
+                acc.replace(ch.second, ch.first)
+            }
+        }
+
+fun String.toPathSegmentDecoded(): String =
+    this.replace("+", "%2B")
+        .let {
+            URLDecoder.decode(it, "UTF-8")
+        }
 
 fun Uri.extend(uri: Uri): Uri =
     appendToPath(uri.path).copy(query = (query.toParameters() + uri.query.toParameters()).toUrlFormEncoded())

--- a/http4k-core/src/main/kotlin/org/http4k/core/UriTemplate.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/UriTemplate.kt
@@ -1,7 +1,5 @@
 package org.http4k.core
 
-import java.net.URLDecoder
-import java.net.URLEncoder
 import java.util.regex.Pattern
 
 data class UriTemplate private constructor(private val template: String) {
@@ -32,11 +30,11 @@ data class UriTemplate private constructor(private val template: String) {
     fun generate(parameters: Map<String, String>): String =
         template.replace(URI_TEMPLATE_FORMAT) { matchResult ->
             val paramValue = parameters[matchResult.groupValues[1]] ?: ""
-            if (paramValue.contains("/")) paramValue else URLEncoder.encode(paramValue, "UTF-8")
+            if (paramValue.contains("/")) paramValue else paramValue.toPathSegmentEncoded()
         }
 
     private fun Regex.findParameterValues(uri: String): List<String> =
-        findAll(uri).first().groupValues.drop(1).map { URLDecoder.decode(it, "UTF-8") }
+        findAll(uri).first().groupValues.drop(1).map { it.toPathSegmentDecoded() }
 
     private fun String.replace(regex: Regex, notMatched: (String) -> String, matched: (MatchResult) -> String): String {
         val matches = regex.findAll(this)

--- a/http4k-core/src/main/kotlin/org/http4k/lens/path.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/path.kt
@@ -1,7 +1,7 @@
 package org.http4k.lens
 
 import org.http4k.core.Request
-import org.http4k.core.toPathEncoded
+import org.http4k.core.toPathSegmentEncoded
 import org.http4k.lens.ParamMeta.BooleanParam
 import org.http4k.lens.ParamMeta.EnumParam
 import org.http4k.lens.ParamMeta.IntegerParam
@@ -93,7 +93,7 @@ object Path : BiDiPathLensSpec<String>(StringParam,
             target.uri.path(
                 target.uri.path.replaceFirst(
                     "{$name}",
-                    values.first().toPathEncoded()
+                    values.first().toPathSegmentEncoded()
                 )
             )
         )

--- a/http4k-core/src/test/kotlin/org/http4k/core/UriTemplateTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/UriTemplateTest.kt
@@ -92,7 +92,7 @@ class UriTemplateTest {
     @Test
     fun canExtractFromUriWithEncodedSpace() {
         val template = from("path/{id1}")
-        assertThat(template.extract("path/foo+bar").getValue("id1"), equalTo("foo+bar"))
+        assertThat(template.extract("path/foo%20bar").getValue("id1"), equalTo("foo bar"))
     }
 
     @Test

--- a/http4k-core/src/test/kotlin/org/http4k/core/UriTemplateTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/UriTemplateTest.kt
@@ -14,7 +14,7 @@ class UriTemplateTest {
 
         assertThat(
             template.generate(pathParameters(pair("name", "a name with spaces"))),
-            equalTo("properties/a+name+with+spaces"))
+            equalTo("properties/a%20name%20with%20spaces"))
 
         assertThat(
             template.generate(pathParameters(pair("name", "a/name/with/slashes"))),
@@ -92,7 +92,7 @@ class UriTemplateTest {
     @Test
     fun canExtractFromUriWithEncodedSpace() {
         val template = from("path/{id1}")
-        assertThat(template.extract("path/foo+bar").getValue("id1"), equalTo("foo bar"))
+        assertThat(template.extract("path/foo+bar").getValue("id1"), equalTo("foo+bar"))
     }
 
     @Test
@@ -109,7 +109,7 @@ class UriTemplateTest {
     }
 
     @Test
-    fun matchedValuesAreUrlDecoded() {
+    fun matchedValuesArePathDecoded() {
         val extracted = from("path/{band}").extract("path/Earth%2C%20Wind%20%26%20Fire")
         assertThat(extracted.getValue("band"), equalTo("Earth, Wind & Fire"))
     }

--- a/http4k-core/src/test/kotlin/org/http4k/core/UriTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/UriTest.kt
@@ -92,8 +92,8 @@ class UriTest {
     @Test
     fun `can encode a path segment correctly`() {
         val original = "123 / 456"
-        val encoded = "123+%2F+456"
-        assertThat(original.toPathEncoded(), equalTo(encoded))
+        val encoded = "123%20%2F%20456"
+        assertThat(original.toPathSegmentEncoded(), equalTo(encoded))
     }
 
     @Test

--- a/http4k-core/src/test/kotlin/org/http4k/lens/PathTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/PathTest.kt
@@ -20,7 +20,7 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
-import java.util.UUID
+import java.util.*
 
 class PathTest {
 
@@ -86,9 +86,14 @@ class PathTest {
             assertThat(pathParam(updated), equalTo(unencoded))
         }
 
-        checkEncodeDecode("123 45/6", "123+45%2F6")
-        checkEncodeDecode("Bob Tables%/M", "Bob+Tables%25%2FM")
-        checkEncodeDecode("2020-03-19T19:12:34.567+01:00", "2020-03-19T19%3A12%3A34.567%2B01%3A00")
+        // unreserved
+        checkEncodeDecode("azAZ09-._~", "azAZ09-._~")
+        // subdelimiter
+        checkEncodeDecode("!$&'()*+,;=", "!$&'()*+,;=")
+        // others
+        checkEncodeDecode(":@", ":@")
+        checkEncodeDecode("Bob Tables%/M", "Bob%20Tables%25%2FM")
+        checkEncodeDecode("2020-03-19T19:12:34.567+01:00", "2020-03-19T19:12:34.567+01:00")
         checkEncodeDecode("ÅÄÖ", "%C3%85%C3%84%C3%96")
         checkDecode("Bob%20Tables%25%2FM", "Bob Tables%/M")
         checkDecode("ÅÄÖ", "ÅÄÖ")

--- a/src/docs/guide/reference/core/RoutingTest.kt
+++ b/src/docs/guide/reference/core/RoutingTest.kt
@@ -21,7 +21,7 @@ class DynamicPathTest {
     @Test
     fun `echoes body from path`() {
         val route: RoutingHttpHandler = routes(EchoPath)
-        val response: Response = route(Request(GET, "/echo/my+great+message"))
+        val response: Response = route(Request(GET, "/echo/my%20great%20message"))
         assertThat(response, hasStatus(OK).and(hasBody("my great message")))
     }
 }


### PR DESCRIPTION
See [appendix A (https://www.ietf.org/rfc/rfc3986.txt)](https://datatracker.ietf.org/doc/html/rfc3986#appendix-A) for details about valid path segments. In summary the spec indicates that a valid path segment can contain:
```
segment       = *pchar
pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
pct-encoded   = "%" HEXDIG HEXDIG
unreserved    = ALPHA / DIGIT / "-" / "." / "_" / "~"
sub-delims    = "!" / "$" / "&" / "'" / "(" / ")"
              / "*" / "+" / "," / ";" / "="
```

The implementation can probably be optimised but the PathTest.kt tests should now capture the specification more accurately and `toPathSegmentEncoded` / `toPathSegmentDecoded` are used to encode/decode path segments.

This will change the current path encoding behaviour allowing the characters above, although technically it is a fix, I am not sure whether it should be flagged as a breaking change.

Fixes http4k/http4k#602