### PR TITLE
fix: Keep-alive for Netty when not streaming

### DIFF
--- a/http4k-core/src/test/kotlin/org/http4k/server/ServerContract.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/server/ServerContract.kt
@@ -194,6 +194,18 @@ abstract class ServerContract(private val serverConfig: (Int) -> ServerConfig, p
             ))
     }
 
+    @Test
+    fun `sets keep-alive for non-streaming response`() {
+        assertThat(client(Request(GET, "$baseUrl/headers")),
+            allOf(hasStatus(ACCEPTED),
+                hasHeader("connection", "keep-alive")
+            ))
+        assertThat(client(Request(GET, "$baseUrl/stream")),
+            allOf(hasStatus(OK),
+                hasHeader("connection", "close")
+            ))
+    }
+
     open fun clientAddress() = anyOf(
         equalTo(InetAddress.getLoopbackAddress().hostAddress),
         equalTo(InetAddress.getLocalHost().hostAddress),


### PR DESCRIPTION
I have noticed that the Netty implementation does not respect connection keep-alive and the reason is because `HttpServerKeepAliveHandler` from Netty disables keep-alive whenever the content-length is unknown: https://github.com/netty/netty/blob/4.1/codec-http/src/main/java/io/netty/handler/codec/http/HttpServerKeepAliveHandler.java#L115

So I reimplemented `Http4kChannelHandler` to differentiate between the streaming and non-streaming case.