### PR TITLE
Added ContentDispositionAttachment server filter

### DIFF
--- a/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
@@ -11,7 +11,6 @@ import org.http4k.core.ContentType
 import org.http4k.core.ContentType.Companion.OCTET_STREAM
 import org.http4k.core.ContentType.Companion.TEXT_HTML
 import org.http4k.core.Headers
-import org.http4k.core.Method
 import org.http4k.core.Method.DELETE
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.OPTIONS
@@ -454,7 +453,7 @@ class ServerFiltersTest {
 
         val handler = FlashAttributesFilter.then { request -> Response(OK).body(request.flash().orEmpty()) }
 
-        val response = handler(Request(Method.GET, "/"))
+        val response = handler(Request(GET, "/"))
         assertThat(response, hasBody(""))
     }
 
@@ -462,7 +461,7 @@ class ServerFiltersTest {
     fun `retrieve flash attributes if set`() {
         val handler = FlashAttributesFilter.then { _ -> Response(OK).body("abc").withFlash("Error 123") }
 
-        val response = handler(Request(Method.GET, "/"))
+        val response = handler(Request(GET, "/"))
         assertThat(response.flash(), equalTo("Error 123"))
     }
 
@@ -470,8 +469,38 @@ class ServerFiltersTest {
     fun `remove flash attributes after usage`() {
         val handler = FlashAttributesFilter.then { _ -> Response(OK).body("abc") }
 
-        val request = Request(Method.GET, "/").withFlash("input flash")
+        val request = Request(GET, "/").withFlash("input flash")
         val response = handler(request)
         assertThat(response.flash(), equalTo(""))
+    }
+
+    @Test
+    fun `does not add content disposition if response is not 2xx`() {
+        val handler = ServerFilters.ContentDispositionAttachment().then { _ -> Response(NOT_FOUND) }
+
+        val response = handler(Request(GET, "/"))
+        assertThat(response.header("Content-Disposition"), absent())
+    }
+
+    @Test
+    fun `adds content disposition attachment for all extensions by default`() {
+        val handler = ServerFilters.ContentDispositionAttachment().then { _ -> Response(OK).body("abc") }
+
+        assertThat(handler(Request(GET, "/")).header("Content-Disposition"), equalTo("attachment; filename=unnamed"))
+        assertThat(handler(Request(GET, "/no-extension")).header("Content-Disposition"), equalTo("attachment; filename=no-extension"))
+        assertThat(handler(Request(GET, "/file.pdf")).header("Content-Disposition"), equalTo("attachment; filename=file.pdf"))
+        assertThat(handler(Request(GET, "/dir/file.pdf")).header("Content-Disposition"), equalTo("attachment; filename=file.pdf"))
+    }
+
+    @Test
+    fun `adds content disposition for selected types`() {
+        val handler = ServerFilters.ContentDispositionAttachment(setOf("pdf")).then { _ -> Response(OK).body("abc") }
+
+        assertThat(handler(Request(GET, "/")).header("Content-Disposition"), absent())
+        assertThat(handler(Request(GET, "/no-extension")).header("Content-Disposition"), absent())
+        assertThat(handler(Request(GET, "/not-listed-extension.png")).header("Content-Disposition"), absent())
+        assertThat(handler(Request(GET, "/.pdf")).header("Content-Disposition"), equalTo("attachment; filename=.pdf"))
+        assertThat(handler(Request(GET, "/file.pdf")).header("Content-Disposition"), equalTo("attachment; filename=file.pdf"))
+        assertThat(handler(Request(GET, "/dir/file.pdf")).header("Content-Disposition"), equalTo("attachment; filename=file.pdf"))
     }
 }


### PR DESCRIPTION
Added ContentDispositionAttachment Server Filter to add response header based on the request path.
By default all extensions are selected, including paths with no extension.
If no path is present, the filename will be set to "unnamed".

Fixes #445 