### PR TITLE
add disk cache path to MultipartFormBody.from() parameters

### DIFF
--- a/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
@@ -11,6 +11,7 @@ import org.http4k.multipart.Part
 import org.http4k.multipart.StreamingMultipartFormParts
 import java.io.ByteArrayInputStream
 import java.io.Closeable
+import java.io.File
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files

--- a/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
@@ -81,13 +81,12 @@ data class MultipartFormBody private constructor(internal val formParts: List<Mu
     companion object {
         const val DEFAULT_DISK_THRESHOLD = 1000 * 1024
 
-        fun from(httpMessage: HttpMessage, diskThreshold: Int = DEFAULT_DISK_THRESHOLD): MultipartFormBody {
+        fun from(httpMessage: HttpMessage, diskThreshold: Int = DEFAULT_DISK_THRESHOLD, diskDir: File = Files.createTempDirectory("http4k-mp").toFile().apply { deleteOnExit() }): MultipartFormBody {
             val boundary = CONTENT_TYPE(httpMessage)?.directives?.firstOrNull()?.second ?: ""
             val inputStream = httpMessage.body.run { if (stream.available() > 0) stream else ByteArrayInputStream(payload.array()) }
             val form = StreamingMultipartFormParts.parse(boundary.toByteArray(UTF_8), inputStream, UTF_8)
-            val dir = Files.createTempDirectory("http4k-mp").toFile().apply { deleteOnExit() }
 
-            val parts = MultipartFormParser(UTF_8, diskThreshold, dir).formParts(form).map {
+            val parts = MultipartFormParser(UTF_8, diskThreshold, diskDir).formParts(form).map {
                 if (it.isFormField) MultipartEntity.Field(it.fieldName!!, it.string(diskThreshold), it.headers.toList())
                 else MultipartEntity.File(it.fieldName!!, MultipartFormFile(it.fileName!!, ContentType(it.contentType!!, TEXT_HTML.directives), it.newInputStream))
             }


### PR DESCRIPTION
Working as server to handle file upload

Now the disk cache can only be cleaned using deleteOnExit(). That means keep all the temp files until restart. But server is normally keep running without restart. 

The pull is simply put the disk cache path into parameters so we can provide the cache path and clean the cache ourselves when each request is finished.

