### PR TITLE
Add jackson csv module

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Alternatively, read the [quickstart](https://www.http4k.org/quickstart/) or take
         * **[YAML](https://www.http4k.org/guide/reference/yaml/)** - includes support for:
             * **Jackson** - includes support for **fully automatic marshalling of Data classes**
             * **Moshi** - includes support for **fully automatic marshalling of Data classes**
+        * **CSV** - includes support for: 
+            * **Jackson** - CSV format for Jackson
 * [Resilience4J:](https://http4k.org/guide/reference/resilience4j) 
     * Circuits, Retrying, Rate-Limiting, Bulkheading via Resilience4J integration
 * [Micrometer:](https://http4k.org/guide/reference/micrometer) 

--- a/http4k-format/jackson-csv/build.gradle.kts
+++ b/http4k-format/jackson-csv/build.gradle.kts
@@ -1,0 +1,12 @@
+description = "Http4k CSV support using Jackson as an underlying engine"
+
+dependencies {
+    api(project(":http4k-format-core"))
+    api(project(":http4k-realtime-core"))
+    api(project(":http4k-format-jackson"))
+    api("com.fasterxml.jackson.dataformat:jackson-dataformat-csv:_")
+    testImplementation(project(":http4k-core"))
+    testImplementation(project(path = ":http4k-core", configuration ="testArtifacts"))
+    testImplementation(project(path = ":http4k-format-core", configuration ="testArtifacts"))
+    testImplementation(project(path = ":http4k-format-jackson", configuration ="testArtifacts"))
+}

--- a/http4k-format/jackson-csv/src/main/kotlin/org/http4k/format/ConfigurableJacksonCsv.kt
+++ b/http4k-format/jackson-csv/src/main/kotlin/org/http4k/format/ConfigurableJacksonCsv.kt
@@ -1,0 +1,66 @@
+package org.http4k.format
+
+import com.fasterxml.jackson.dataformat.csv.CsvMapper
+import com.fasterxml.jackson.dataformat.csv.CsvSchema
+import org.http4k.asString
+import org.http4k.core.Body
+import org.http4k.core.ContentType
+import org.http4k.lens.*
+import java.io.StringWriter
+import kotlin.reflect.KClass
+
+open class ConfigurableJacksonCsv(val mapper: CsvMapper, val defaultContentType: ContentType = ContentType.TEXT_CSV) {
+
+    inline fun <reified T> defaultSchema(): CsvSchema = mapper.schemaFor(T::class.java).withHeader()
+
+    fun <T: Any> writerFor(type: KClass<T>, schema: CsvSchema): (List<T>) -> String {
+        val writer = mapper.writerFor(type.java).with(schema)
+        return { body: List<T> ->
+            StringWriter().use { stringWriter ->
+                writer.writeValues(stringWriter)
+                    .writeAll(body)
+                stringWriter
+            }.toString()
+        }
+    }
+
+    fun <T: Any> readerFor(type: KClass<T>, schema: CsvSchema): (String) -> List<T> {
+        val reader = mapper.readerFor(type.java).with(schema)
+        return { body: String ->
+            reader.readValues<T>(body).readAll()
+        }
+    }
+
+    inline fun <reified T: Any> writeCsv(input: List<T>, schema: CsvSchema = defaultSchema<T>()): String {
+        val writer = writerFor(T::class, schema)
+        return writer(input)
+    }
+
+    inline fun <reified T: Any> readCsv(input: String , schema: CsvSchema = defaultSchema<T>()): List<T> {
+        val reader = readerFor(T::class, schema)
+        return reader(input)
+    }
+
+    inline fun <reified T : Any> Body.Companion.auto(
+        description: String? = null,
+        contentNegotiation: ContentNegotiation = ContentNegotiation.None
+    ) = autoBody<T>(description, contentNegotiation)
+
+    inline fun <reified T : Any> autoBody(
+        description: String? = null,
+        contentNegotiation: ContentNegotiation = ContentNegotiation.None,
+        contentType: ContentType = defaultContentType,
+        schema: CsvSchema = defaultSchema<T>()
+    ): BiDiBodyLensSpec<List<T>> {
+        val reader = readerFor(T::class, schema)
+        val writer = writerFor(T::class, schema)
+
+        return httpBodyRoot(
+            listOf(Meta(true, "body", ParamMeta.ObjectParam, "body", description)),
+            contentType,
+            contentNegotiation
+        )
+            .map({ it.payload.asString() }, { Body(it) })
+            .map(reader, writer)
+    }
+}

--- a/http4k-format/jackson-csv/src/main/kotlin/org/http4k/format/JacksonCsv.kt
+++ b/http4k-format/jackson-csv/src/main/kotlin/org/http4k/format/JacksonCsv.kt
@@ -1,0 +1,18 @@
+package org.http4k.format
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.dataformat.csv.CsvMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+
+object JacksonCsv: ConfigurableJacksonCsv(
+    KotlinModule.Builder().build()
+    .asConfigurable(CsvMapper())
+    .withStandardMappings()
+    .done()
+    .deactivateDefaultTyping()
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+    .configure(DeserializationFeature.FAIL_ON_IGNORED_PROPERTIES, false)
+    .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true)
+    .configure(DeserializationFeature.USE_BIG_INTEGER_FOR_INTS, true)
+    as CsvMapper
+)

--- a/http4k-format/jackson-csv/src/test/kotlin/org/http4k/format/jacksonCsvTests.kt
+++ b/http4k-format/jackson-csv/src/test/kotlin/org/http4k/format/jacksonCsvTests.kt
@@ -1,0 +1,93 @@
+package org.http4k.format
+
+import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.core.Body
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.core.Uri
+import org.http4k.core.with
+import org.http4k.format.JacksonCsv.auto
+import org.junit.jupiter.api.Test
+import java.net.URL
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import java.util.*
+
+@JsonPropertyOrder(value = [ "string", "numbers", "bool"])
+data class CsvArbObject(val string: String, val numbers: List<Int>, val bool: Boolean)
+
+class JacksonCsvBodyTest {
+
+    @Test
+    fun `roundtrip list of arbitrary objects to and from body`() {
+        val lens = Body.auto<CsvArbObject>().toLens()
+
+        val objects = listOf(
+            CsvArbObject("hello", emptyList(), false),
+            CsvArbObject("goodbye", listOf(1, 2, 3), true)
+        )
+
+        assertThat(
+            lens(Response(Status.OK).with(lens of objects)),
+            equalTo(objects)
+        )
+    }
+
+    /**
+     * Ignores properties in sub-types.
+     * See https://github.com/FasterXML/jackson-dataformats-text/issues/202#issuecomment-657346997
+     */
+    @Test
+    fun `roundtrip list of interface implementations - ignores subclass values`() {
+        val lens = Body.auto<Interface>().toLens()
+        val objects = listOf(InterfaceImpl(), InterfaceImpl())
+
+        assertThat(
+            Response(Status.OK).with(lens of objects).bodyString(),
+            equalTo("value\nhello\nhello\n")
+        )
+    }
+
+    @Test
+    fun `roundtrip list of common jdk primitives`() {
+        val localDate = LocalDate.of(2000, 1, 1)
+        val localTime = LocalTime.of(1, 1, 1)
+        val zoneOffset = ZoneOffset.UTC
+        val obj = CommonJdkPrimitives(
+            Duration.ofMillis(1000),
+            localDate,
+            localTime,
+            LocalDateTime.of(localDate, localTime),
+            ZonedDateTime.of(localDate, localTime, ZoneId.of("UTC")),
+            OffsetTime.of(localTime, zoneOffset),
+            OffsetDateTime.of(localDate, localTime, zoneOffset),
+            Instant.EPOCH,
+            UUID.fromString("1a448854-1687-4f90-9562-7d527d64383c"),
+            Uri.of("http://uri:8000"),
+            URL("http://url:9000"),
+            Status.OK
+        )
+
+        val csv =
+            """duration,instant,localDate,localDateTime,localTime,offsetDateTime,offsetTime,status,uri,url,uuid,zonedDateTime
+PT1S,1970-01-01T00:00:00Z,2000-01-01,2000-01-01T01:01:01,01:01:01,2000-01-01T01:01:01Z,01:01:01Z,200,http://uri:8000,http://url:9000,"1a448854-1687-4f90-9562-7d527d64383c","2000-01-01T01:01:01Z[UTC]"
+"""
+
+        val lens = Body.auto<CommonJdkPrimitives>().toLens()
+
+        assertThat(
+            Response(Status.OK).with(lens of listOf(obj)).bodyString(),
+            equalTo(csv)
+        )
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -53,6 +53,7 @@ include("http4k-contract")
     includeModule("moshi")
     includeModule("moshi-yaml")
     includeModule("xml")
+    includeModule("jackson-csv")
 }
 
 include("http4k-graphql")

--- a/versions.properties
+++ b/versions.properties
@@ -28,6 +28,8 @@ version.com.fasterxml.jackson.dataformat..jackson-dataformat-xml=2.13.2
 
 version.com.fasterxml.jackson.dataformat..jackson-dataformat-yaml=2.13.2
 
+version.com.fasterxml.jackson.dataformat..jackson-dataformat-csv=2.13.2
+
 version.com.fasterxml.jackson.module..jackson-module-kotlin=2.13.2
 
 version.com.github.javadev..underscore=1.76


### PR DESCRIPTION
Closes #718.

I was unable to add `AutoMarshalling` support.  The crux of the problem centers around `abstract fun asFormatString(input: Any): String`, which does not reify the type information required to build a `CsvSchema`.  Perhaps this could be accomplished later with reflection, but it would be redoing work that the module already does, given the necessary information.