### PR TITLE
Fix header rendering for effectively empty directive values for FallbackCacheControl

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
@@ -125,7 +125,9 @@ object CachingFilters {
 
                 fun addDefaultCacheHeadersIfAbsent(response: org.http4k.core.Response) =
                     addDefaultHeaderIfAbsent(response, "Cache-Control") {
-                        listOf("public", defaultCacheTimings.maxAge.toHeaderValue(), defaultCacheTimings.staleWhenRevalidateTtl.toHeaderValue(), defaultCacheTimings.staleIfErrorTtl.toHeaderValue()).joinToString(", ")
+                        listOf("public", defaultCacheTimings.maxAge.toHeaderValue(), defaultCacheTimings.staleWhenRevalidateTtl.toHeaderValue(), defaultCacheTimings.staleIfErrorTtl.toHeaderValue())
+                            .filter { it != "" }
+                            .joinToString(", ")
                     }
                         .let { addDefaultHeaderIfAbsent(it, "Expires") { RFC_1123_DATE_TIME.format(ZonedDateTime.now(clock).plus(defaultCacheTimings.maxAge.value)) } }
                         .let { addDefaultHeaderIfAbsent(it, "Vary") { "Accept-Encoding" } }

--- a/http4k-core/src/test/kotlin/org/http4k/filter/CachingFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/CachingFiltersTest.kt
@@ -18,6 +18,7 @@ import org.http4k.hamkrest.hasHeader
 import org.http4k.util.FixedClock
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.time.Duration.ZERO
 import java.time.Duration.ofSeconds
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME
@@ -27,6 +28,7 @@ class CachingFiltersTest {
     private val clock = FixedClock
     private val maxAge = ofSeconds(10)
     private val timings = DefaultCacheTimings(MaxAgeTtl(maxAge), StaleIfErrorTtl(ofSeconds(2000)), StaleWhenRevalidateTtl(ofSeconds(3000)))
+    private val timingsWithZeroValues = DefaultCacheTimings(MaxAgeTtl(maxAge), StaleIfErrorTtl(ZERO), StaleWhenRevalidateTtl(ZERO))
 
     private val request = org.http4k.core.Request(GET, "")
     private val response = Response(OK)
@@ -67,6 +69,14 @@ class CachingFiltersTest {
         assertThat(response, hasHeader("Cache-Control", listOf("rita")))
         assertThat(response, hasHeader("Expires", listOf("sue")))
         assertThat(response, hasHeader("Vary", listOf("bob")))
+    }
+
+    @Test
+    fun `FallbackCacheControl - renders cache header correctly if some directives have an empty Duration`() {
+        val responseWithHeaders = Response(OK)
+        val response = getResponseWith(timingsWithZeroValues, responseWithHeaders)
+
+        assertThat(response, hasHeader("Cache-Control", listOf("public, max-age=10")))
     }
 
     @Test


### PR DESCRIPTION
This PR removes empty directive values in FallbackCacheControl.

I noticed this when testing this in my codebase with zero durations for `stale-while-revalidate` and `stale-if-error`, that the `Cache-Control` header value generates something like `public, max-age=10, , `.