### PR TITLE
Throw a lens failure if a valid locale was not parsed

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
@@ -89,7 +89,10 @@ object StringBiDiMappings {
     fun traceId() = BiDiMapping(::TraceId, TraceId::value)
     fun samplingDecision() = BiDiMapping(::SamplingDecision, SamplingDecision::value)
     fun throwable() = BiDiMapping({ throw Exception(it) }, Throwable::asString)
-    fun locale() = BiDiMapping(Locale::forLanguageTag, Locale::toLanguageTag)
+    fun locale() = BiDiMapping(
+        { s -> Locale.forLanguageTag(s).takeIf { it.language.isNotEmpty() } ?: throw java.lang.IllegalArgumentException("Could not parse IETF locale") },
+        Locale::toLanguageTag
+    )
     inline fun <reified T : Enum<T>> enum() = BiDiMapping<String, T>(::enumValueOf, Enum<T>::name)
     inline fun <reified T : Enum<T>> caseInsensitiveEnum() = BiDiMapping(
         { text -> enumValues<T>().first { it.name.equals(text, ignoreCase = true) } },

--- a/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
@@ -90,7 +90,7 @@ object StringBiDiMappings {
     fun samplingDecision() = BiDiMapping(::SamplingDecision, SamplingDecision::value)
     fun throwable() = BiDiMapping({ throw Exception(it) }, Throwable::asString)
     fun locale() = BiDiMapping(
-        { s -> Locale.forLanguageTag(s).takeIf { it.language.isNotEmpty() } ?: throw java.lang.IllegalArgumentException("Could not parse IETF locale") },
+        { s -> Locale.forLanguageTag(s).takeIf { it.language.isNotEmpty() } ?: throw IllegalArgumentException("Could not parse IETF locale") },
         Locale::toLanguageTag
     )
     inline fun <reified T : Enum<T>> enum() = BiDiMapping<String, T>(::enumValueOf, Enum<T>::name)

--- a/http4k-core/src/test/kotlin/org/http4k/lens/BiDiLensSpecTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/BiDiLensSpecTest.kt
@@ -284,7 +284,7 @@ class BiDiLensSpecTest {
         Locale.CANADA,
         "en-CA",
         "",
-        null,
+        "en_CA", // java cannot parse ISO language codes
         "o",
         "oen-CA",
         "oen-CAen-CA"


### PR DESCRIPTION
Relates to #721 

Java locales cannot parse ISO language codes, but will happily return an empty `Locale` object, which can lead to confusion.  If accepted, this lens validation will only accept locales where a language was detected, and this updated test will formalize the notion that ISO format language codes are not supported.