### PR TITLE
Fix #728: Add requestModifier param to JavaHttpClient

### DIFF
--- a/http4k-client/fuel/src/test/kotlin/org/http4k/client/FuelStreamingTest.kt
+++ b/http4k-client/fuel/src/test/kotlin/org/http4k/client/FuelStreamingTest.kt
@@ -4,8 +4,13 @@ import org.http4k.core.BodyMode.Stream
 import org.http4k.server.ApacheServer
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import java.time.Duration
 
-class FuelStreamingTest : HttpClientContract(::ApacheServer, Fuel(bodyMode = Stream), Fuel(bodyMode = Stream)) {
+class FuelStreamingTest : HttpClientContract(
+    ::ApacheServer,
+    Fuel(bodyMode = Stream),
+    Fuel(bodyMode = Stream, timeout = Duration.ofMillis(100)),
+) {
     @Test
     @Disabled
     override fun `can send multiple headers with same name`() {

--- a/http4k-client/fuel/src/test/kotlin/org/http4k/client/FuelTest.kt
+++ b/http4k-client/fuel/src/test/kotlin/org/http4k/client/FuelTest.kt
@@ -3,8 +3,9 @@ package org.http4k.client
 import org.http4k.server.ApacheServer
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import java.time.Duration
 
-class FuelTest : HttpClientContract(::ApacheServer, Fuel(), Fuel()) {
+class FuelTest : HttpClientContract(::ApacheServer, Fuel(), Fuel(timeout = Duration.ofMillis(100))) {
     @Test
     @Disabled
     override fun `can send multiple headers with same name`() {

--- a/http4k-core/src/test/kotlin/org/http4k/client/HttpClientContract.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/client/HttpClientContract.kt
@@ -31,7 +31,6 @@ import org.http4k.core.then
 import org.http4k.filter.ClientFilters
 import org.http4k.hamkrest.hasBody
 import org.http4k.server.ServerConfig
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
 import java.util.Locale.getDefault
@@ -150,7 +149,6 @@ abstract class HttpClientContract(serverConfig: (Int) -> ServerConfig,
     }
 
     @Test
-    @Disabled
     open fun `socket timeouts are converted into 504`() {
         val response = timeoutClient(Request(GET, "http://localhost:$port/delay?millis=150"))
 

--- a/http4k-core/src/test/kotlin/org/http4k/client/JavaHttpClientTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/client/JavaHttpClientTest.kt
@@ -1,9 +1,5 @@
 package org.http4k.client
 
-import org.apache.hc.client5.http.config.RequestConfig
-import org.apache.hc.client5.http.impl.classic.HttpClients
-import org.apache.hc.core5.util.Timeout
-import org.http4k.core.BodyMode.Stream
 import org.http4k.core.Method
 import org.http4k.core.Request
 import org.http4k.core.Response
@@ -15,17 +11,12 @@ import org.http4k.server.SunHttp
 import org.http4k.server.asServer
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import java.time.Duration
 
 class JavaHttpClientTest : HttpClientContract(
-    ::ApacheServer, JavaHttpClient(),
-    ApacheClient(
-        HttpClients.custom()
-            .setDefaultRequestConfig(
-                RequestConfig.custom()
-                    .setResponseTimeout(Timeout.ofMilliseconds(100))
-                    .build()
-            ).build(), responseBodyMode = Stream
-    )
+    ::ApacheServer,
+    JavaHttpClient(),
+    JavaHttpClient { it.timeout(Duration.ofMillis(100)) },
 ) {
 
     @Disabled("unsupported by the underlying java client")


### PR DESCRIPTION
Note that, although I suggested a receiver function in issue 728, I noticed that the JettyClient had a similar solution using a function `(JettyRequest) -> JettyRequest`, so I followed that example.

Also note that I enabled the `socket timeouts are converted into 504` test-function.