### PR TITLE
Fix ServerFilters.BasicAuth handling of passwords containing colons

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
@@ -143,13 +143,16 @@ object ServerFilters {
             ?.takeIf { it.startsWith("Basic") }
             ?.substringAfter("Basic")
             ?.trim()
+            ?.safeBase64Decoded()
             ?.toCredentials()
 
-        private fun String.toCredentials(): Credentials? = try {
-            base64Decoded().split(":").let { Credentials(it.getOrElse(0) { "" }, it.getOrElse(1) { "" }) }
-        } catch (e: IllegalArgumentException) {
-            null
-        }
+        private fun String.safeBase64Decoded(): String? = try {
+            base64Decoded()
+        } catch (e: IllegalArgumentException) { null }
+
+        private fun String.toCredentials(): Credentials =
+            split(":", ignoreCase = false, limit = 2)
+            .let { Credentials(it.getOrElse(0) { "" }, it.getOrElse(1) { "" }) }
     }
 
     /**

--- a/http4k-core/src/test/kotlin/org/http4k/filter/BasicAuthenticationTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/BasicAuthenticationTest.kt
@@ -48,6 +48,13 @@ class BasicAuthenticationTest {
     }
 
     @Test
+    fun authenticate_with_colons_in_password() {
+        val handler = ServerFilters.BasicAuth("my realm", "user", "pass:word").then { Response(OK) }
+        val response = ClientFilters.BasicAuth("user", "pass:word").then(handler)(Request(GET, "/"))
+        assertThat(response.status, equalTo(OK))
+    }
+
+    @Test
     fun fails_to_authenticate_with_non_basic_token() {
         val handler = ServerFilters.BasicAuth("my realm", "user", "password").then { Response(OK) }
         val response = ClientFilters.BearerAuth(CredentialsProvider { "token" }).then(handler)(Request(GET, "/"))


### PR DESCRIPTION
Previously the server filter would truncate any colon and everything after from an incoming password