### PR TITLE
feat: Enable publishPercentileHistogram for Micrometer request timer

### DIFF
--- a/http4k-metrics-micrometer/src/main/kotlin/org/http4k/filter/micrometerExtensions.kt
+++ b/http4k-metrics-micrometer/src/main/kotlin/org/http4k/filter/micrometerExtensions.kt
@@ -17,7 +17,7 @@ class MicrometerMetrics(private val defaults: MetricsDefaults) {
                      labeler: HttpTransactionLabeler = defaults.labeler,
                      clock: Clock = Clock.systemUTC()): Filter =
         ReportHttpTransaction(clock) {
-            labeler(it).labels.entries.fold(Timer.builder(name).description(description)) { memo, next ->
+            labeler(it).labels.entries.fold(Timer.builder(name).publishPercentileHistogram().description(description)) { memo, next ->
                 memo.tag(next.key, next.value)
             }.register(meterRegistry).record(it.duration)
         }


### PR DESCRIPTION
This is enabling percentiles for Micrometer request timer as documented here: https://micrometer.io/docs/registry/datadog