### PR TITLE
Change constructor to use supported shutdown mode

### DIFF
--- a/http4k-server/jetty/src/main/kotlin/org/http4k/server/jetty.kt
+++ b/http4k-server/jetty/src/main/kotlin/org/http4k/server/jetty.kt
@@ -32,7 +32,7 @@ import java.time.Duration
 class Jetty(private val port: Int, override val stopMode: StopMode, private val server: Server) : PolyServerConfig {
     constructor(port: Int = 8000) : this(port, StopMode.Graceful(Duration.ofSeconds(5)))
     constructor(port: Int = 8000, stopMode: StopMode) : this(port, stopMode, http(port))
-    constructor(port: Int = 8000, server: Server) : this(port, StopMode.Immediate, server)
+    constructor(port: Int = 8000, server: Server) : this(port, StopMode.Graceful(Duration.ofSeconds(5)), server)
     constructor(port: Int, vararg inConnectors: ConnectorBuilder) : this(port, StopMode.Graceful(Duration.ofSeconds(5)), *inConnectors)
     constructor(port: Int, stopMode: StopMode, vararg inConnectors: ConnectorBuilder) : this(port, stopMode, Server().apply {
         inConnectors.forEach { addConnector(it(this)) }


### PR DESCRIPTION
Changes a left-over constructor that's using an unsupported shutdown mode to use a valid one, so the Jetty doesn't explode as soon as you try to use it.