### PR TITLE
Drop AddETag in favour of more fully-featured ETagSupport filter

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
@@ -96,37 +96,6 @@ object CachingFilters {
         }
 
         /**
-         * Hash algo stolen from http://stackoverflow.com/questions/26423662/scalatra-response-hmac-calulation
-         * By default, only applies when the status code of the response is < 400. This is overridable.
-         */
-        object AddETag {
-
-            operator fun invoke(predicate: (org.http4k.core.Response) -> Boolean = { it.status.code < 400 }): Filter = Filter { next ->
-                { request ->
-                    val response = next(request)
-                    if (predicate(response)) {
-                        val hashedBody = md5().digest(response.body.payload.copyToByteArray()).joinToString("") { "%02x".format(it) }
-                        response.replaceHeader("Etag", hashedBody)
-                    } else
-                        response
-                }
-            }
-
-            private fun md5() = MessageDigest.getInstance("MD5")
-
-            private fun ByteBuffer.copyToByteArray(): ByteArray {
-                val clone = ByteBuffer.allocate(capacity())
-                rewind()
-                clone.put(this)
-                rewind()
-                clone.flip()
-                val ba = ByteArray(clone.remaining())
-                clone.get(ba)
-                return ba
-            }
-        }
-
-        /**
          * Applies the passed cache timings (Cache-Control, Expires, Vary) to responses, but only if they are not there already.
          * Use this for adding default cache settings.
          * By default, only applies when the status code of the response is < 400. This is overridable.

--- a/http4k-core/src/test/kotlin/org/http4k/filter/CachingFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/CachingFiltersTest.kt
@@ -10,19 +10,16 @@ import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.then
 import org.http4k.filter.CachingFilters.Request.AddIfModifiedSince
-import org.http4k.filter.CachingFilters.Response.AddETag
 import org.http4k.filter.CachingFilters.Response.FallbackCacheControl
 import org.http4k.filter.CachingFilters.Response.MaxAge
 import org.http4k.filter.CachingFilters.Response.NoCache
 import org.http4k.hamkrest.hasHeader
 import org.http4k.util.FixedClock
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
 import java.time.Duration
 import java.time.Duration.ZERO
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME
-import org.junit.jupiter.params.provider.CsvSource
 
 class CachingFiltersTest {
 
@@ -40,30 +37,6 @@ class CachingFiltersTest {
         val response = AddIfModifiedSince(clock, maxAge).then { Response(OK).header("If-modified-since", it.header("If-modified-since")) }(
             request)
         assertThat(response, hasHeader("If-modified-since", RFC_1123_DATE_TIME.format(ZonedDateTime.now(clock).minus(maxAge))))
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        """  bob, 9f9d51bc70ef21ca5c14f307980a29d8  """,
-        """  999, b706835de79a2b4e80506f582af3676a  """,
-        """  &*(, f2cd6baf16754f03166b2c846088de53  """,
-    )
-    fun `Add eTag - string body`(actualBody: String, expectedETag: String) {
-        val response = AddETag { true }.then { Response(OK).body(actualBody) }(request)
-        assertThat(response, hasHeader("etag", expectedETag))
-        assertThat(response.bodyString(), equalTo(actualBody))
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        """  bob, 9f9d51bc70ef21ca5c14f307980a29d8  """,
-        """  999, b706835de79a2b4e80506f582af3676a  """,
-        """  &*(, f2cd6baf16754f03166b2c846088de53  """,
-    )
-    fun `Add eTag - input stream body`(actualBody: String, expectedETag: String) {
-        val response = AddETag { true }.then { Response(OK).body(actualBody.byteInputStream()) }(request)
-        assertThat(response, hasHeader("etag", expectedETag))
-        assertThat(response.bodyString(), equalTo(actualBody))
     }
 
     private fun getResponseWith(cacheTimings: DefaultCacheTimings, response: Response) = FallbackCacheControl(clock, cacheTimings).then { response }(request)


### PR DESCRIPTION
As discussed in #738 , this drops the `AddETag` filter in favour of `ETagSupport`, which properly skips streaming responses and also handles a 304 response where appropriate.

This does leave us without a standard filter to provide _only_ etag headers, but that seems a very niche case, and it's definitely worth reducing the confusion here.