### PR TITLE
Support parsing digest challenge where nonce has an '='

### DIFF
--- a/http4k-security/digest/src/main/kotlin/org/http4k/security/digest/ParameterizedHeader.kt
+++ b/http4k-security/digest/src/main/kotlin/org/http4k/security/digest/ParameterizedHeader.kt
@@ -12,7 +12,7 @@ data class ParameterizedHeader(
                 .split(",")
                 .filter { "=" in it }
                 .associate {
-                    val (key, value) = it.trim().split("=")
+                    val (key, value) = it.trim().split("=", limit = 2)
                     key.trim() to value.trim().replace("\"", "")
                 }
 

--- a/http4k-security/digest/src/test/kotlin/org/http4k/security/digest/DigestChallengeTest.kt
+++ b/http4k-security/digest/src/test/kotlin/org/http4k/security/digest/DigestChallengeTest.kt
@@ -30,4 +30,16 @@ class DigestChallengeTest {
             qop = listOf(Qop.Auth)
         )))
     }
+
+    @Test
+    fun `process auth challenge with '=' in nonce`() {
+        val challenge = DigestChallenge.parse("Digest realm=\"axis\", nonce=\"1234=abcd\", algorithm=MD5, qop=\"auth\"")
+        assertThat(challenge, equalTo(DigestChallenge(
+            realm = "axis",
+            nonce = Nonce("1234=abcd"),
+            algorithm = "MD5",
+            opaque = null,
+            qop = listOf(Qop.Auth)
+        )))
+    }
 }


### PR DESCRIPTION
I don't know why some devices think they can put an `=` in a nonce, but this fix will allow us to correctly parse the challenge.