### PR TITLE
Add `queryParametersEncoded` + query param value split bug fix

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/Parameters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Parameters.kt
@@ -19,7 +19,7 @@ fun Parameters.findSingle(name: String): String? = find { it.first == name }?.se
 
 fun Parameters.findMultiple(name: String) = filter { it.first == name }.map { it.second }
 
-private fun String.toParameter(): Parameter = split("=").map(String::fromFormEncoded).let { l -> l.elementAt(0) to l.elementAtOrNull(1) }
+private fun String.toParameter(): Parameter = split("=", limit = 2).map(String::fromFormEncoded).let { l -> l.elementAt(0) to l.elementAtOrNull(1) }
 
 internal fun String.fromFormEncoded() = URLDecoder.decode(this, "UTF-8")
 

--- a/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
@@ -70,6 +70,9 @@ fun Uri.removeQueries(prefix: String) =
 fun Uri.query(name: String, value: String?): Uri =
     copy(query = query.toParameters().plus(name to value).toUrlFormEncoded())
 
+fun Uri.queryParametersEncoded(): Uri =
+    copy(query = query.toParameters().toUrlFormEncoded())
+
 /**
  * @see [RFC 3986, appendix A](https://www.ietf.org/rfc/rfc3986.txt)
  */

--- a/http4k-core/src/test/kotlin/org/http4k/core/ParametersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/ParametersTest.kt
@@ -37,4 +37,9 @@ class ParametersTest {
         assertThat(map.getFirst("b"), equalTo("B"))
         assertThat(map.getFirst("c"), absent())
     }
+
+    @Test
+    fun `should split query param only into 2 strings`() {
+        assertThat("q1=value1=10&q2=value2=10".toParameters(), equalTo(listOf("q1" to "value1=10", "q2" to "value2=10")))
+    }
 }

--- a/http4k-core/src/test/kotlin/org/http4k/core/UriTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/UriTest.kt
@@ -109,4 +109,13 @@ class UriTest {
     fun `can extend existing uri`() {
         assertThat(Uri.of("http://ignore?foo=bar").extend(Uri.of("/?abc=xyz")), equalTo(Uri.of("http://ignore/?foo=bar&abc=xyz")))
     }
+
+    @Test
+    fun `can encode query param values`() {
+        val unEncodedUri = Uri.of("http://ignore/?q1=encode me pls&q2=encode me 2")
+        val encodedUri = "http://ignore/?q1=encode+me+pls&q2=encode+me+2"
+        val queryParametersEncodedUri = unEncodedUri.queryParametersEncoded()
+        assertThat(queryParametersEncodedUri.toString(), equalTo(encodedUri))
+        assertThat(queryParametersEncodedUri.queries(), equalTo(listOf("q1" to "encode me pls", "q2" to "encode me 2")))
+    }
 }

--- a/http4k-security/oauth/src/test/kotlin/org/http4k/security/oauth/server/AuthRequestWithRequestAuthRequestExtractorTest.kt
+++ b/http4k-security/oauth/src/test/kotlin/org/http4k/security/oauth/server/AuthRequestWithRequestAuthRequestExtractorTest.kt
@@ -177,7 +177,7 @@ internal class AuthRequestWithRequestAuthRequestExtractorTest {
                 underTest().extract(
                     Request(
                         GET,
-                        "/?client_id=12345&scope=openid+email+address=&response_type=code&redirect_uri=https://somehost&request=$requestObjectJwt"
+                        "/?client_id=12345&scope=openid+email+address&response_type=code&redirect_uri=https://somehost&request=$requestObjectJwt"
                     )
                 ), equalTo(
                     success(
@@ -208,7 +208,7 @@ internal class AuthRequestWithRequestAuthRequestExtractorTest {
                 ), equalTo(
                     success(
                         AuthRequest(
-                            client = ClientId("12345"),
+                            client = ClientId("12345="),
                             responseType = Code,
                             redirectUri = Uri.of("https://somehost"),
                             scopes = listOf("email", "openid", "address"),
@@ -234,7 +234,7 @@ internal class AuthRequestWithRequestAuthRequestExtractorTest {
                 ), equalTo(
                     success(
                         AuthRequest(
-                            client = ClientId("12345"),
+                            client = ClientId("12345="),
                             responseType = Code,
                             redirectUri = Uri.of("https://somehost"),
                             scopes = listOf("openid", "email", "address"),
@@ -312,7 +312,7 @@ internal class AuthRequestWithRequestAuthRequestExtractorTest {
                 underTest(AuthRequestOnly).extract(
                     Request(
                         GET,
-                        "/?client_id=12345&scope=openid+email+address=&response_type=code&redirect_uri=https://somehost&request=$requestObjectJwt"
+                        "/?client_id=12345&scope=openid+email+address&response_type=code&redirect_uri=https://somehost&request=$requestObjectJwt"
                     )
                 ), equalTo(
                     success(
@@ -343,7 +343,7 @@ internal class AuthRequestWithRequestAuthRequestExtractorTest {
                 ), equalTo(
                     success(
                         AuthRequest(
-                            client = ClientId("12345"),
+                            client = ClientId("12345="),
                             responseType = Code,
                             redirectUri = Uri.of("https://somehost"),
                             scopes = emptyList(),
@@ -369,7 +369,7 @@ internal class AuthRequestWithRequestAuthRequestExtractorTest {
                 ), equalTo(
                     success(
                         AuthRequest(
-                            client = ClientId("12345"),
+                            client = ClientId("12345="),
                             responseType = Code,
                             redirectUri = Uri.of("https://somehost"),
                             scopes = listOf("openid", "email", "address"),
@@ -447,7 +447,7 @@ internal class AuthRequestWithRequestAuthRequestExtractorTest {
                 underTest(RequestObjectOnly).extract(
                     Request(
                         GET,
-                        "/?client_id=12345&scope=openid+email+address=&response_type=code&redirect_uri=https://somehost&request=$requestObjectJwt"
+                        "/?client_id=12345&scope=openid+email+address&response_type=code&redirect_uri=https://somehost&request=$requestObjectJwt"
                     )
                 ), equalTo(
                     success(
@@ -478,7 +478,7 @@ internal class AuthRequestWithRequestAuthRequestExtractorTest {
                 ), equalTo(
                     success(
                         AuthRequest(
-                            client = ClientId("12345"),
+                            client = ClientId("12345="),
                             responseType = Code,
                             redirectUri = requestObject.redirectUri,
                             scopes = requestObject.scope,
@@ -504,7 +504,7 @@ internal class AuthRequestWithRequestAuthRequestExtractorTest {
                 ), equalTo(
                     success(
                         AuthRequest(
-                            client = ClientId("12345"),
+                            client = ClientId("12345="),
                             responseType = Code,
                             redirectUri = requestObject.redirectUri,
                             scopes = requestObject.scope,


### PR DESCRIPTION
- Add `queryParametersEncoded` extension to Uri to encode only parameter values
- :bug: Change `split("=")` to `split("=", limit=2)` to deal with parameter values that contain `=`