### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/create_github_release.yaml
+++ b/.github/workflows/create_github_release.yaml
@@ -2,8 +2,13 @@ name: New Release - GitHub
 on:
   repository_dispatch:
     types: [http4k-release]
+permissions:
+  contents: read
+
 jobs:
   release:
+    permissions:
+      contents: write  # for actions/create-release to create a release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release_site.yaml
+++ b/.github/workflows/release_site.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - master
+permissions:
+  contents: read
+
 jobs:
   release-site:
     runs-on: ubuntu-latest

--- a/.github/workflows/send_to_slack.yaml
+++ b/.github/workflows/send_to_slack.yaml
@@ -2,6 +2,9 @@ name: New Release - Slack
 on:
   repository_dispatch:
     types: [http4k-release]
+permissions:
+  contents: read
+
 jobs:
   slackify:
     runs-on: ubuntu-latest

--- a/.github/workflows/tweet_release.yaml
+++ b/.github/workflows/tweet_release.yaml
@@ -2,8 +2,13 @@ name: New Release - Twitter
 on:
   repository_dispatch:
     types: [http4k-release]
+permissions:
+  contents: read
+
 jobs:
   tweet:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     steps:
       - uses: ethomson/send-tweet-action@v1


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
