### PR TITLE
For Discussion: Moshi AutoMarshallingJson

### DIFF
--- a/http4k-format/moshi/src/main/kotlin/org/http4k/format/ConfigurableMoshi.kt
+++ b/http4k-format/moshi/src/main/kotlin/org/http4k/format/ConfigurableMoshi.kt
@@ -25,7 +25,9 @@ import kotlin.reflect.KClass
 open class ConfigurableMoshi(
     builder: Moshi.Builder,
     val defaultContentType: ContentType = APPLICATION_JSON
-) : AutoMarshalling() {
+) : AutoMarshallingJson<MoshiElement>(),
+    Json<MoshiElement> by MoshiJson
+{
 
     private val moshi: Moshi = builder.build()
 
@@ -38,6 +40,16 @@ open class ConfigurableMoshi(
     override fun <T : Any> asA(input: InputStream, target: KClass<T>): T = moshi.adapter(target.java).fromJson(
         input.source().buffer()
     )!!
+
+    override fun asJsonObject(input: Any): MoshiElement {
+        val string = asFormatString(input)  // TODO read directly to MoshiElement
+        return string.asJsonObject()
+    }
+
+    override fun <T : Any> asA(j: MoshiElement, target: KClass<T>): T {
+        val string = j.asCompactJsonString() // TODO read directly from MoshiElement
+        return asA(string, target)
+    }
 
     inline fun <reified T : Any> Body.Companion.auto(
         description: String? = null,

--- a/http4k-format/moshi/src/main/kotlin/org/http4k/format/MoshiElement.kt
+++ b/http4k-format/moshi/src/main/kotlin/org/http4k/format/MoshiElement.kt
@@ -1,0 +1,11 @@
+package org.http4k.format
+
+sealed interface MoshiElement
+
+data class MoshiArray(val elements: List<MoshiElement>): MoshiElement
+data class MoshiObject(val attributes: Map<String, MoshiElement>): MoshiElement
+sealed interface MoshiPrimitive: MoshiElement
+data class MoshiString(val value: String): MoshiPrimitive
+data class MoshiNumber(val value: Number): MoshiPrimitive
+data class MoshiBoolean(val value: Boolean): MoshiPrimitive
+object MoshiNull: MoshiPrimitive

--- a/http4k-format/moshi/src/main/kotlin/org/http4k/format/MoshiElement.kt
+++ b/http4k-format/moshi/src/main/kotlin/org/http4k/format/MoshiElement.kt
@@ -1,6 +1,14 @@
 package org.http4k.format
 
-sealed interface MoshiElement
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import okio.Buffer
+import okio.buffer
+import okio.source
+
+sealed interface MoshiElement {
+    companion object
+}
 
 data class MoshiArray(val elements: List<MoshiElement>): MoshiElement
 data class MoshiObject(val attributes: Map<String, MoshiElement>): MoshiElement
@@ -9,3 +17,82 @@ data class MoshiString(val value: String): MoshiPrimitive
 data class MoshiNumber(val value: Number): MoshiPrimitive
 data class MoshiBoolean(val value: Boolean): MoshiPrimitive
 object MoshiNull: MoshiPrimitive
+
+fun MoshiElement.toJson(configure: (JsonWriter) -> Unit = {}): String {
+    val buffer = Buffer()
+    JsonWriter.of(buffer).use { writer ->
+        configure(writer)
+        write(writer)
+    }
+    return buffer.readUtf8()
+}
+
+private fun MoshiElement.write(writer: JsonWriter) {
+    when(this) {
+        is MoshiArray -> writeArray(writer)
+        is MoshiObject -> writeObject(writer)
+        is MoshiString -> writer.value(value)
+        is MoshiNumber -> writer.value(value)
+        is MoshiNull -> writer.nullValue()
+        is MoshiBoolean -> writer.value(value)
+    }
+}
+
+private fun MoshiArray.writeArray(writer: JsonWriter) {
+    writer.beginArray()
+    for (element in elements) {
+        element.write(writer)
+    }
+    writer.endArray()
+}
+
+private fun MoshiObject.writeObject(writer: JsonWriter) {
+    writer.beginObject()
+    for ((name, value) in attributes) {
+        writer.name(name)
+        value.write(writer)
+    }
+    writer.endObject()
+}
+
+fun MoshiElement.Companion.parse(json: String): MoshiElement {
+    JsonReader.of(json.byteInputStream().source().buffer()).use { reader ->
+        return reader.parse()
+    }
+}
+
+private fun JsonReader.parse(): MoshiElement {
+    return when(val token = peek()) {
+        JsonReader.Token.BEGIN_ARRAY -> parseArray()
+        JsonReader.Token.BEGIN_OBJECT -> parseObject()
+        JsonReader.Token.STRING -> MoshiString(nextString())
+        JsonReader.Token.BOOLEAN -> MoshiBoolean(nextBoolean())
+        JsonReader.Token.NUMBER -> MoshiNumber(nextDouble())
+        JsonReader.Token.NULL -> { nextNull<Any>(); MoshiNull }
+        else -> throw java.lang.IllegalStateException("can't handle $token")
+    }
+}
+
+private fun JsonReader.parseObject(): MoshiObject {
+    val attributes = mutableMapOf<String, MoshiElement>()
+
+    beginObject()
+    while(hasNext()) {
+        val name = nextName()
+        val value = parse()
+        attributes[name] = value
+    }
+    endObject()
+    return MoshiObject(attributes)
+}
+
+private fun JsonReader.parseArray(): MoshiArray {
+    val elements = mutableListOf<MoshiElement>()
+
+    beginArray()
+    while(hasNext()) {
+        elements += parse()
+    }
+    endArray()
+    return MoshiArray(elements)
+}

--- a/http4k-format/moshi/src/main/kotlin/org/http4k/format/MoshiJson.kt
+++ b/http4k-format/moshi/src/main/kotlin/org/http4k/format/MoshiJson.kt
@@ -1,0 +1,145 @@
+package org.http4k.format
+
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import okio.Buffer
+import okio.buffer
+import okio.source
+import java.math.BigDecimal
+import java.math.BigInteger
+
+object MoshiJson: Json<MoshiElement> {
+
+    override fun MoshiElement.asPrettyJsonString(): String {
+        val buffer = Buffer()
+        JsonWriter.of(buffer).use { writer ->
+            writer.indent = "  "
+            write(writer)
+        }
+        return buffer.readUtf8()
+    }
+
+    override fun MoshiElement.asCompactJsonString(): String {
+        val buffer = Buffer()
+        JsonWriter.of(buffer).use { writer ->
+            write(writer)
+        }
+        return buffer.readUtf8()
+    }
+
+    private fun MoshiElement.write(writer: JsonWriter) {
+        when(this) {
+            is MoshiArray -> writeArray(writer)
+            is MoshiObject -> writeObject(writer)
+            is MoshiPrimitive -> writePrimitive(writer)
+        }
+    }
+
+    private fun MoshiArray.writeArray(writer: JsonWriter) {
+        writer.beginArray()
+        for (element in elements) {
+            element.write(writer)
+        }
+        writer.endArray()
+    }
+
+    private fun MoshiObject.writeObject(writer: JsonWriter) {
+        writer.beginObject()
+        for ((name, value) in attributes) {
+            writer.name(name)
+            value.write(writer)
+        }
+        writer.endObject()
+    }
+
+    private fun MoshiPrimitive.writePrimitive(writer: JsonWriter) {
+        when(this) {
+            is MoshiString -> writer.value(value)
+            is MoshiNumber -> writer.value(value)
+            is MoshiNull -> writer.nullValue()
+            is MoshiBoolean -> writer.value(value)
+        }
+    }
+
+    override fun String.asJsonObject(): MoshiElement {
+        JsonReader.of(byteInputStream().source().buffer()).use { reader ->
+            return reader.parse()
+        }
+    }
+
+    private fun JsonReader.parse(): MoshiElement {
+        return when(val token = peek()) {
+            JsonReader.Token.BEGIN_ARRAY -> parseArray()
+            JsonReader.Token.BEGIN_OBJECT -> parseObject()
+            JsonReader.Token.STRING -> MoshiString(nextString())
+            JsonReader.Token.BOOLEAN -> MoshiBoolean(nextBoolean())
+            JsonReader.Token.NUMBER -> MoshiNumber(nextDouble())
+            JsonReader.Token.NULL -> { nextNull<Any>(); MoshiNull }
+            else -> throw java.lang.IllegalStateException("can't handle $token")
+        }
+    }
+
+    private fun JsonReader.parseObject(): MoshiObject {
+        val attributes = mutableMapOf<String, MoshiElement>()
+
+        beginObject()
+        while(hasNext()) {
+            val name = nextName()
+            val value = parse()
+            attributes[name] = value
+        }
+        endObject()
+        return MoshiObject(attributes)
+    }
+
+    private fun JsonReader.parseArray(): MoshiArray {
+        val elements = mutableListOf<MoshiElement>()
+
+        beginArray()
+        while(hasNext()) {
+            elements += parse()
+        }
+        endArray()
+        return MoshiArray(elements)
+    }
+
+
+    override fun <LIST : Iterable<Pair<String, MoshiElement>>> LIST.asJsonObject() = MoshiObject(toMap())
+    override fun String?.asJsonValue() = if (this == null) MoshiNull else MoshiString(this)
+    override fun Int?.asJsonValue() = if (this == null) MoshiNull else MoshiNumber(this)
+    override fun Double?.asJsonValue() = if (this == null) MoshiNull else MoshiNumber(this)
+    override fun Long?.asJsonValue() = if (this == null) MoshiNull else MoshiNumber(this)
+    override fun BigDecimal?.asJsonValue() = if (this == null) MoshiNull else MoshiNumber(this)
+    override fun BigInteger?.asJsonValue() = if (this == null) MoshiNull else MoshiNumber(this)
+    override fun Boolean?.asJsonValue() = if (this == null) MoshiNull else MoshiBoolean(this)
+    override fun <T : Iterable<MoshiElement>> T.asJsonArray() = MoshiArray(toList())
+
+    override fun textValueOf(node: MoshiElement, name: String) = (node as MoshiObject)
+        .attributes[name]
+        ?.let { text(it) }
+
+    override fun decimal(value: MoshiElement) = when(val num = (value as MoshiNumber).value) {
+        is Long -> num.toBigDecimal()
+        is Int -> num.toBigDecimal()
+        is Float -> num.toBigDecimal()
+        is Double -> num.toBigDecimal()
+        is BigDecimal -> num
+        is BigInteger -> num.toBigDecimal()
+        else -> throw java.lang.IllegalArgumentException("Cannot convert $value to BigDecimal")
+    }
+
+    override fun integer(value: MoshiElement) = ((value as MoshiNumber).value).toLong()
+    override fun bool(value: MoshiElement) = (value as MoshiBoolean).value
+    override fun text(value: MoshiElement) = (value as MoshiString).value
+    override fun elements(value: MoshiElement) = (value as MoshiArray).elements
+    override fun fields(node: MoshiElement) = (node as MoshiObject).attributes.map { it.key to it.value }
+
+    override fun typeOf(value: MoshiElement) = when(value) {
+        is MoshiObject -> JsonType.Object
+        is MoshiArray -> JsonType.Array
+        is MoshiNull -> JsonType.Null
+        is MoshiNumber -> JsonType.Number
+        is MoshiString -> JsonType.String
+        is MoshiBoolean -> JsonType.Boolean
+    }
+}

--- a/http4k-format/moshi/src/main/kotlin/org/http4k/format/MoshiJson.kt
+++ b/http4k-format/moshi/src/main/kotlin/org/http4k/format/MoshiJson.kt
@@ -1,108 +1,13 @@
 package org.http4k.format
 
-import com.squareup.moshi.JsonReader
-import com.squareup.moshi.JsonWriter
-import okio.Buffer
-import okio.buffer
-import okio.source
 import java.math.BigDecimal
 import java.math.BigInteger
 
 object MoshiJson: Json<MoshiElement> {
 
-    override fun MoshiElement.asPrettyJsonString(): String {
-        val buffer = Buffer()
-        JsonWriter.of(buffer).use { writer ->
-            writer.indent = "  "
-            write(writer)
-        }
-        return buffer.readUtf8()
-    }
-
-    override fun MoshiElement.asCompactJsonString(): String {
-        val buffer = Buffer()
-        JsonWriter.of(buffer).use { writer ->
-            write(writer)
-        }
-        return buffer.readUtf8()
-    }
-
-    private fun MoshiElement.write(writer: JsonWriter) {
-        when(this) {
-            is MoshiArray -> writeArray(writer)
-            is MoshiObject -> writeObject(writer)
-            is MoshiPrimitive -> writePrimitive(writer)
-        }
-    }
-
-    private fun MoshiArray.writeArray(writer: JsonWriter) {
-        writer.beginArray()
-        for (element in elements) {
-            element.write(writer)
-        }
-        writer.endArray()
-    }
-
-    private fun MoshiObject.writeObject(writer: JsonWriter) {
-        writer.beginObject()
-        for ((name, value) in attributes) {
-            writer.name(name)
-            value.write(writer)
-        }
-        writer.endObject()
-    }
-
-    private fun MoshiPrimitive.writePrimitive(writer: JsonWriter) {
-        when(this) {
-            is MoshiString -> writer.value(value)
-            is MoshiNumber -> writer.value(value)
-            is MoshiNull -> writer.nullValue()
-            is MoshiBoolean -> writer.value(value)
-        }
-    }
-
-    override fun String.asJsonObject(): MoshiElement {
-        JsonReader.of(byteInputStream().source().buffer()).use { reader ->
-            return reader.parse()
-        }
-    }
-
-    private fun JsonReader.parse(): MoshiElement {
-        return when(val token = peek()) {
-            JsonReader.Token.BEGIN_ARRAY -> parseArray()
-            JsonReader.Token.BEGIN_OBJECT -> parseObject()
-            JsonReader.Token.STRING -> MoshiString(nextString())
-            JsonReader.Token.BOOLEAN -> MoshiBoolean(nextBoolean())
-            JsonReader.Token.NUMBER -> MoshiNumber(nextDouble())
-            JsonReader.Token.NULL -> { nextNull<Any>(); MoshiNull }
-            else -> throw java.lang.IllegalStateException("can't handle $token")
-        }
-    }
-
-    private fun JsonReader.parseObject(): MoshiObject {
-        val attributes = mutableMapOf<String, MoshiElement>()
-
-        beginObject()
-        while(hasNext()) {
-            val name = nextName()
-            val value = parse()
-            attributes[name] = value
-        }
-        endObject()
-        return MoshiObject(attributes)
-    }
-
-    private fun JsonReader.parseArray(): MoshiArray {
-        val elements = mutableListOf<MoshiElement>()
-
-        beginArray()
-        while(hasNext()) {
-            elements += parse()
-        }
-        endArray()
-        return MoshiArray(elements)
-    }
-
+    override fun MoshiElement.asPrettyJsonString() = toJson { writer -> writer.indent = "  " }
+    override fun MoshiElement.asCompactJsonString() = toJson()
+    override fun String.asJsonObject() = MoshiElement.parse(this)
 
     override fun <LIST : Iterable<Pair<String, MoshiElement>>> LIST.asJsonObject() = MoshiObject(toMap())
     override fun String?.asJsonValue() = if (this == null) MoshiNull else MoshiString(this)


### PR DESCRIPTION
I wanted to add `AutoMarshallingJson` capabilities to Moshi, so I could use it for OpenApi spec generation in my lightweight AWS Lambda APIs.  Presumably, the reason this was never done is because Moshi only supports object mapping and json streaming, with no intermediary `NODE` format, as required by `AutoMarshallingJson<NODE>`.  I came up with my own `MoshiElement` format, which went pretty well at first.

As, you'll see in `ConfigurableMoshi`, I didn't have a great way of implementing `fun asJsonObject(input: Any): MoshiElement` and `fun <T : Any> asA(j: MoshiElement, target: KClass<T>): T`, so I used the existing Moshi `JsonAdapter` capabilities to convert the object to Json before reading to the `NODE` format.  This isn't ideal, but I think implementing it properly would involve performing custom reflection on the classes, which would overlap with Moshi's `JsonAdapter` responsibilities.

Unfortunately, when I try to use this to generate my OpenApi Spec, `fun asJsonObject(input: Any): MoshiElement` is called to convert `org.http4k.contract.openapi.v3.ArrayItems`, and when that's delegated to `asFormatString`, the conversion to json fails because Moshi can't generate an `JsonAdapter` for `ArrayItems` (an interface).

```kotlin
OpenApi3(
    ApiInfo(title = "My API", version = "v1.0"),
    json = Moshi,
    apiRenderer = ApiRenderer.Auto(Moshi, AutoJsonToJsonSchema(Moshi))
)
```

```
java.lang.IllegalArgumentException: No JsonAdapter for interface org.http4k.contract.openapi.v3.ArrayItems (with no annotations)
for interface org.http4k.contract.openapi.v3.ArrayItems items
for class org.http4k.contract.openapi.v3.SchemaNode$Array
	at com.squareup.moshi.Moshi$LookupChain.exceptionWithLookupStack(Moshi.java:389)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:158)
	at com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory.create(KotlinJsonAdapter.kt:292)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:146)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:106)
	at com.squareup.moshi.Moshi.adapter(Moshi.java:80)
	at org.http4k.format.ConfigurableMoshi.asFormatString(ConfigurableMoshi.kt:34)
```

**tl;dr**
- No way to efficiently convert from `Any->MoshiElement` and `MoshiElement->T`
- Moshi's adapter format can't support writing the openapi models without custom adapters