### PR TITLE
Do not throw exception when iteration over empty TestWsClient.received sequence

### DIFF
--- a/http4k-realtime-core/src/main/kotlin/org/http4k/testing/TestWsClient.kt
+++ b/http4k-realtime-core/src/main/kotlin/org/http4k/testing/TestWsClient.kt
@@ -26,6 +26,8 @@ class TestWsClient internal constructor(consumer: WsConsumer, request: Request) 
             queue.remove()()
         } catch (e: ClosedWebsocket) {
             if (e.status == NORMAL) null else throw e
+        } catch (e: NoSuchElementException) {
+            null
         }
     }
 

--- a/http4k-realtime-core/src/test/kotlin/org/http4k/websocket/WsClientTest.kt
+++ b/http4k-realtime-core/src/test/kotlin/org/http4k/websocket/WsClientTest.kt
@@ -2,6 +2,7 @@ package org.http4k.websocket
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.isEmpty
 import com.natpryce.hamkrest.throws
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
@@ -102,5 +103,6 @@ class WsClientTest {
         }.testWsClient(Request(GET, "/"))
 
         assertThat(client.received().none(), equalTo(true))
+        assertThat(client.received().toList(), isEmpty) // verify NoSuchElement not thrown during iteration
     }
 }


### PR DESCRIPTION
Guarding against this by checking if the sequence `hasNext` is all well and good, but I think we should be able to iterate without fear.  For Example, this would throw `NoSuchElementException` if the client had no messages.

```kotlin
for (message in client.received()) {
  // do stuff
}
```
