### PR TITLE
replace moshi-kotlin with moshi-metadata-reflect

### DIFF
--- a/http4k-format/moshi/build.gradle.kts
+++ b/http4k-format/moshi/build.gradle.kts
@@ -4,7 +4,7 @@ dependencies {
     api(project(":http4k-format-core"))
     api(project(":http4k-realtime-core"))
     api(Square.moshi)
-    implementation("dev.zacsweers.moshix:moshi-metadata-reflect:0.18.3")
+    api("dev.zacsweers.moshix:moshi-metadata-reflect:0.18.3")
     testImplementation(project(":http4k-core"))
     testImplementation(project(path = ":http4k-core", configuration ="testArtifacts"))
     testImplementation(project(path = ":http4k-format-core", configuration ="testArtifacts"))

--- a/http4k-format/moshi/build.gradle.kts
+++ b/http4k-format/moshi/build.gradle.kts
@@ -4,7 +4,7 @@ dependencies {
     api(project(":http4k-format-core"))
     api(project(":http4k-realtime-core"))
     api(Square.moshi)
-    api(Square.moshi.kotlinReflect)
+    implementation("dev.zacsweers.moshix:moshi-metadata-reflect:0.18.3")
     testImplementation(project(":http4k-core"))
     testImplementation(project(path = ":http4k-core", configuration ="testArtifacts"))
     testImplementation(project(path = ":http4k-format-core", configuration ="testArtifacts"))

--- a/http4k-format/moshi/src/main/kotlin/org/http4k/format/ConfigurableMoshi.kt
+++ b/http4k-format/moshi/src/main/kotlin/org/http4k/format/ConfigurableMoshi.kt
@@ -4,7 +4,7 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dev.zacsweers.moshix.reflect.MetadataKotlinJsonAdapterFactory
 import okio.buffer
 import okio.source
 import org.http4k.core.Body
@@ -143,7 +143,7 @@ fun Moshi.Builder.asConfigurable() = object : AutoMappingConfiguration<Moshi.Bui
 
     // add the Kotlin adapter last, as it will hjiack our custom mappings otherwise
     override fun done() =
-        this@asConfigurable.add(KotlinJsonAdapterFactory()).add(Unit::class.java, UnitAdapter)
+        this@asConfigurable.add(MetadataKotlinJsonAdapterFactory()).add(Unit::class.java, UnitAdapter)
 }
 
 private object UnitAdapter : JsonAdapter<Unit>() {


### PR DESCRIPTION
As discussed in #763.  Replaces the [moshi-kotlin](https://github.com/square/moshi/tree/master/moshi-kotlin) module (based on `kotlin-reflect`) with the [moshi-metadata-reflect](https://github.com/ZacSweers/MoshiX/tree/main/moshi-metadata-reflect) module, based on `kotlinx-metadata`.  The new reflection backend is supposed to bring various performance improvements, but it also reduces the jar size from 3 MB to 1 MB, which is incredibly useful in serverless environments.

- Tested on Android
- Http4k tests pass
- My own small pet project is successfully using this