### PR TITLE
allow netty ws config to be overridden

### DIFF
--- a/http4k-server/netty/src/main/kotlin/org/http4k/server/WebSocketServerHandler.kt
+++ b/http4k-server/netty/src/main/kotlin/org/http4k/server/WebSocketServerHandler.kt
@@ -15,7 +15,10 @@ import org.http4k.core.Uri
 import org.http4k.websocket.WsHandler
 import java.net.InetSocketAddress
 
-class WebSocketServerHandler(private val wsHandler: WsHandler) : ChannelInboundHandlerAdapter() {
+class WebSocketServerHandler(
+    private val wsHandler: WsHandler,
+    private val customConfig: (WebSocketServerProtocolConfig.Builder) -> WebSocketServerProtocolConfig.Builder = { it }
+) : ChannelInboundHandlerAdapter() {
     override fun channelRead(ctx: ChannelHandlerContext, msg: Any) {
         if (msg is HttpRequest) {
             if (requiresWsUpgrade(msg)) {
@@ -27,6 +30,7 @@ class WebSocketServerHandler(private val wsHandler: WsHandler) : ChannelInboundH
                     .handleCloseFrames(false)
                     .websocketPath(upgradeRequest.uri.toString())
                     .checkStartsWith(true)
+                    .let(customConfig)
                     .build()
 
                 ctx.pipeline().addAfter(

--- a/http4k-server/netty/src/test/kotlin/org/http4k/websocket/NettyWebsocketTest.kt
+++ b/http4k-server/netty/src/test/kotlin/org/http4k/websocket/NettyWebsocketTest.kt
@@ -2,5 +2,17 @@ package org.http4k.websocket
 
 import org.http4k.client.JavaHttpClient
 import org.http4k.server.Netty
+import org.http4k.server.WebSocketServerHandler
+import org.junit.jupiter.api.Test
 
-class NettyWebsocketTest : WebsocketServerContract(::Netty, JavaHttpClient())
+class NettyWebsocketTest : WebsocketServerContract(::Netty, JavaHttpClient()) {
+
+    @Test
+    fun `override websocket config`() {
+        Netty(8000, createWebsocketHandler = { ws ->
+            WebSocketServerHandler(ws) {
+                it.maxFramePayloadLength(30_000)
+            }
+        })
+    }
+}


### PR DESCRIPTION
I don't love how this complicates the nice simple `Netty` constructor, but I think it's valid to want to override some default settings.