### PR TITLE
Add Coroutine context to Zipkin traces

### DIFF
--- a/http4k-core/build.gradle.kts
+++ b/http4k-core/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     implementation("javax.servlet:javax.servlet-api:_")
     implementation("dev.forkhandles:result4k:_")
     implementation("dev.forkhandles:values4k:_")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 
     testApi(project(":http4k-client-apache"))
     testApi(project(":http4k-client-websocket"))

--- a/http4k-core/src/main/kotlin/org/http4k/filter/ZipkinTraces.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ZipkinTraces.kt
@@ -1,5 +1,7 @@
 package org.http4k.filter
 
+import kotlinx.coroutines.ThreadContextElement
+import kotlinx.coroutines.asContextElement
 import org.http4k.core.HttpMessage
 import org.http4k.core.with
 import org.http4k.filter.SamplingDecision.Companion.SAMPLE
@@ -61,6 +63,10 @@ data class ZipkinTraces(val traceId: TraceId, val spanId: TraceId, val parentSpa
         }
 
         fun forCurrentThread(): ZipkinTraces = THREAD_LOCAL.get()
+
+        fun asContextElement(): ThreadContextElement<ZipkinTraces> {
+            return THREAD_LOCAL.asContextElement()
+        }
 
         internal val THREAD_LOCAL = object : ThreadLocal<ZipkinTraces>() {
             override fun initialValue() = ZipkinTraces(TraceId.new(), TraceId.new(), null, SAMPLE)


### PR DESCRIPTION
Allows the Zipkin client and server filters to be used in a coroutine context, so the trace ID is still propagated even if the outgoing request is on a different thread. To be used like:

runBlocking(ZipkinTraces.asContextElement()) {
 ... 
}