### PR TITLE
Add StringBiDiMappings.csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ changes with their rationale when appropriate:
 ### v4.32.4.0 (uncut)
 - **http4k-core** : Move Jakarta Servlet code from Jetty as is now shared.
 - **http4k-contract** : Add `UserCredentialsOAuthSecurity`.  This allows the OpenApi spec to define a Resource Owner Password Credentials grant.  It also includes a shortcut to load the principal into a `RequestContextLens`.  H/T @oharaandrew314
+- **http4k-core**: Add `StringBiDiMappings.csv` to map between string and list, with a configurable delimiter.  H/T @oharaandrew314 
 
 ### v4.32.3.0
 - **http4k-*** : Upgrade some dependency versions including CVE fix for Undertow backend.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ changes with their rationale when appropriate:
 ### v4.32.4.0 (uncut)
 - **http4k-core** : Move Jakarta Servlet code from Jetty as is now shared.
 - **http4k-contract** : Add `UserCredentialsOAuthSecurity`.  This allows the OpenApi spec to define a Resource Owner Password Credentials grant.  It also includes a shortcut to load the principal into a `RequestContextLens`.  H/T @oharaandrew314
-- **http4k-core**: Add `StringBiDiMappings.csv` to map between string and list, with a configurable delimiter.  H/T @oharaandrew314 
+- **http4k-core**: Add `StringBiDiMappings.csv` to map between string and list, with a configurable delimiter and element mapping.  H/T @oharaandrew314 
 
 ### v4.32.3.0
 - **http4k-*** : Upgrade some dependency versions including CVE fix for Undertow backend.

--- a/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
@@ -112,21 +112,6 @@ object StringBiDiMappings {
         Enum<T>::name
     )
 
-//    fun <T> list(
-//        delimiter: String,
-//        escaped: (String),
-//        mapElement: BiDiMapping<String, T>
-//    ) = BiDiMapping<String, List<T>>(
-//        asOut = { text ->
-//            if (text.isEmpty()) {
-//                emptyList()
-//            } else {
-//                text.split(delimiter).map { mapElement(it.replace(escaped, delimiter)) }
-//            }
-//        },
-//        asIn = { list -> list.map { mapElement(it) }.joinToString(delimiter) { it.replace(delimiter, escaped) } }
-//    )
-
     fun <T> csv(
         delimiter: String = ",",
         mapElement: BiDiMapping<String, T>

--- a/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
@@ -111,15 +111,10 @@ object StringBiDiMappings {
         Enum<T>::name
     )
 
-    fun <T> csv(
-        delimiter: String = ",",
-        mapElement: BiDiMapping<String, T>
-    ): BiDiMapping<String, List<T>> {
-        return BiDiMapping(
-            asOut = { if (it.isEmpty()) emptyList() else it.split(delimiter).map(mapElement::invoke) },
-            asIn = { it.joinToString(delimiter, transform = mapElement::invoke) }
-        )
-    }
+    fun <T> csv(delimiter: String = ",", mapElement: BiDiMapping<String, T>) = BiDiMapping<String, List<T>>(
+        asOut = { if (it.isEmpty()) emptyList() else it.split(delimiter).map(mapElement::invoke) },
+        asIn = { it.joinToString(delimiter, transform = mapElement::invoke) }
+    )
 
     private fun String.safeBase64Decoded(): String? = try {
         base64Decoded()

--- a/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
@@ -34,7 +34,6 @@ import java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME
 import java.util.Locale
 import java.util.Locale.getDefault
 import java.util.UUID
-import java.util.regex.Pattern
 
 /**
  * A BiDiMapping defines a reusable bidirectional transformation between an input and output type

--- a/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/BiDiMapping.kt
@@ -110,6 +110,16 @@ object StringBiDiMappings {
         { text -> enumValues<T>().first { it.name.equals(text, ignoreCase = true) } },
         Enum<T>::name
     )
+    fun csv(delimiter: String, escaped: (String)) = BiDiMapping<String, List<String>>(
+        asOut = { text ->
+            if (text.isEmpty()) {
+                emptyList()
+            } else {
+                text.split(delimiter).map { it.replace(escaped, delimiter) }
+            }
+        },
+        asIn = { list -> list.joinToString(delimiter) { it.replace(delimiter, escaped) } }
+    )
 
     private fun String.safeBase64Decoded(): String? = try {
         base64Decoded()

--- a/http4k-core/src/main/kotlin/org/http4k/lens/lensSpec.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/lensSpec.kt
@@ -247,7 +247,9 @@ fun <IN: Any> BiDiLensSpec<IN, String>.zoneId() = map(StringBiDiMappings.zoneId(
 fun <IN: Any> BiDiLensSpec<IN, String>.zoneOffset() = map(StringBiDiMappings.zoneOffset())
 fun <IN: Any> BiDiLensSpec<IN, String>.locale() = map(StringBiDiMappings.locale())
 fun <IN: Any> BiDiLensSpec<IN, String>.basicCredentials() = map(StringBiDiMappings.basicCredentials())
-fun <IN: Any> BiDiLensSpec<IN, String>.csv(delimiter: String = ",", escaped: String = "\\$delimiter") = map(StringBiDiMappings.csv(delimiter, escaped))
+fun <IN: Any, T: Any> BiDiLensSpec<IN, String>.csv(delimiter: String = ",", mapElement: BiDiMapping<String, T>)
+    = map(StringBiDiMappings.csv(delimiter, mapElement))
+fun <IN: Any> BiDiLensSpec<IN, String>.csv(delimiter: String = ",") = csv(delimiter, BiDiMapping({ it }, { it }))
 
 inline fun <IN : Any, reified T : Enum<T>> BiDiLensSpec<IN, String>.enum() = mapWithNewMeta(StringBiDiMappings.enum<T>(), EnumParam(T::class))
 inline fun <IN : Any, reified T : Enum<T>> BiDiLensSpec<IN, String>.enum(noinline nextOut: (String) -> T, noinline nextIn: (T) -> String) = mapWithNewMeta(BiDiMapping(nextOut, nextIn), EnumParam(T::class))

--- a/http4k-core/src/main/kotlin/org/http4k/lens/lensSpec.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/lensSpec.kt
@@ -247,6 +247,7 @@ fun <IN: Any> BiDiLensSpec<IN, String>.zoneId() = map(StringBiDiMappings.zoneId(
 fun <IN: Any> BiDiLensSpec<IN, String>.zoneOffset() = map(StringBiDiMappings.zoneOffset())
 fun <IN: Any> BiDiLensSpec<IN, String>.locale() = map(StringBiDiMappings.locale())
 fun <IN: Any> BiDiLensSpec<IN, String>.basicCredentials() = map(StringBiDiMappings.basicCredentials())
+fun <IN: Any> BiDiLensSpec<IN, String>.csv(delimiter: String = ",", escaped: String = "\\$delimiter") = map(StringBiDiMappings.csv(delimiter, escaped))
 
 inline fun <IN : Any, reified T : Enum<T>> BiDiLensSpec<IN, String>.enum() = mapWithNewMeta(StringBiDiMappings.enum<T>(), EnumParam(T::class))
 inline fun <IN : Any, reified T : Enum<T>> BiDiLensSpec<IN, String>.enum(noinline nextOut: (String) -> T, noinline nextIn: (T) -> String) = mapWithNewMeta(BiDiMapping(nextOut, nextIn), EnumParam(T::class))

--- a/http4k-core/src/test/kotlin/org/http4k/lens/BiDiLensSpecTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/BiDiLensSpecTest.kt
@@ -304,26 +304,26 @@ class BiDiLensSpecTest {
     }
 
     @Test
-    fun csv() {
-        checkContract(
-            spec.csv(),
-            listOf("foo\"", "bar\n", "", "baz"),
-            "foo\",bar\n,,baz",
-            "",
-            null,
-            "bang",
-            "bangfoo\",bar\n,,baz",
-            "bangfoo\",bar\n,,bazfoo\",bar\n,,baz"
-        )
-        checkContract(
-            spec.csv("\n", "\\n"),
-            listOf("foo\n", "bar", "baz"),
-            "foo\\n\nbar\nbaz",
-            "",
-            null,
-            "bang",
-            "bangfoo\\n\nbar\nbaz",
-            "bangfoo\\n\nbar\nbazfoo\\n\nbar\nbaz"
-        )
-    }
+    fun csv() = checkContract(
+        spec.csv(),
+        listOf("foo", "bar", "", "baz"),
+        "foo,bar,,baz",
+        "",
+        null,
+        "bang",
+        "bangfoo,bar,,baz",
+        "bangfoo,bar,,bazfoo,bar,,baz"
+    )
+
+    @Test
+    fun `csv - custom`() = checkContract(
+        spec.csv(";", StringBiDiMappings.int()),
+        listOf(0, 1, 2),
+        "0;1;2",
+        "",
+        "foo;bar;baz",
+        "-1",
+        "-10;1;2",
+        "-10;1;20;1;2"
+    )
 }

--- a/http4k-core/src/test/kotlin/org/http4k/lens/BiDiLensSpecTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/BiDiLensSpecTest.kt
@@ -302,4 +302,28 @@ class BiDiLensSpecTest {
         assertThat(lens("123"), equalTo(expected))
         assertThat(lens(expected, "prefix"), equalTo("prefix123123"))
     }
+
+    @Test
+    fun csv() {
+        checkContract(
+            spec.csv(),
+            listOf("foo\"", "bar\n", "", "baz"),
+            "foo\",bar\n,,baz",
+            "",
+            null,
+            "bang",
+            "bangfoo\",bar\n,,baz",
+            "bangfoo\",bar\n,,bazfoo\",bar\n,,baz"
+        )
+        checkContract(
+            spec.csv("\n", "\\n"),
+            listOf("foo\n", "bar", "baz"),
+            "foo\\n\nbar\nbaz",
+            "",
+            null,
+            "bang",
+            "bangfoo\\n\nbar\nbaz",
+            "bangfoo\\n\nbar\nbazfoo\\n\nbar\nbaz"
+        )
+    }
 }

--- a/http4k-core/src/test/kotlin/org/http4k/lens/QueryTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/QueryTest.kt
@@ -11,6 +11,7 @@ import org.http4k.core.Request
 import org.http4k.core.Uri.Companion.of
 import org.http4k.core.query
 import org.http4k.core.with
+import org.http4k.hamkrest.hasQuery
 import org.junit.jupiter.api.Test
 
 class QueryTest {
@@ -176,5 +177,22 @@ class QueryTest {
     fun `case-insensitive enum`() {
         val lens = Query.enum<Method>(caseSensitive = false).required("method")
         assertThat(lens(Request(GET,"/?method=delete")), equalTo(Method.DELETE))
+    }
+
+    @Test
+    fun csv() {
+        val lens = Query.csv().required("stuff")
+        assertThat(
+            lens(Request(GET, "/?stuff=foo\",1,,bar")),
+            equalTo(listOf("foo\"","1", "", "bar"))
+        )
+        assertThat(
+            Request(GET, "/").with(lens of listOf("foo\"","1", "", "bar")),
+            hasQuery("stuff", "foo\",1,,bar")
+        )
+        assertThat(
+            lens(Request(GET, "/?stuff=")),
+            equalTo(emptyList())
+        )
     }
 }


### PR DESCRIPTION
Useful for parsing comma-separated query args.  Also has an optional mapping for elements, e.g. list of ints.
I've intentionally omitted escape characters and element quoting; I feel like if you're going to introduce that level of configuration and complexity, you might as well use a dedicated CSV parser to do it for you.