### PR TITLE
Allow for keeping temporary multiparts around.

### DIFF
--- a/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
@@ -82,7 +82,7 @@ data class MultipartFormBody private constructor(internal val formParts: List<Mu
     companion object {
         const val DEFAULT_DISK_THRESHOLD = 1000 * 1024
 
-        fun from(httpMessage: HttpMessage, diskThreshold: Int = DEFAULT_DISK_THRESHOLD, diskDir: File = Files.createTempDirectory("http4k-mp").toFile().apply { deleteOnExit() }): MultipartFormBody {
+        fun from(httpMessage: HttpMessage, diskThreshold: Int = DEFAULT_DISK_THRESHOLD, deleteTempFilesOnExit: Boolean = true, diskDir: File = Files.createTempDirectory("http4k-mp").toFile().apply { if (deleteTempFilesOnExit) deleteOnExit() }): MultipartFormBody {
             val boundary = CONTENT_TYPE(httpMessage)?.directives?.firstOrNull{ it.first == "boundary" }?.second ?: ""
             val inputStream = httpMessage.body.run { if (stream.available() > 0) stream else ByteArrayInputStream(payload.array()) }
             val form = StreamingMultipartFormParts.parse(boundary.toByteArray(UTF_8), inputStream, UTF_8)

--- a/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
@@ -5,17 +5,17 @@ import org.http4k.core.MultipartFormBody.Companion.DEFAULT_DISK_THRESHOLD
 import org.http4k.lens.Header.CONTENT_TYPE
 import org.http4k.lens.MultipartFormField
 import org.http4k.lens.MultipartFormFile
+import org.http4k.multipart.DiskLocation
 import org.http4k.multipart.MultipartFormBuilder
 import org.http4k.multipart.MultipartFormParser
 import org.http4k.multipart.Part
 import org.http4k.multipart.StreamingMultipartFormParts
+import org.http4k.multipart.TempDiskLocation
 import java.io.ByteArrayInputStream
 import java.io.Closeable
-import java.io.File
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.Files
-import java.util.UUID
+import java.util.*
 
 sealed class MultipartEntity : Closeable {
     abstract val name: String
@@ -82,12 +82,12 @@ data class MultipartFormBody private constructor(internal val formParts: List<Mu
     companion object {
         const val DEFAULT_DISK_THRESHOLD = 1000 * 1024
 
-        fun from(httpMessage: HttpMessage, diskThreshold: Int = DEFAULT_DISK_THRESHOLD, deleteTempFilesOnExit: Boolean = true, diskDir: File = Files.createTempDirectory("http4k-mp").toFile().apply { if (deleteTempFilesOnExit) deleteOnExit() }): MultipartFormBody {
+        fun from(httpMessage: HttpMessage, diskThreshold: Int = DEFAULT_DISK_THRESHOLD, diskLocation: DiskLocation = TempDiskLocation()): MultipartFormBody {
             val boundary = CONTENT_TYPE(httpMessage)?.directives?.firstOrNull{ it.first == "boundary" }?.second ?: ""
             val inputStream = httpMessage.body.run { if (stream.available() > 0) stream else ByteArrayInputStream(payload.array()) }
             val form = StreamingMultipartFormParts.parse(boundary.toByteArray(UTF_8), inputStream, UTF_8)
 
-            val parts = MultipartFormParser(UTF_8, diskThreshold, diskDir).formParts(form).map {
+            val parts = MultipartFormParser(UTF_8, diskThreshold, diskLocation).formParts(form).map {
                 if (it.isFormField) MultipartEntity.Field(it.fieldName!!, it.string(diskThreshold), it.headers.toList())
                 else MultipartEntity.File(it.fieldName!!, MultipartFormFile(it.fileName!!, ContentType(it.contentType!!, TEXT_HTML.directives), it.newInputStream))
             }

--- a/http4k-multipart/src/main/kotlin/org/http4k/multipart/DiskLocation.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/multipart/DiskLocation.kt
@@ -1,0 +1,52 @@
+package org.http4k.multipart
+
+import java.io.Closeable
+import java.io.File
+import java.nio.file.FileSystemException
+import java.nio.file.Files
+import java.util.*
+
+interface DiskLocation {
+    fun createFile(filename: String?) : MultipartFile
+}
+
+interface MultipartFile : Closeable {
+    fun file(): File
+    override fun close()
+}
+
+class TempDiskLocation(private val diskDir: File = Files.createTempDirectory("http4k-mp").toFile().apply { deleteOnExit() }) : DiskLocation {
+    override fun createFile(filename: String?): MultipartFile =
+        TempFile(File.createTempFile(
+            filename ?: (UUID.randomUUID().toString() + "-"),
+            ".tmp", diskDir
+        ).apply {
+            deleteOnExit()
+        })
+}
+
+class PermanentDiskLocation(private val diskDir: File = Files.createTempDirectory("http4k-mp").toFile()) : DiskLocation {
+    override fun createFile(filename: String?): MultipartFile =
+        PermanentFile(File.createTempFile(
+            filename ?: (UUID.randomUUID().toString() + "-"),
+            ".tmp", diskDir
+        ))
+}
+
+internal class TempFile(private val file: File) : MultipartFile {
+
+    override fun file() = file
+
+    override fun close() {
+        if (!file.delete()) throw FileSystemException("Failed to delete file")
+    }
+}
+
+internal class PermanentFile(private val file: File) : MultipartFile {
+
+    override fun file() = file
+
+    override fun close() {
+        // do nothing
+    }
+}

--- a/http4k-multipart/src/main/kotlin/org/http4k/multipart/Part.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/multipart/Part.kt
@@ -2,36 +2,34 @@ package org.http4k.multipart
 
 import java.io.ByteArrayInputStream
 import java.io.Closeable
-import java.io.File
 import java.io.FileInputStream
 import java.io.InputStream
 import java.nio.charset.Charset
-import java.nio.file.FileSystemException
 
-internal sealed class Part(fieldName: String?, formField: Boolean, contentType: String?, fileName: String?, headers: Map<String, String>, val length: Int) : PartMetaData(fieldName, formField, contentType, fileName, headers), Closeable {
+internal sealed class Part(fieldName: String?, formField: Boolean, contentType: String?, fileName: String?, headers: Map<String, String>, val length: Int) :
+    PartMetaData(fieldName, formField, contentType, fileName, headers), Closeable {
 
     abstract val newInputStream: InputStream
 
     abstract val bytes: ByteArray
 
-    class DiskBacked(part: PartMetaData, private val theFile: File, private val deleteOnClose: Boolean = true) : Part(part.fieldName, part.isFormField, part.contentType, part.fileName, part.headers, theFile.length().toInt()) {
+    class DiskBacked(part: PartMetaData, private val multipartFile: MultipartFile) : Part(part.fieldName, part.isFormField, part.contentType, part.fileName, part.headers, multipartFile.file().length().toInt()) {
         override val newInputStream: InputStream
-            get() = FileInputStream(theFile)
+            get() = FileInputStream(multipartFile.file())
 
         override val bytes
             get() = throw IllegalStateException("Cannot get bytes from a DiskBacked Part")
 
         override fun close() {
-            if (deleteOnClose) {
-                if (!theFile.delete()) throw FileSystemException("Failed to delete file")
-            }
+            multipartFile.close()
         }
     }
 
-    class InMemory(original: PartMetaData,
-                   override val bytes: ByteArray /* not immutable*/,
-                   internal val encoding: Charset)
-        : Part(original.fieldName, original.isFormField, original.contentType, original.fileName, original.headers, bytes.size) {
+    class InMemory(
+        original: PartMetaData,
+        override val bytes: ByteArray /* not immutable*/,
+        internal val encoding: Charset
+    ) : Part(original.fieldName, original.isFormField, original.contentType, original.fileName, original.headers, bytes.size) {
 
         override val newInputStream: InputStream
             get() = ByteArrayInputStream(bytes)

--- a/http4k-multipart/src/main/kotlin/org/http4k/multipart/Part.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/multipart/Part.kt
@@ -14,7 +14,7 @@ internal sealed class Part(fieldName: String?, formField: Boolean, contentType: 
 
     abstract val bytes: ByteArray
 
-    class DiskBacked(part: PartMetaData, private val theFile: File) : Part(part.fieldName, part.isFormField, part.contentType, part.fileName, part.headers, theFile.length().toInt()) {
+    class DiskBacked(part: PartMetaData, private val theFile: File, private val deleteOnClose: Boolean = true) : Part(part.fieldName, part.isFormField, part.contentType, part.fileName, part.headers, theFile.length().toInt()) {
         override val newInputStream: InputStream
             get() = FileInputStream(theFile)
 
@@ -22,7 +22,9 @@ internal sealed class Part(fieldName: String?, formField: Boolean, contentType: 
             get() = throw IllegalStateException("Cannot get bytes from a DiskBacked Part")
 
         override fun close() {
-            if (!theFile.delete()) throw FileSystemException("Failed to delete file")
+            if (deleteOnClose) {
+                if (!theFile.delete()) throw FileSystemException("Failed to delete file")
+            }
         }
     }
 

--- a/http4k-multipart/src/test/kotlin/org/http4k/multipart/MultipartFormParserTest.kt
+++ b/http4k-multipart/src/test/kotlin/org/http4k/multipart/MultipartFormParserTest.kt
@@ -36,7 +36,7 @@ class MultipartFormParserTest {
                     boundary, body, ISO_8859_1, maxStreamLength
                 )
 
-                val parts = MultipartFormParser(UTF_8, writeToDiskThreshold, temporaryFileDirectory!!).formParts(streamingParts)
+                val parts = MultipartFormParser(UTF_8, writeToDiskThreshold, TempDiskLocation(TEMPORARY_FILE_DIRECTORY)).formParts(streamingParts)
                 parts.let {
                     val articleType = it.parts("articleType")[0]
                     println(articleType.fieldName) // "articleType"
@@ -72,7 +72,7 @@ class MultipartFormParserTest {
             .stream()
         val form = StreamingMultipartFormParts.parse(boundary.toByteArray(UTF_8), multipartFormContentsStream, UTF_8)
 
-        val parts = MultipartFormParser(UTF_8, 1024, TEMPORARY_FILE_DIRECTORY).formParts(form)
+        val parts = MultipartFormParser(UTF_8, 1024, TempDiskLocation(TEMPORARY_FILE_DIRECTORY)).formParts(form)
 
         assertThat(parts.parts("file")[0].fileName, equalTo("foo.tab"))
         assertThat(parts.parts("anotherFile")[0].fileName, equalTo("BAR.tab"))
@@ -86,7 +86,7 @@ class MultipartFormParserTest {
     fun canLoadComplexRealLifeSafariExample() {
         val form = safariExample()
 
-        val parts = MultipartFormParser(UTF_8, 1024000, TEMPORARY_FILE_DIRECTORY).formParts(form)
+        val parts = MultipartFormParser(UTF_8, 1024000, TempDiskLocation(TEMPORARY_FILE_DIRECTORY)).formParts(form)
         allFieldsAreLoadedCorrectly(parts, true, true, true, true)
         parts.forEach { it.close() }
     }
@@ -101,7 +101,7 @@ class MultipartFormParserTest {
         )
 
         try {
-            MultipartFormParser(UTF_8, 1024, TEMPORARY_FILE_DIRECTORY).formParts(form)
+            MultipartFormParser(UTF_8, 1024, TempDiskLocation(TEMPORARY_FILE_DIRECTORY)).formParts(form)
             fail("should have failed because the form is too big")
         } catch (e: Throwable) {
             assertThat(e.localizedMessage, containsSubstring("Form contents was longer than 1024 bytes"))
@@ -112,7 +112,7 @@ class MultipartFormParserTest {
     fun savesAllPartsToDisk() {
         val form = safariExample()
 
-        val parts = MultipartFormParser(UTF_8, 100, TEMPORARY_FILE_DIRECTORY).formParts(form)
+        val parts = MultipartFormParser(UTF_8, 100, TempDiskLocation(TEMPORARY_FILE_DIRECTORY)).formParts(form)
 
         allFieldsAreLoadedCorrectly(parts, false, false, false, false)
 
@@ -125,7 +125,7 @@ class MultipartFormParserTest {
     fun savesSomePartsToDisk() {
         val form = safariExample()
 
-        val parts = MultipartFormParser(UTF_8, 1024 * 4, TEMPORARY_FILE_DIRECTORY).formParts(form)
+        val parts = MultipartFormParser(UTF_8, 1024 * 4, TempDiskLocation(TEMPORARY_FILE_DIRECTORY)).formParts(form)
 
         allFieldsAreLoadedCorrectly(parts, false, true, true, false)
 
@@ -143,7 +143,7 @@ class MultipartFormParserTest {
         try {
             val form = safariExample()
 
-            val parts = MultipartFormParser(UTF_8, 1024 * 4, TEMPORARY_FILE_DIRECTORY, deleteTempFilesOnExit = false).formParts(form)
+            val parts = MultipartFormParser(UTF_8, 1024 * 4, PermanentDiskLocation(TEMPORARY_FILE_DIRECTORY)).formParts(form)
 
             allFieldsAreLoadedCorrectly(parts, false, true, true, false)
 
@@ -175,7 +175,7 @@ class MultipartFormParserTest {
         )
 
         try {
-            MultipartFormParser(UTF_8, 1024 * 4, TEMPORARY_FILE_DIRECTORY).formParts(form)
+            MultipartFormParser(UTF_8, 1024 * 4, TempDiskLocation(TEMPORARY_FILE_DIRECTORY)).formParts(form)
             fail("Should have thrown an Exception")
         } catch (e: Throwable) {
             assertThat(e.localizedMessage, containsSubstring("Boundary must be proceeded by field separator, but didn't find it"))


### PR DESCRIPTION
When uploading a file through a multipart form, we want to keep the temp file around for async virus scanning. However, in the following piece of code, the file is deleted upon JVM exit:
```kotlin
    private fun writeToDisk(part: StreamingPart, bytes: ByteArray, length: Int) =
        File.createTempFile(part.fileName ?: UUID.randomUUID().toString()
        + "-", ".tmp", temporaryFileDirectory).apply {
            deleteOnExit()
            FileOutputStream(this).apply {
                write(bytes, 0, length)
                use { part.inputStream.copyTo(it, writeToDiskThreshold) }
            }
        }
```
with the `deleteOnExit()` call.

We want to keep the file around even when the JVM exits (we're running on k8s so pods can always be killed).

This PR uses a flag that is passed from MultipartFormBody.from to the MultipartFormParser indicating to delete (or not) the temp file, delegating control over when the temp file will be deleted to the caller.
