### PR TITLE
Add Json utility methods to define mapping from json to objects

### DIFF
--- a/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/health/ReadinessCheckResultRenderer.kt
+++ b/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/health/ReadinessCheckResultRenderer.kt
@@ -31,7 +31,7 @@ object DefaultReadinessCheckResultRenderer : ReadinessCheckResultRenderer {
  * Reporting of ReadinessCheckResults in a JSON tree
  */
 object JsonReadinessCheckResultRenderer {
-    operator fun <NODE> invoke(json: Json<NODE>): ReadinessCheckResultRenderer {
+    operator fun <NODE : Any> invoke(json: Json<NODE>): ReadinessCheckResultRenderer {
         fun render(result: ReadinessCheckResult) = json {
             val core = listOf(
                 "name" to string(result.name),

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/JsonErrorResponseRenderer.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/JsonErrorResponseRenderer.kt
@@ -9,7 +9,7 @@ import org.http4k.lens.Header
 import org.http4k.lens.LensFailure
 import org.http4k.lens.ParamMeta.ArrayParam
 
-class JsonErrorResponseRenderer<NODE>(private val json: Json<NODE>) : ErrorResponseRenderer {
+class JsonErrorResponseRenderer<NODE : Any>(private val json: Json<NODE>) : ErrorResponseRenderer {
     override fun badRequest(lensFailure: LensFailure) =
         Response(Status.BAD_REQUEST)
             .with(Header.CONTENT_TYPE of ContentType.APPLICATION_JSON)

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/OpenApiExtension.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/OpenApiExtension.kt
@@ -4,5 +4,5 @@ package org.http4k.contract.openapi
  * Provides a way to apply extensions to the OpenAPI JSON document.
  */
 interface OpenApiExtension {
-    operator fun <NODE> invoke(node: NODE): Render<NODE>
+    operator fun <NODE : Any> invoke(node: NODE): Render<NODE>
 }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/SecurityRenderer.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/SecurityRenderer.kt
@@ -8,31 +8,31 @@ import org.http4k.contract.security.Security
  * Provides rendering of Security models in to OpenApi specs.
  */
 interface SecurityRenderer {
-    fun <NODE> full(security: Security): Render<NODE>?
-    fun <NODE> ref(security: Security): Render<NODE>?
+    fun <NODE : Any> full(security: Security): Render<NODE>?
+    fun <NODE : Any> ref(security: Security): Render<NODE>?
 
     companion object {
         operator fun invoke(vararg renderers: SecurityRenderer): SecurityRenderer = object : SecurityRenderer {
-            override fun <NODE> full(security: Security): Render<NODE>? = when (security) {
+            override fun <NODE : Any> full(security: Security): Render<NODE>? = when (security) {
                 is AndSecurity -> security.renderAll { full<NODE>(it) }?.toObj()
                 is OrSecurity -> security.renderAll { full<NODE>(it) }?.toObj()
                 else -> renderers.asSequence().mapNotNull { it.full<NODE>(security) }.firstOrNull()
             }
 
-            override fun <NODE> ref(security: Security): Render<NODE>? = when (security) {
+            override fun <NODE : Any> ref(security: Security): Render<NODE>? = when (security) {
                 is AndSecurity -> security.renderAll { ref<NODE>(it) }?.toObj()
                 is OrSecurity -> security.renderAll { ref<NODE>(it) }?.toArray()
                 else -> renderers.asSequence().mapNotNull { it.ref<NODE>(security) }.firstOrNull()
             }
 
-            private fun <NODE> Iterable<Security>.renderAll(transform: (Security) -> Render<NODE>?) =
+            private fun <NODE : Any> Iterable<Security>.renderAll(transform: (Security) -> Render<NODE>?) =
                 mapNotNull(transform).takeIf { it.isNotEmpty() }
 
-            private fun <NODE> List<Render<NODE>>.toObj(): Render<NODE> = {
+            private fun <NODE : Any> List<Render<NODE>>.toObj(): Render<NODE> = {
                 obj(flatMap { fields(it(this)) })
             }
 
-            private fun <NODE> List<Render<NODE>>.toArray(): Render<NODE> = {
+            private fun <NODE : Any> List<Render<NODE>>.toArray(): Render<NODE> = {
                 array(flatMap { fields(it(this)) }.map { obj(it) })
             }
         }
@@ -40,11 +40,11 @@ interface SecurityRenderer {
 }
 
 interface RenderModes {
-    fun <NODE> full(): Render<NODE>
-    fun <NODE> ref(): Render<NODE>
+    fun <NODE : Any> full(): Render<NODE>
+    fun <NODE : Any> ref(): Render<NODE>
 }
 
 inline fun <reified T : Security> rendererFor(crossinline fn: (T) -> RenderModes) = object : SecurityRenderer {
-    override fun <NODE> full(security: Security): Render<NODE>? = if (security is T) fn(security).full() else null
-    override fun <NODE> ref(security: Security): Render<NODE>? = if (security is T) fn(security).ref() else null
+    override fun <NODE : Any> full(security: Security): Render<NODE>? = if (security is T) fn(security).full() else null
+    override fun <NODE : Any> ref(security: Security): Render<NODE>? = if (security is T) fn(security).ref() else null
 }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/JsonToJsonSchema.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/JsonToJsonSchema.kt
@@ -11,7 +11,7 @@ import org.http4k.util.IllegalSchemaException
 import org.http4k.util.JsonSchema
 import org.http4k.util.JsonSchemaCreator
 
-class JsonToJsonSchema<NODE>(
+class JsonToJsonSchema<NODE : Any>(
     private val json: Json<NODE>,
     private val refLocationPrefix: String = "definitions"
 ) : JsonSchemaCreator<NODE, NODE> {
@@ -53,7 +53,7 @@ class JsonToJsonSchema<NODE>(
             }
 
         val newDefinition = json { obj("type" to string("object"), "properties" to obj(fields)) }
-        val definitionId = prefix + (overrideDefinitionId ?: ("object" + newDefinition!!.hashCode()))
+        val definitionId = prefix + (overrideDefinitionId ?: ("object" + newDefinition.hashCode()))
         val allDefinitions = subDefinitions.plus(definitionId to newDefinition)
         return JsonSchema(json { obj("\$ref" to string("#/$refLocationPrefix/$definitionId")) }, allDefinitions)
     }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/OpenApi2.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/OpenApi2.kt
@@ -33,7 +33,7 @@ import java.util.Locale.getDefault
  * Contract renderer for OpenApi2 format JSON. Note that for the JSON schema generation, auto-naming of
  * object models is used as the input relies on JSON objects and not JVM classees.
  */
-open class OpenApi2<out NODE>(
+open class OpenApi2<out NODE : Any>(
     private val apiInfo: ApiInfo,
     private val json: Json<NODE>,
     private val baseUri: Uri? = null,

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/OpenApi2SecurityRenderer.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v2/OpenApi2SecurityRenderer.kt
@@ -16,7 +16,7 @@ val OpenApi2SecurityRenderer = SecurityRenderer(ApiKeySecurity.renderer, BasicAu
 val ApiKeySecurity.Companion.renderer
     get() = rendererFor<ApiKeySecurity<*>> {
         object : RenderModes {
-            override fun <NODE> full(): Render<NODE> = {
+            override fun <NODE : Any> full(): Render<NODE> = {
                 obj(it.name to obj(
                     "type" to string("apiKey"),
                     "in" to string(it.param.meta.location),
@@ -24,27 +24,27 @@ val ApiKeySecurity.Companion.renderer
                 ))
             }
 
-            override fun <NODE> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
+            override fun <NODE : Any> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
         }
     }
 
 val BasicAuthSecurity.Companion.renderer
     get() = rendererFor<BasicAuthSecurity> {
         object : RenderModes {
-            override fun <NODE> full(): Render<NODE> = {
+            override fun <NODE : Any> full(): Render<NODE> = {
                 obj(it.name to obj(
                     "type" to string("basic")
                 ))
             }
 
-            override fun <NODE> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
+            override fun <NODE : Any> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
         }
     }
 
 val ImplicitOAuthSecurity.Companion.renderer
     get() = rendererFor<ImplicitOAuthSecurity> {
         object : RenderModes {
-            override fun <NODE> full(): Render<NODE> = {
+            override fun <NODE : Any> full(): Render<NODE> = {
                 obj(it.name to
                     obj(
                         listOfNotNull(
@@ -56,6 +56,6 @@ val ImplicitOAuthSecurity.Companion.renderer
                 )
             }
 
-            override fun <NODE> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
+            override fun <NODE : Any> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
         }
     }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/JsonToJsonSchema.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/JsonToJsonSchema.kt
@@ -7,7 +7,7 @@ import org.http4k.util.IllegalSchemaException
 import org.http4k.util.JsonSchema
 import org.http4k.util.JsonSchemaCreator
 
-class JsonToJsonSchema<NODE>(
+class JsonToJsonSchema<NODE : Any>(
     private val json: Json<NODE>,
     private val refLocationPrefix: String = "components/schemas"
 ) : JsonSchemaCreator<NODE, NODE> {

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3SecurityRenderer.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3SecurityRenderer.kt
@@ -26,7 +26,7 @@ val OpenApi3SecurityRenderer: SecurityRenderer = SecurityRenderer(
 val ApiKeySecurity.Companion.renderer
     get() = rendererFor<ApiKeySecurity<*>> {
         object : RenderModes {
-            override fun <NODE> full(): Render<NODE> = {
+            override fun <NODE : Any> full(): Render<NODE> = {
                 obj(it.name to obj(
                     "type" to string("apiKey"),
                     "in" to string(it.param.meta.location),
@@ -34,14 +34,14 @@ val ApiKeySecurity.Companion.renderer
                 ))
             }
 
-            override fun <NODE> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
+            override fun <NODE : Any> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
         }
     }
 
 val AuthCodeOAuthSecurity.Companion.renderer
     get() = rendererFor<AuthCodeOAuthSecurity> {
         object : RenderModes {
-            override fun <NODE> full(): Render<NODE> = {
+            override fun <NODE : Any> full(): Render<NODE> = {
                 obj(it.name to obj(
                     "type" to string("oauth2"),
                     "flows" to obj("authorizationCode" to
@@ -58,42 +58,42 @@ val AuthCodeOAuthSecurity.Companion.renderer
                 ))
             }
 
-            override fun <NODE> ref(): Render<NODE> = { obj(it.name to array(it.scopes.map { string(it.name) })) }
+            override fun <NODE : Any> ref(): Render<NODE> = { obj(it.name to array(it.scopes.map { string(it.name) })) }
         }
     }
 
 val BasicAuthSecurity.Companion.renderer
     get() = rendererFor<BasicAuthSecurity> {
         object : RenderModes {
-            override fun <NODE> full(): Render<NODE> = {
+            override fun <NODE : Any> full(): Render<NODE> = {
                 obj(it.name to obj(
                     "scheme" to string("basic"),
                     "type" to string("http")
                 ))
             }
 
-            override fun <NODE> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
+            override fun <NODE : Any> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
         }
     }
 
 val BearerAuthSecurity.Companion.renderer
     get() = rendererFor<BearerAuthSecurity> {
         object : RenderModes {
-            override fun <NODE> full(): Render<NODE> = {
+            override fun <NODE : Any> full(): Render<NODE> = {
                 obj(it.name to obj(
                     "scheme" to string("bearer"),
                     "type" to string("http")
                 ))
             }
 
-            override fun <NODE> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
+            override fun <NODE : Any> ref(): Render<NODE> = { obj(it.name to array(emptyList())) }
         }
     }
 
 val ImplicitOAuthSecurity.Companion.renderer
     get() = rendererFor<ImplicitOAuthSecurity> {
         object : RenderModes {
-            override fun <NODE> full(): Render<NODE> = {
+            override fun <NODE : Any> full(): Render<NODE> = {
                 obj(it.name to obj(
                     "type" to string("oauth2"),
                     "flows" to obj("implicit" to
@@ -109,14 +109,14 @@ val ImplicitOAuthSecurity.Companion.renderer
                 ))
             }
 
-            override fun <NODE> ref(): Render<NODE> = { obj(it.name to array(it.scopes.map { string(it.name) })) }
+            override fun <NODE : Any> ref(): Render<NODE> = { obj(it.name to array(it.scopes.map { string(it.name) })) }
         }
     }
 
 val UserCredentialsOAuthSecurity.Companion.renderer
     get() = rendererFor<UserCredentialsOAuthSecurity> {
         object : RenderModes {
-            override fun <NODE> full(): Render<NODE> = {
+            override fun <NODE : Any> full(): Render<NODE> = {
                 obj(it.name to obj(
                     "type" to string("oauth2"),
                     "flows" to obj("password" to
@@ -132,6 +132,6 @@ val UserCredentialsOAuthSecurity.Companion.renderer
                 ))
             }
 
-            override fun <NODE> ref(): Render<NODE> = { obj(it.name to array(it.scopes.map { string(it.name) })) }
+            override fun <NODE : Any> ref(): Render<NODE> = { obj(it.name to array(it.scopes.map { string(it.name) })) }
         }
     }

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/simple/SimpleJson.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/simple/SimpleJson.kt
@@ -12,7 +12,7 @@ import org.http4k.core.Status.Companion.OK
 import org.http4k.core.with
 import org.http4k.format.Json
 
-class SimpleJson<out NODE>(private val json: Json<NODE>) : ContractRenderer, ErrorResponseRenderer by JsonErrorResponseRenderer(json) {
+class SimpleJson<out NODE : Any>(private val json: Json<NODE>) : ContractRenderer, ErrorResponseRenderer by JsonErrorResponseRenderer(json) {
     private fun render(pathSegments: PathSegments, route: ContractRoute) =
         route.method.toString() + ":" + route.describeFor(pathSegments) to json.string(route.meta.summary)
 

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/helper.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/openapi/helper.kt
@@ -1,7 +1,7 @@
 package org.http4k.contract.openapi
 
 object AddSimpleFieldToRootNode : OpenApiExtension {
-    override fun <NODE> invoke(node: NODE): Render<NODE> = {
+    override fun <NODE : Any> invoke(node: NODE): Render<NODE> = {
         obj(fields(node) + ("x-extension" to array(string("extensionField"))))
     }
 }

--- a/http4k-format/core/src/test/kotlin/org/http4k/format/JsonContract.kt
+++ b/http4k-format/core/src/test/kotlin/org/http4k/format/JsonContract.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.math.BigInteger
 
-abstract class JsonContract<NODE>(open val j: Json<NODE>) {
+abstract class JsonContract<NODE : Any>(open val j: Json<NODE>) : JsonMappingContract<NODE>(j) {
 
     abstract val prettyString: String
 

--- a/http4k-format/core/src/test/kotlin/org/http4k/format/JsonMappingContract.kt
+++ b/http4k-format/core/src/test/kotlin/org/http4k/format/JsonMappingContract.kt
@@ -1,0 +1,93 @@
+package org.http4k.format
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.lens.ParamMeta
+import org.http4k.lens.enum
+import org.http4k.lens.int
+import org.junit.jupiter.api.Test
+
+abstract class JsonMappingContract<NODE : Any>(private val json: Json<NODE>) {
+
+    @Test
+    fun `mapping json to object`() {
+        val lens = json.body().map(toEmployee()).toLens()
+
+        val employee: Employee = lens(Response(Status.OK).body(JSON))
+
+        assertThat(employee, equalTo(Employee(
+            name = "Betty",
+            age = 33,
+            department = Department.Technology,
+            manager = Employee(
+                name = "Susan",
+                age = 37,
+                department = Department.Technology
+            ),
+            skills = listOf("Coding", "Coffee-making", "http4k")
+        )))
+    }
+
+    @Test
+    fun `mapping json to array of objects`() {
+        val lens = json.body().map(toEmployees()).toLens()
+
+        val employees: List<Employee> = lens(Response(Status.OK).body("""[ $JSON ]"""))
+
+        assertThat(employees, equalTo(listOf(Employee(
+            name = "Betty",
+            age = 33,
+            department = Department.Technology,
+            manager = Employee(
+                name = "Susan",
+                age = 37,
+                department = Department.Technology
+            ),
+            skills = listOf("Coding", "Coffee-making", "http4k")
+        ))))
+    }
+
+    private fun toEmployee(): (NODE) -> Employee = json {
+        asA {
+            Employee(
+                name = field().required("name")[it],
+                age = field().int().required("age")[it],
+                department = field().enum<NODE, Department>().required("department")[it],
+                manager = obj(toEmployee()).optional("manager")[it],
+                skills = array(ParamMeta.StringParam, this::text).defaulted("skills", emptyList())[it]
+            )
+        }
+    }
+
+    private fun toEmployees(): (NODE) -> List<Employee> = json.asArray(toEmployee())
+
+    companion object {
+        private const val JSON = """
+            {
+                "name" : "Betty",
+                "age" : 33,
+                "department" : "Technology",
+                "manager" : {
+                    "name" : "Susan",
+                    "age" : 37,
+                    "department" : "Technology"
+                },
+                "skills" : [ "Coding", "Coffee-making", "http4k" ]
+            }
+            """
+    }
+}
+
+data class Employee(
+    val name: String,
+    val age: Int,
+    val department: Department,
+    val manager: Employee? = null,
+    val skills: List<String> = emptyList()
+)
+
+enum class Department {
+    Technology
+}

--- a/http4k-format/core/src/test/kotlin/org/http4k/jsonrpc/JsonRpcServiceContract.kt
+++ b/http4k-format/core/src/test/kotlin/org/http4k/jsonrpc/JsonRpcServiceContract.kt
@@ -48,7 +48,7 @@ object CounterErrorHandler : ErrorHandler {
     }
 
     private class NegativeIncrementExceptionMessage : ErrorMessage(1, "Increment by negative") {
-        override fun <NODE> data(json: Json<NODE>): NODE? =
+        override fun <NODE : Any> data(json: Json<NODE>): NODE =
             json.string("cannot increment counter by negative")
     }
 }

--- a/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/ConfigurableKotlinxSerialization.kt
+++ b/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/ConfigurableKotlinxSerialization.kt
@@ -75,7 +75,11 @@ open class ConfigurableKotlinxSerialization(
 
     override fun JsonElement.asCompactJsonString() = json.encodeToString(JsonElement.serializer(), this)
 
-    override fun String.asJsonObject() = json.decodeFromString(JsonObject.serializer(), this)
+    override fun String.asJsonObject() = json.parseToJsonElement(this).also {
+        // To achieve functional parity with the other formats, we only allow Object and Array,
+        // even though KotlinxSerialization is fully capable of parsing raw values.
+        require(it is JsonObject || it is JsonArray) { "invalid json"}
+    }
 
     override fun String?.asJsonValue() = JsonPrimitive(this)
 

--- a/http4k-jsonrpc/src/main/kotlin/org/http4k/jsonrpc/ErrorMessage.kt
+++ b/http4k-jsonrpc/src/main/kotlin/org/http4k/jsonrpc/ErrorMessage.kt
@@ -3,9 +3,9 @@ package org.http4k.jsonrpc
 import org.http4k.format.Json
 
 open class ErrorMessage(val code: Int, val message: String) {
-    open fun <NODE> data(json: Json<NODE>): NODE? = null
+    open fun <NODE : Any> data(json: Json<NODE>): NODE? = null
 
-    operator fun <NODE> invoke(json: Json<NODE>): NODE = json {
+    operator fun <NODE : Any> invoke(json: Json<NODE>): NODE = json {
         val fields = listOf("code" to number(code), "message" to string(message))
         val data = data(json)
         json.obj(data?.let { fields + ("data" to it) } ?: fields)

--- a/http4k-jsonrpc/src/main/kotlin/org/http4k/jsonrpc/JsonRpcService.kt
+++ b/http4k-jsonrpc/src/main/kotlin/org/http4k/jsonrpc/JsonRpcService.kt
@@ -110,7 +110,7 @@ typealias ErrorHandler = (Throwable) -> ErrorMessage?
 
 private const val jsonRpcVersion: String = "2.0"
 
-private class JsonRpcRequest<NODE>(json: Json<NODE>, fields: Map<String, NODE>) {
+private class JsonRpcRequest<NODE : Any>(json: Json<NODE>, fields: Map<String, NODE>) {
     private var valid = (fields["jsonrpc"] ?: json.nullNode()).let {
         json.typeOf(it) == JsonType.String && jsonRpcVersion == json.text(it)
     }

--- a/http4k-testing/hamkrest/src/main/kotlin/org/http4k/hamkrest/httpMessage.kt
+++ b/http4k-testing/hamkrest/src/main/kotlin/org/http4k/hamkrest/httpMessage.kt
@@ -58,8 +58,8 @@ fun hasBody(expected: Regex): Matcher<HttpMessage> = hasBody(present(matches(exp
 
 fun <T> hasBody(lens: BodyLens<T>, matcher: Matcher<T>): Matcher<HttpMessage> = LensMatcher(httpMessageHas("Body", { m: HttpMessage -> lens(m) }, matcher))
 
-fun <NODE> Json<NODE>.hasBody(expected: NODE): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> parse(m.bodyString()) }, equalTo(expected))
+fun <NODE : Any> Json<NODE>.hasBody(expected: NODE): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> parse(m.bodyString()) }, equalTo(expected))
 
-fun <NODE> Json<NODE>.hasBody(expected: Matcher<NODE>): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> parse(m.bodyString()) }, expected)
+fun <NODE : Any> Json<NODE>.hasBody(expected: Matcher<NODE>): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> parse(m.bodyString()) }, expected)
 
-fun <NODE> Json<NODE>.hasBody(expected: String): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> compactify(m.bodyString()) }, equalTo(compactify(expected)))
+fun <NODE : Any> Json<NODE>.hasBody(expected: String): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> compactify(m.bodyString()) }, equalTo(compactify(expected)))

--- a/http4k-testing/kotest/src/main/kotlin/org/http4k/kotest/httpMessage.kt
+++ b/http4k-testing/kotest/src/main/kotlin/org/http4k/kotest/httpMessage.kt
@@ -81,11 +81,11 @@ fun <T> HttpMessage.shouldHaveBody(lens: BodyLens<T>, matcher: Matcher<T>) = thi
 fun <T> HttpMessage.shouldNotHaveBody(lens: BodyLens<T>, matcher: Matcher<T>) = this shouldNot haveBody(lens, matcher)
 fun <T : HttpMessage, B> haveBody(lens: BodyLens<B>, matcher: Matcher<B>): Matcher<T> = LensMatcher(httpMessageHas("Body", { m: T -> lens(m) }, matcher))
 
-fun <NODE> Json<NODE>.haveBody(expected: NODE): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> compact(parse(m.bodyString())) }, be(compact(expected)))
+fun <NODE : Any> Json<NODE>.haveBody(expected: NODE): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> compact(parse(m.bodyString())) }, be(compact(expected)))
 
-fun <NODE> Json<NODE>.haveBody(expected: Matcher<NODE>): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> parse(m.bodyString()) }, expected)
+fun <NODE : Any> Json<NODE>.haveBody(expected: Matcher<NODE>): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> parse(m.bodyString()) }, expected)
 
-fun <NODE> Json<NODE>.haveBody(expected: String): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> compactify(m.bodyString()) }, be(compactify(expected)))
+fun <NODE : Any> Json<NODE>.haveBody(expected: String): Matcher<HttpMessage> = httpMessageHas("Body", { m: HttpMessage -> compactify(m.bodyString()) }, be(compactify(expected)))
 
 fun <T : HttpMessage, R> httpMessageHas(name: String, extractValue: (T) -> R, match: Matcher<R>): Matcher<T> = object : Matcher<T> {
     override fun test(value: T): MatcherResult {

--- a/http4k-testing/strikt/src/main/kotlin/org/http4k/strikt/httpMessage.kt
+++ b/http4k-testing/strikt/src/main/kotlin/org/http4k/strikt/httpMessage.kt
@@ -14,4 +14,4 @@ val <M : HttpMessage> Assertion.Builder<M>.contentType get() = get { CONTENT_TYP
 val <M : HttpMessage> Assertion.Builder<M>.body get() = get(HttpMessage::body)
 val <M : HttpMessage> Assertion.Builder<M>.bodyString get() = get { bodyString() }
 
-fun <NODE, M : HttpMessage> Assertion.Builder<M>.jsonBody(json: Json<NODE>) = get { json.parse(bodyString()) }
+fun <NODE : Any, M : HttpMessage> Assertion.Builder<M>.jsonBody(json: Json<NODE>) = get { json.parse(bodyString()) }

--- a/src/docs/guide/reference/jsonrpc/example.kt
+++ b/src/docs/guide/reference/jsonrpc/example.kt
@@ -34,7 +34,7 @@ object CounterErrorHandler : ErrorHandler {
 
     private class NegativeIncrementExceptionMessage :
         ErrorMessage(1, "Increment by negative") {
-        override fun <NODE> data(json: Json<NODE>) =
+        override fun <NODE : Any> data(json: Json<NODE>) =
             json.string("cannot increment counter by negative")
     }
 }


### PR DESCRIPTION
This PR adds the ability to manually define mapping from JSON to objects using a set of new utility methods in `Json` interface.

This is useful when we don't know what implementation we are using and cannot use auto-marshalling functionality from e.g. Jackson or Moshi.

This is in the similar vein as the current utility methods to create JSON.

Naming of methods etc are all open for discussion - I simply went with what I thought made the most sense - but there are probably better names.

I am raising this as a draft PR, so that I can gather feedback on the implementation and if it is actually a good idea or not.

NOTE: I also had to change the signature of `Json<NODE>` to be `Json<NODE : Any>` to make it work with lenses, which do require the generic type to be `IN : Any`. That is why there are so many files changed, even though all the core changes are in `Json` and the associated tests.