### PR TITLE
fix: avoid altering path params

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/PathSegments.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/PathSegments.kt
@@ -40,4 +40,5 @@ object Root : PathSegments() {
 internal fun Request.isIn(contractRoot: PathSegments) = pathSegments().startsWith(contractRoot)
 
 internal fun Request.pathSegments() = PathSegments(uri.path)
-internal fun Request.without(pathSegments: PathSegments) = PathSegments(uri.path.replace(pathSegments.toString(), ""))
+internal fun Request.without(pathSegments: PathSegments) =
+    PathSegments(uri.path.replaceFirst(pathSegments.toString(), ""))

--- a/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
+++ b/http4k-contract/src/test/kotlin/org/http4k/contract/ContractRouteTest.kt
@@ -251,6 +251,13 @@ class ContractRouteTest {
     }
 
     @Test
+    fun `param starting with prefix is not changed`() {
+        val route = "somePrefix" / Path.of("value") bindContract GET to { value -> { Response(OK).body(value) } }
+
+        assertThat(route(Request(GET, "/somePrefix/somePrefixInValue")).bodyString(), equalTo("somePrefixInValue"))
+    }
+
+    @Test
     fun `can receive negotiated body with PreFlightExtraction`() {
         val v1Lens = Body.string(ContentType("custom/v1"))
             .map({ require("v1-" in it); it.replace("v1-", "") }, { "v1-$it" })


### PR DESCRIPTION
Hello !

When using contracts, there is a bug when parsing parameters and passing them to the handler.

For example, if you have a route like this `"somePrefix" / Path.of("value")`, when matching `/somePrefix/somePrefixInValue`, the prefix will be removed from the value.

This PR is fixing this bug by trimming only the first occurrence when matching the uri.