### PR TITLE
Allow access-control-max-age header to be set from cors policy

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
@@ -34,7 +34,8 @@ data class CorsPolicy(
     val headers: List<String>,
     val methods: List<Method>,
     val credentials: Boolean = false,
-    val exposedHeaders: List<String> = emptyList()
+    val exposedHeaders: List<String> = emptyList(),
+    val maxAge: Int? = null
 ) {
     companion object {
         val UnsafeGlobalPermissive =
@@ -71,7 +72,8 @@ object ServerFilters {
                         res.takeIf { policy.exposedHeaders.isNotEmpty() }
                             ?.header("access-control-expose-headers", policy.exposedHeaders.joined())
                             ?: res
-                    }
+                    },
+                    { res -> policy.maxAge?.let { maxAge -> res.header("access-control-max-age", "$maxAge") } ?: res }
                 )
             }
         }

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
@@ -136,7 +136,8 @@ class ServerFiltersTest {
             .and(hasHeader("access-control-allow-headers", "content-type"))
             .and(hasHeader("access-control-allow-methods", "GET, POST, PUT, DELETE, OPTIONS, TRACE, PATCH, PURGE, HEAD"))
             .and(hasHeader("access-control-allow-credentials", "true"))
-            .and(hasHeader("access-control-expose-headers").not()))
+            .and(hasHeader("access-control-expose-headers").not())
+            .and(hasHeader("access-control-max-age").not()))
     }
 
     @Test
@@ -147,6 +148,16 @@ class ServerFiltersTest {
 
         assertThat(response, hasStatus(I_M_A_TEAPOT)
             .and(hasHeader("access-control-expose-headers", "foo, bar")))
+    }
+
+    @Test
+    fun `GET - with max age`() {
+        val policy = CorsPolicy(OriginPolicy.AllowAll(), emptyList(), emptyList(), maxAge = 86400)
+        val handler = ServerFilters.Cors(policy).then { Response(I_M_A_TEAPOT) }
+        val response = handler(Request(GET, "/"))
+
+        assertThat(response, hasStatus(I_M_A_TEAPOT)
+            .and(hasHeader("access-control-max-age", "86400")))
     }
 
     @Test


### PR DESCRIPTION
Allow caching of cors preflight checks as described [here](https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request) by letting CorsPolicy set an access-control-max-age header. 

