### PR TITLE
Add support for SSE to Jetty server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ changes with their rationale when appropriate:
 
 ### v4.35.5.0 (uncut)
 - **http4k-multipart** : Add lensing of Multipart form fields using JSON and Automarshalling
+- **http4k-server-jetty** : Add support for serving SSE. H/T @FredNordin
 
 ### v4.35.4.0
 - **http4k-*** : Upgrade some dependency versions.

--- a/http4k-server/jetty/src/main/kotlin/org/http4k/server/JettyEventStreamHandler.kt
+++ b/http4k-server/jetty/src/main/kotlin/org/http4k/server/JettyEventStreamHandler.kt
@@ -1,0 +1,173 @@
+package org.http4k.server
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.eclipse.jetty.server.handler.HandlerWrapper
+import org.eclipse.jetty.util.component.LifeCycle
+import org.eclipse.jetty.util.thread.AutoLock
+import org.eclipse.jetty.util.thread.Scheduler
+import org.http4k.core.ContentType
+import org.http4k.core.Request
+import org.http4k.servlet.jakarta.asHttp4kRequest
+import org.http4k.sse.PushAdaptingSse
+import org.http4k.sse.SseHandler
+import org.http4k.sse.SseMessage
+import java.io.IOException
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import org.eclipse.jetty.server.Request as JettyRequest
+
+class JettyEventStreamHandler(
+    private val sse: SseHandler,
+    private val heartBeatDuration: Duration = Duration.ofSeconds(15)
+) : HandlerWrapper() {
+
+    override fun handle(target: String, baseRequest: JettyRequest,
+                        request: HttpServletRequest, response: HttpServletResponse) {
+        if (!baseRequest.isHandled && request.isEventStream()) {
+            val connectRequest = request.asHttp4kRequest()
+            if (connectRequest != null) {
+                response.writeEventStreamResponse()
+
+                val async = request.startAsyncWithNoTimeout()
+                val output = async.response.outputStream
+                val scheduler = baseRequest.httpChannel.connector.scheduler
+                val server = baseRequest.httpChannel.connector.server
+                val emitter = JettyEventStreamEmitter(connectRequest, output, heartBeatDuration, scheduler, onClose = {
+                    async.complete()
+                    server.removeEventListener(it)
+                }).also(server::addEventListener)
+
+                sse(connectRequest)(emitter)
+
+                baseRequest.isHandled = true
+            }
+        }
+
+        if (!baseRequest.isHandled) super.handle(target, baseRequest, request, response)
+    }
+
+    companion object {
+        private fun HttpServletRequest.isEventStream() =
+            method == "GET" && getHeaders("Accept").toList().any { it.equals(ContentType.TEXT_EVENT_STREAM.value, true) }
+
+        private fun HttpServletResponse.writeEventStreamResponse() {
+            status = HttpServletResponse.SC_OK
+            characterEncoding = StandardCharsets.UTF_8.name()
+            contentType = ContentType.TEXT_EVENT_STREAM.value
+            // By adding this header, and not closing the connection,
+            // we disable HTTP chunking, and we can use write()+flush()
+            // to send data in the text/event-stream protocol
+            addHeader("Connection", "close")
+            flushBuffer()
+        }
+
+        private fun HttpServletRequest.startAsyncWithNoTimeout() =
+            startAsync().apply {
+                // Infinite timeout because the continuation is never resumed,
+                // but only completed on close
+                timeout = 0
+            }
+    }
+}
+
+internal class JettyEventStreamEmitter(
+    request: Request,
+    private val output: OutputStream,
+    private val heartBeatDuration: Duration,
+    private val scheduler: Scheduler,
+    private val onClose: (JettyEventStreamEmitter) -> Unit
+): PushAdaptingSse(request), Runnable, LifeCycle.Listener {
+    private val lock: AutoLock = AutoLock()
+    private var heartBeat: Scheduler.Task? = null
+    private var closed = false
+
+    init {
+        scheduleHeartBeat()
+    }
+
+    override fun send(message: SseMessage) = when (message) {
+        is SseMessage.Event -> sendEvent(message.event, message.data, message.id)
+        is SseMessage.Data -> sendData(message.data)
+        is SseMessage.Retry -> sendRetry(message.backoff)
+    }
+
+    private fun sendEvent(event: String, data: String, id: String?) = lock.lock().use {
+        id?.also {
+            output.write(ID_FIELD)
+            output.write(it.toByteArray())
+            output.write(CRLF)
+        }
+        output.write(EVENT_FIELD)
+        output.write(event.toByteArray())
+        output.write(CRLF)
+        sendData(data)
+    }
+
+    private fun sendData(data: String) = lock.lock().use {
+        data.lines().forEach { line ->
+            output.write(DATA_FIELD)
+            output.write(line.toByteArray())
+            output.write(CRLF)
+        }
+        output.write(CRLF)
+        output.flush()
+    }
+
+    private fun sendRetry(duration: Duration) = lock.lock().use {
+        output.write(RETRY_FIELD)
+        output.write(duration.toMillis().toString().toByteArray())
+        output.write(CRLF)
+        output.write(CRLF)
+        output.flush()
+    }
+
+    override fun close() = lock.lock().use {
+        if (!closed) {
+            closed = true
+            heartBeat?.cancel()
+            onClose(this)
+            triggerClose()
+        }
+    }
+
+    override fun lifeCycleStopping(event: LifeCycle) {
+        close()
+    }
+
+    override fun run() {
+        try {
+            // If the other peer closes the connection, the first
+            // flush() should generate a TCP reset that is detected
+            // on the second flush()
+            lock.lock().use {
+                output.write('\r'.code)
+                output.flush()
+                output.write('\n'.code)
+                output.flush()
+            }
+            scheduleHeartBeat()
+        } catch (e: IOException) {
+            // The other peer closed the connection
+            close()
+        }
+    }
+
+    private fun scheduleHeartBeat() {
+        lock.lock().use {
+            if (!closed) {
+                heartBeat = scheduler.schedule(this, heartBeatDuration.toMillis(), TimeUnit.MILLISECONDS)
+            }
+        }
+    }
+
+    companion object {
+        private val CRLF = "\r\n".toByteArray()
+        private val ID_FIELD = "id:".toByteArray()
+        private val EVENT_FIELD = "event:".toByteArray()
+        private val DATA_FIELD = "data:".toByteArray()
+        private val RETRY_FIELD = "retry:".toByteArray()
+    }
+}

--- a/http4k-server/jetty/src/main/kotlin/org/http4k/server/jettyInfra.kt
+++ b/http4k-server/jetty/src/main/kotlin/org/http4k/server/jettyInfra.kt
@@ -15,11 +15,14 @@ import org.eclipse.jetty.servlet.ServletContextHandler.SESSIONS
 import org.eclipse.jetty.servlet.ServletHolder
 import org.eclipse.jetty.util.ssl.SslContextFactory
 import org.eclipse.jetty.websocket.core.FrameHandler
+import org.eclipse.jetty.websocket.core.WebSocketComponents
 import org.eclipse.jetty.websocket.core.server.WebSocketNegotiation
 import org.eclipse.jetty.websocket.core.server.WebSocketNegotiator
+import org.eclipse.jetty.websocket.core.server.WebSocketUpgradeHandler
 import org.http4k.core.HttpHandler
 import org.http4k.servlet.jakarta.asHttp4kRequest
 import org.http4k.servlet.jakarta.asServlet
+import org.http4k.sse.SseHandler
 import org.http4k.websocket.WsHandler
 
 fun HttpHandler.toJettyHandler(withStatisticsHandler: Boolean = false): HandlerWrapper = ServletContextHandler(
@@ -28,6 +31,12 @@ fun HttpHandler.toJettyHandler(withStatisticsHandler: Boolean = false): HandlerW
     addServlet(ServletHolder(this@toJettyHandler.asServlet()), "/*")
 }.let {
     if (withStatisticsHandler) StatisticsHandler().apply { handler = it } else it
+}
+
+fun SseHandler.toJettySseHandler() = JettyEventStreamHandler(this)
+
+fun WsHandler.toJettyWsHandler() = WebSocketUpgradeHandler(WebSocketComponents()).apply {
+    addMapping("/*", this@toJettyWsHandler.toJettyNegotiator())
 }
 
 fun WsHandler.toJettyNegotiator() = object : WebSocketNegotiator.AbstractNegotiator() {

--- a/http4k-server/jetty/src/test/kotlin/org/http4k/server/JettyEventStreamEmitterTest.kt
+++ b/http4k-server/jetty/src/test/kotlin/org/http4k/server/JettyEventStreamEmitterTest.kt
@@ -1,0 +1,231 @@
+package org.http4k.server
+
+import com.natpryce.hamkrest.allOf
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.has
+import com.natpryce.hamkrest.present
+import com.natpryce.hamkrest.sameInstance
+import org.eclipse.jetty.util.component.AbstractLifeCycle
+import org.eclipse.jetty.util.thread.Scheduler
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.sse.SseMessage
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class JettyEventStreamEmitterTest {
+
+    @Test
+    fun `sse connectRequest is returned`() {
+        val emitter = JettyEventStreamEmitter(connectRequest, FakeOutput(), Duration.ofMillis(5), FakeScheduler(), onClose = {})
+
+        assertThat(emitter.connectRequest, equalTo(connectRequest))
+    }
+
+    @Test
+    fun `can send Retry message`() {
+        val output = FakeOutput()
+        val emitter = JettyEventStreamEmitter(connectRequest, output, Duration.ofMillis(5), FakeScheduler(), onClose = {})
+
+        emitter.send(SseMessage.Retry(Duration.ofMillis(3)))
+
+        assertThat(output.toString(), equalTo("retry:3\r\n\r\n"))
+        assertThat(output.flushCalls, equalTo(1))
+    }
+
+    @Test
+    fun `can send Data message`() {
+        val output = FakeOutput()
+        val emitter = JettyEventStreamEmitter(connectRequest, output, Duration.ofMillis(5), FakeScheduler(), onClose = {})
+
+        emitter.send(SseMessage.Data("some data"))
+
+        assertThat(output.toString(), equalTo("data:some data\r\n\r\n"))
+        assertThat(output.flushCalls, equalTo(1))
+    }
+
+    @Test
+    fun `can send Data message containing multiple lines`() {
+        val output = FakeOutput()
+        val emitter = JettyEventStreamEmitter(connectRequest, output, Duration.ofMillis(5), FakeScheduler(), onClose = {})
+
+        emitter.send(SseMessage.Data("some data\nwith another line"))
+
+        assertThat(output.toString(), equalTo("data:some data\r\ndata:with another line\r\n\r\n"))
+        assertThat(output.flushCalls, equalTo(1))
+    }
+
+    @Test
+    fun `can send Event message with an id`() {
+        val output = FakeOutput()
+        val emitter = JettyEventStreamEmitter(connectRequest, output, Duration.ofMillis(5), FakeScheduler(), onClose = {})
+
+        emitter.send(SseMessage.Event("event name", "some data", "an id"))
+
+        assertThat(output.toString(), equalTo("id:an id\r\nevent:event name\r\ndata:some data\r\n\r\n"))
+        assertThat(output.flushCalls, equalTo(1))
+    }
+
+    @Test
+    fun `can send Event message without an id`() {
+        val output = FakeOutput()
+        val emitter = JettyEventStreamEmitter(connectRequest, output, Duration.ofMillis(5), FakeScheduler(), onClose = {})
+
+        emitter.send(SseMessage.Event("event name", "some data", id = null))
+
+        assertThat(output.toString(), equalTo("event:event name\r\ndata:some data\r\n\r\n"))
+        assertThat(output.flushCalls, equalTo(1))
+    }
+
+    @Test
+    fun `can send Event message with multiline data`() {
+        val output = FakeOutput()
+        val emitter = JettyEventStreamEmitter(connectRequest, output, Duration.ofMillis(5), FakeScheduler(), onClose = {})
+
+        emitter.send(SseMessage.Event("event name", "some data\nwith another line", id = null))
+
+        assertThat(output.toString(), equalTo("event:event name\r\ndata:some data\r\ndata:with another line\r\n\r\n"))
+        assertThat(output.flushCalls, equalTo(1))
+    }
+
+    @Test
+    fun `schedules a heart beat on creation with provided duration`() {
+        val scheduler = FakeScheduler()
+        val emitter = JettyEventStreamEmitter(connectRequest, FakeOutput(), Duration.ofMillis(5), scheduler, onClose = {})
+
+        assertThat(scheduler.currentTask, present(allOf(
+            has(FakeScheduler.FakeTask::task, sameInstance(emitter)),
+            has(FakeScheduler.FakeTask::delay, equalTo(5)),
+            has(FakeScheduler.FakeTask::units, equalTo(TimeUnit.MILLISECONDS))
+        )))
+        assertThat(scheduler.tasksScheduled, equalTo(1))
+    }
+
+    @Test
+    fun `when a heart beat triggers a blank line is written to the output and a new heart beat is scheduled`() {
+        val scheduler = FakeScheduler()
+        val output = FakeOutput()
+        JettyEventStreamEmitter(connectRequest, output, Duration.ofMillis(5), scheduler, onClose = {})
+
+        scheduler.trigger()
+
+        assertThat(output.toString(), equalTo("\r\n"))
+        assertThat(output.flushCalls, equalTo(2))
+        assertThat(scheduler.tasksScheduled, equalTo(2))
+    }
+
+    @Test
+    fun `close cancels the heart beat and invokes the onClose callbacks`() {
+        val scheduler = FakeScheduler()
+        val emitterOnCloseCallCount = AtomicInteger(0)
+        val sseOnCloseCallCount = AtomicInteger(0)
+        val emitter = JettyEventStreamEmitter(connectRequest, FakeOutput(), Duration.ofMillis(5), scheduler,
+            onClose = { emitterOnCloseCallCount.incrementAndGet() })
+        emitter.onClose { sseOnCloseCallCount.incrementAndGet() }
+
+        emitter.close()
+
+        assertThat(scheduler.currentTask, present(has(FakeScheduler.FakeTask::cancelled, equalTo(true))))
+        assertThat(emitterOnCloseCallCount.get(), equalTo(1))
+        assertThat(sseOnCloseCallCount.get(), equalTo(1))
+    }
+
+    @Test
+    fun `close called multiple times only cancels the heart beat and invokes the onClose callbacks once`() {
+        val scheduler = FakeScheduler()
+        val emitterOnCloseCallCount = AtomicInteger(0)
+        val sseOnCloseCallCount = AtomicInteger(0)
+        val emitter = JettyEventStreamEmitter(connectRequest, FakeOutput(), Duration.ofMillis(5), scheduler,
+            onClose = { emitterOnCloseCallCount.incrementAndGet() })
+        emitter.onClose { sseOnCloseCallCount.incrementAndGet() }
+
+        emitter.close()
+        emitter.close()
+        emitter.close()
+
+        assertThat(scheduler.currentTask, present(has(FakeScheduler.FakeTask::cancelled, equalTo(true))))
+        assertThat(emitterOnCloseCallCount.get(), equalTo(1))
+        assertThat(sseOnCloseCallCount.get(), equalTo(1))
+    }
+
+    @Test
+    fun `close is called on lifeCycleStopping`() {
+        val scheduler = FakeScheduler()
+        val emitterOnCloseCallCount = AtomicInteger(0)
+        val sseOnCloseCallCount = AtomicInteger(0)
+        val emitter = JettyEventStreamEmitter(connectRequest, FakeOutput(), Duration.ofMillis(5), scheduler,
+            onClose = { emitterOnCloseCallCount.incrementAndGet() })
+        emitter.onClose { sseOnCloseCallCount.incrementAndGet() }
+
+        emitter.lifeCycleStopping(object : AbstractLifeCycle() {})
+
+        assertThat(scheduler.currentTask, present(has(FakeScheduler.FakeTask::cancelled, equalTo(true))))
+        assertThat(emitterOnCloseCallCount.get(), equalTo(1))
+        assertThat(sseOnCloseCallCount.get(), equalTo(1))
+    }
+
+    @Test
+    fun `close is called when the heart beat cannot write to the output`() {
+        val scheduler = FakeScheduler()
+        val emitterOnCloseCallCount = AtomicInteger(0)
+        val sseOnCloseCallCount = AtomicInteger(0)
+        val emitter = JettyEventStreamEmitter(connectRequest, FakeOutput(flushFails = true), Duration.ofMillis(5), scheduler,
+            onClose = { emitterOnCloseCallCount.incrementAndGet() })
+        emitter.onClose { sseOnCloseCallCount.incrementAndGet() }
+
+        scheduler.trigger()
+
+        assertThat(scheduler.currentTask, present(has(FakeScheduler.FakeTask::cancelled, equalTo(true))))
+        assertThat(emitterOnCloseCallCount.get(), equalTo(1))
+        assertThat(sseOnCloseCallCount.get(), equalTo(1))
+    }
+
+    companion object {
+        private val connectRequest = Request(Method.GET, "/some/path")
+    }
+}
+
+private class FakeOutput(private val flushFails: Boolean = false) : ByteArrayOutputStream() {
+    var flushCalls = 0
+
+    override fun flush() {
+        if (flushFails) {
+            throw IOException()
+        }
+        flushCalls++
+        super.flush()
+    }
+}
+
+private class FakeScheduler : Scheduler, AbstractLifeCycle() {
+    var currentTask: FakeTask? = null
+    var tasksScheduled = 0
+
+    override fun schedule(task: Runnable, delay: Long, units: TimeUnit): Scheduler.Task {
+        return FakeTask(task, delay, units).also {
+            currentTask = it
+            tasksScheduled++
+        }
+    }
+
+    fun trigger() {
+        currentTask?.task?.run()
+    }
+
+    class FakeTask(val task: Runnable, val delay: Long, val units: TimeUnit) : Scheduler.Task {
+        var cancelled = false
+
+        override fun cancel(): Boolean {
+            require(!cancelled) {
+                "Task has already been cancelled"
+            }
+            cancelled = true
+            return true
+        }
+    }
+}

--- a/http4k-server/jetty/src/test/kotlin/org/http4k/sse/JettySseTest.kt
+++ b/http4k-server/jetty/src/test/kotlin/org/http4k/sse/JettySseTest.kt
@@ -1,0 +1,6 @@
+package org.http4k.sse
+
+import org.http4k.client.JavaHttpClient
+import org.http4k.server.Jetty
+
+class JettySseTest : SseServerContract(::Jetty, JavaHttpClient())

--- a/src/docs/guide/howto/serve_sse/index.md
+++ b/src/docs/guide/howto/serve_sse/index.md
@@ -6,6 +6,8 @@ description: Recipes for using http4k with Server-Sent Events
 ```groovy
 implementation group: "org.http4k", name: "http4k-core", version: "4.35.4.0"
 implementation group: "org.http4k", name: "http4k-server-undertow", version: "4.35.4.0"
+// Or if you prefer Jetty
+implementation group: "org.http4k", name: "http4k-server-jetty", version: "4.35.4.0"
 ```
 
 **http4k** provides SSE (Server Sent Events) support using a simple, consistent, typesafe, and testable API on supported server backends (see above). SSE communication consists of 3 main concepts:


### PR DESCRIPTION
This PR adds SSE support to Jetty server.

# Background

The fact that Jetty server does not have support for SSE out of the box has bugged me for a while and it does seem slightly strange that Jetty doesn't come with a supported handler, like it does for websocket. So I started hunting around for some 3rd party solutions, that could either be directly used or be used as an inspiration.

# Findings

Turns out that there is another Jetty lib called `jetty-servlets` that contain a servlet to handle SSE, but it was not suitable for the following reasons:

* It doesn't support Retry messages
* It doesn't cancel outstanding SSE sessions when the server shuts down, which means client connections are left to time out, instead of being properly closed (I tested this using the existing SSE tests in http4k).
* It's another servlet, which makes it cumbersome to mount to the server when we already convert HttpHandler to a servlet - we need to wrap both in another servlet that directs requests to the correct servlet depending on the content type and method used. Not very elegant.
* It's yet another dependency we need to add to `http4k-server-jetty`, just for one servlet.

Source code: https://github.com/eclipse/jetty.project/blob/jetty-11.0.13/jetty-servlets/src/main/java/org/eclipse/jetty/servlets/EventSourceServlet.java

# Solution

What I've done is taking the good bits from the `jetty-servlets` code, namely the implementation of the Event Stream protocol and heart beats, and created a custom jetty HandlerWrapper that is inserted in the handler chain, just like we do for WsHandler. I've also addressed the short-comings listed above (implement Retry, close connections on server shutdown). Everything is tested as would be expected.