### PR TITLE
Added methods for copying `ContractRoute` with new fields.

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
@@ -80,7 +80,7 @@ class ContractRoute internal constructor(val method: Method,
 
     fun meta(meta: RouteMeta) = ContractRoute(method, spec, meta, toHandler)
     fun method(method: Method) = ContractRoute(method, spec, meta, toHandler)
-    fun method(spec: ContractRouteSpec) = ContractRoute(method, spec, meta, toHandler)
+    fun spec(spec: ContractRouteSpec) = ContractRoute(method, spec, meta, toHandler)
 }
 
 internal class ExtractedParts(private val mapping: Map<PathLens<*>, *>) {

--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ContractRoute.kt
@@ -77,6 +77,10 @@ class ContractRoute internal constructor(val method: Method,
     }
 
     override fun toString() = "${method.name}: ${spec.describe(Root)}"
+
+    fun meta(meta: RouteMeta) = ContractRoute(method, spec, meta, toHandler)
+    fun method(method: Method) = ContractRoute(method, spec, meta, toHandler)
+    fun method(spec: ContractRouteSpec) = ContractRoute(method, spec, meta, toHandler)
 }
 
 internal class ExtractedParts(private val mapping: Map<PathLens<*>, *>) {


### PR DESCRIPTION
Not sure if this exposes too much internal API - but I have what I think is a valid use case for this.

Each one of the handlers for my app is injected into a main class that creates the `contract`. I have a global security policy that I used - but I'd like the rendered schema to have this global security policy applied to each route for better client auto generation. So I need a way to "edit" (immutably of course) a `ContractRoute` such that I can add the Security to the individual routes `meta` before I add them to the final contract.