### PR TITLE
HTTP Message Parser fixes

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/parser.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/parser.kt
@@ -4,7 +4,7 @@ fun Request.Companion.parse(request: String, lineBreak: String = "\r\n"): Reques
     val lines = lines(request, lineBreak)
     val (method, uri) = parseRequestLine(lines[0])
     val headers = parseHeaders(headerLines(lines))
-    val body = parseBody(bodyLines(lines))
+    val body = parseBody(bodyLines(lines), lineBreak)
     return headers.fold(Request(method, uri).body(body)
     ) { memo, (first, second) -> memo.header(first, second) }
 }
@@ -13,7 +13,7 @@ fun Response.Companion.parse(response: String, lineBreak: String = "\r\n"): Resp
     val lines = lines(response, lineBreak)
     val status = parseStatus(lines[0])
     val headers = parseHeaders(headerLines(lines))
-    val body = parseBody(bodyLines(lines))
+    val body = parseBody(bodyLines(lines), lineBreak)
     return headers.fold(Response(status).body(body)) { memo, (first, second) -> memo.header(first, second) }
 }
 
@@ -28,7 +28,7 @@ private fun parseStatus(value: String): Status {
     return Status(code, values.getOrElse(2) { "" })
 }
 
-private fun parseBody(bodyLines: List<String>): Body = Body(bodyLines.joinToString(""))
+private fun parseBody(bodyLines: List<String>, lineBreak: String): Body = Body(bodyLines.joinToString(lineBreak))
 
 private fun bodyLines(lines: List<String>): List<String> = lines.subList(lines.indexOf("") + 1, lines.size)
 

--- a/http4k-core/src/main/kotlin/org/http4k/core/parser.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/parser.kt
@@ -34,7 +34,7 @@ private fun bodyLines(lines: List<String>): List<String> = lines.subList(lines.i
 
 private fun parseHeaders(headerLines: List<String>): Parameters = headerLines.map(::parseHeader)
 
-private fun parseHeader(line: String) = line.split(": ").let { it[0] to it[1] }
+private fun parseHeader(line: String) = line.split(":").let { it[0] to it[1].trimStart() }
 
 private fun headerLines(lines: List<String>) = lines.subList(1, lines.indexOf(""))
 

--- a/http4k-core/src/test/kotlin/org/http4k/core/HttpMessageAsStringTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/HttpMessageAsStringTest.kt
@@ -41,11 +41,12 @@ foo:one
 bar: two
 baz:  three
 
-body""".toPayload()), equalTo(Request(GET, Uri.of("http://www.somewhere.com/path"))
+body1
+body2""".toPayload()), equalTo(Request(GET, Uri.of("http://www.somewhere.com/path"))
             .header("foo", "one")
             .header("bar", "two")
             .header("baz", "three")
-            .body(Body("body"))
+            .body(Body("body1\r\nbody2"))
         ))
     }
 
@@ -57,11 +58,12 @@ foo:one
 bar: two
 baz:  three
 
-body""".toPayload()), equalTo(Response(OK)
+body1
+body2""".toPayload()), equalTo(Response(OK)
             .header("foo", "one")
             .header("bar", "two")
             .header("baz", "three")
-            .body("body")
+            .body("body1\r\nbody2")
         ))
     }
 

--- a/http4k-core/src/test/kotlin/org/http4k/core/HttpMessageAsStringTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/HttpMessageAsStringTest.kt
@@ -37,11 +37,15 @@ class HttpMessageAsStringTest {
     @Test
     fun `parses request string`() {
         assertThat(Request.parse("""GET http://www.somewhere.com/path HTTP/1.1
-foo: one
+foo:one
 bar: two
+baz:  three
 
 body""".toPayload()), equalTo(Request(GET, Uri.of("http://www.somewhere.com/path"))
-            .header("foo", "one").header("bar", "two").body(Body("body"))
+            .header("foo", "one")
+            .header("bar", "two")
+            .header("baz", "three")
+            .body(Body("body"))
         ))
     }
 
@@ -49,11 +53,15 @@ body""".toPayload()), equalTo(Request(GET, Uri.of("http://www.somewhere.com/path
     fun `parses response string`() {
         assertThat(Response.parse("""
 HTTP/1.1 200 OK
-foo: one
+foo:one
 bar: two
+baz:  three
 
 body""".toPayload()), equalTo(Response(OK)
-            .header("foo", "one").header("bar", "two").body("body")
+            .header("foo", "one")
+            .header("bar", "two")
+            .header("baz", "three")
+            .body("body")
         ))
     }
 


### PR DESCRIPTION
I've discovered 2 issues preventing me from accurately parsing messages as they are received.

**Header values with optional leading whitespace**
The MDN specification implies that leading whitespace for header values is optional.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers

**Body line-breaks not being preserved**