### PR TITLE
standardize behaviour of json text method

### DIFF
--- a/http4k-format/argo/src/main/kotlin/org/http4k/format/Argo.kt
+++ b/http4k-format/argo/src/main/kotlin/org/http4k/format/Argo.kt
@@ -69,7 +69,15 @@ object Argo : Json<JsonNode> {
         if (typeOf(node) != Object) emptyList() else node.fieldList.map { it.name.text to it.value }
 
     override fun elements(value: JsonNode): Iterable<JsonNode> = value.elements
-    override fun text(value: JsonNode): String = value.text
+    override fun text(value: JsonNode): String = when(value.type) {
+        STRING -> value.text
+        NUMBER -> value.getNumberValue().toString()
+        ARRAY -> ""
+        OBJECT -> ""
+        null, NULL -> "null"
+        TRUE -> "true"
+        FALSE -> "false"
+    }
     override fun bool(value: JsonNode): Boolean = value.getBooleanValue()
     override fun integer(value: JsonNode) = value.getNumberValue().toLong()
     override fun decimal(value: JsonNode) = value.getNumberValue().toBigDecimal()

--- a/http4k-format/core/src/test/kotlin/org/http4k/format/JsonContract.kt
+++ b/http4k-format/core/src/test/kotlin/org/http4k/format/JsonContract.kt
@@ -3,6 +3,7 @@ package org.http4k.format
 import com.natpryce.hamkrest.anything
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.present
 import com.natpryce.hamkrest.throws
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
@@ -89,6 +90,20 @@ abstract class JsonContract<NODE>(open val j: Json<NODE>) {
             assertThat(integer(number(1)), equalTo(1L))
             assertThat(decimal(number(BigDecimal("1.0567"))), equalTo(BigDecimal("1.0567")))
             assertThat(bool(boolean(true)), equalTo(true))
+        }
+    }
+
+    @Test
+    fun `get text for all primitive types`() {
+        j {
+            assertThat(text(string("1.0")), equalTo("1.0"))
+            assertThat(text(number(1)), equalTo("1"))
+            assertThat(text(number(1L)), equalTo("1"))
+            assertThat(text(number(1.1)), present()) // won't depend on platform differences
+            assertThat(text(number(BigInteger("1"))), equalTo("1"))
+            assertThat(text(number(BigDecimal("1.1"))), equalTo("1.1"))
+            assertThat(text(boolean(false)), equalTo("false"))
+            assertThat(text(nullNode()), equalTo("null"))
         }
     }
 

--- a/http4k-format/gson/src/main/kotlin/org/http4k/format/ConfigurableGson.kt
+++ b/http4k-format/gson/src/main/kotlin/org/http4k/format/ConfigurableGson.kt
@@ -78,7 +78,7 @@ open class ConfigurableGson(builder: GsonBuilder,
         }
 
     override fun elements(value: JsonElement): Iterable<JsonElement> = value.asJsonArray
-    override fun text(value: JsonElement): String = value.asString
+    override fun text(value: JsonElement): String = if (value is JsonNull) "null" else value.asString
     override fun bool(value: JsonElement): Boolean = value.asBoolean
     override fun integer(value: JsonElement) = value.asLong
     override fun decimal(value: JsonElement): BigDecimal = value.asBigDecimal

--- a/http4k-format/moshi/src/main/kotlin/org/http4k/format/ConfigurableMoshi.kt
+++ b/http4k-format/moshi/src/main/kotlin/org/http4k/format/ConfigurableMoshi.kt
@@ -55,7 +55,15 @@ open class ConfigurableMoshi(
     override fun decimal(value: MoshiNode) = (value as MoshiDecimal).value.toBigDecimal()
     override fun integer(value: MoshiNode) = ((value as MoshiInteger).value)
     override fun bool(value: MoshiNode) = (value as MoshiBoolean).value
-    override fun text(value: MoshiNode) = (value as MoshiString).value
+    override fun text(value: MoshiNode) = when(value) {
+        is MoshiString -> value.value
+        is MoshiBoolean -> value.value.toString()
+        is MoshiInteger -> value.value.toString()
+        is MoshiDecimal -> value.value.toString()
+        is MoshiArray -> ""
+        is MoshiObject -> ""
+        MoshiNull -> "null"
+    }
     override fun elements(value: MoshiNode) = (value as MoshiArray).elements
     override fun fields(node: MoshiNode) = (node as? MoshiObject)
         ?.attributes


### PR DESCRIPTION
OpenApi generation currently relies on the `Json.text(value: NODE): String` method to produce something usable for all primitive `NODE` types.  Not all of the `Json` implementations support this, so this new test and associated fixes will standardize the expected behaviour; baselined by Jackson's capabilities.