### PR TITLE
Standardize AutoMarshalling roundtrip of arbitrary collections

### DIFF
--- a/http4k-format/core/src/test/kotlin/org/http4k/format/AutoMarshallingContract.kt
+++ b/http4k-format/core/src/test/kotlin/org/http4k/format/AutoMarshallingContract.kt
@@ -80,7 +80,8 @@ abstract class AutoMarshallingContract(private val marshaller: AutoMarshalling) 
     protected abstract val expectedAutoMarshallingResultPrimitives: String
     protected abstract val expectedWrappedMap: String
     protected abstract val expectedMap: String
-    protected abstract val expectedArray: String
+    protected abstract val expectedArbitraryMap: String
+    protected abstract val expectedAbitraryArray: String
     protected abstract val expectedConvertToInputStream: String
     protected abstract val expectedThrowable: String
     protected abstract val inputUnknownValue: String
@@ -158,10 +159,30 @@ abstract class AutoMarshallingContract(private val marshaller: AutoMarshalling) 
     }
 
     @Test
-    open fun `roundtrip array of string`() {
-        val wrapper = listOf("foo", "bar", "baz")
+    open fun `roundtrip arbitrary map`() {
+        val wrapper = mapOf(
+            "str" to "val1",
+            "num" to 123.1,
+            "array" to listOf(1.1,"stuff"),
+            "map" to mapOf("foo" to "bar"),
+            "bool" to true
+        )
         val asString = marshaller.asFormatString(wrapper)
-        assertThat(asString.normaliseJson(), equalTo(expectedArray.normaliseJson()))
+        assertThat(asString.normaliseJson(), equalTo(expectedArbitraryMap))
+        assertThat(marshaller.asA(asString), equalTo(wrapper))
+    }
+
+    @Test
+    open fun `roundtrip arbitrary array`() {
+        val wrapper = listOf(
+            "foo",
+            123.1,
+            mapOf("foo" to "bar"),
+            listOf(1.1,2.1),
+            true
+        )
+        val asString = marshaller.asFormatString(wrapper)
+        assertThat(asString.normaliseJson(), equalTo(expectedAbitraryArray.normaliseJson()))
         assertThat(marshaller.asA(asString), equalTo(wrapper))
     }
 

--- a/http4k-format/core/src/test/kotlin/org/http4k/format/AutoMarshallingContract.kt
+++ b/http4k-format/core/src/test/kotlin/org/http4k/format/AutoMarshallingContract.kt
@@ -80,6 +80,7 @@ abstract class AutoMarshallingContract(private val marshaller: AutoMarshalling) 
     protected abstract val expectedAutoMarshallingResultPrimitives: String
     protected abstract val expectedWrappedMap: String
     protected abstract val expectedMap: String
+    protected abstract val expectedArray: String
     protected abstract val expectedConvertToInputStream: String
     protected abstract val expectedThrowable: String
     protected abstract val inputUnknownValue: String
@@ -153,6 +154,14 @@ abstract class AutoMarshallingContract(private val marshaller: AutoMarshalling) 
         val wrapper = mapOf("key" to "value", "key2" to "123")
         val asString = marshaller.asFormatString(wrapper)
         assertThat(asString.normaliseJson(), equalTo(expectedMap))
+        assertThat(marshaller.asA(asString), equalTo(wrapper))
+    }
+
+    @Test
+    open fun `roundtrip array of string`() {
+        val wrapper = listOf("foo", "bar", "baz")
+        val asString = marshaller.asFormatString(wrapper)
+        assertThat(asString.normaliseJson(), equalTo(expectedArray.normaliseJson()))
         assertThat(marshaller.asA(asString), equalTo(wrapper))
     }
 

--- a/http4k-format/core/src/test/kotlin/org/http4k/format/AutoMarshallingJsonContract.kt
+++ b/http4k-format/core/src/test/kotlin/org/http4k/format/AutoMarshallingJsonContract.kt
@@ -19,7 +19,8 @@ abstract class AutoMarshallingJsonContract(marshaller: AutoMarshalling) : AutoMa
     val expectedCustomWrappedNumber = """{"value":"1.01"}"""
     val expectedInOutOnly = """{"value":"foobar"}"""
     override val expectedMap = """{"key":"value","key2":"123"}"""
-    override val expectedArray = """["foo","bar","baz"]"""
+    override val expectedAbitraryArray = """["foo",123.1,{"foo":"bar"},[1.1,2.1],true]"""
+    override val expectedArbitraryMap = """{"str":"val1","num":123.1,"array":[1.1,"stuff"],"map":{"foo":"bar"},"bool":true}"""
 
     @Test
     open fun `out only string`() {

--- a/http4k-format/core/src/test/kotlin/org/http4k/format/AutoMarshallingJsonContract.kt
+++ b/http4k-format/core/src/test/kotlin/org/http4k/format/AutoMarshallingJsonContract.kt
@@ -19,6 +19,7 @@ abstract class AutoMarshallingJsonContract(marshaller: AutoMarshalling) : AutoMa
     val expectedCustomWrappedNumber = """{"value":"1.01"}"""
     val expectedInOutOnly = """{"value":"foobar"}"""
     override val expectedMap = """{"key":"value","key2":"123"}"""
+    override val expectedArray = """["foo","bar","baz"]"""
 
     @Test
     open fun `out only string`() {

--- a/http4k-format/jackson-yaml/src/test/kotlin/org/http4k/format/jacksonYamlTests.kt
+++ b/http4k-format/jackson-yaml/src/test/kotlin/org/http4k/format/jacksonYamlTests.kt
@@ -130,6 +130,8 @@ unknown: "2000-01-01"
 key2:"123"
 """
 
+    override val expectedArray = """foo,bar,baz"""
+
     override val expectedAutoMarshallingZonesAndLocale = "zoneId:\"America/Toronto\"\nzoneOffset:\"-04:00\"\nlocale:\"en-CA\"\n"
 
 

--- a/http4k-format/jackson/src/test/kotlin/org/http4k/format/jacksonJsonTests.kt
+++ b/http4k-format/jackson/src/test/kotlin/org/http4k/format/jacksonJsonTests.kt
@@ -15,6 +15,7 @@ import org.http4k.format.Jackson.autoView
 import org.http4k.hamkrest.hasBody
 import org.http4k.websocket.WsMessage
 import org.junit.jupiter.api.Test
+import java.math.BigDecimal
 
 class JacksonAutoTest : AutoMarshallingJsonContract(Jackson) {
 
@@ -137,6 +138,34 @@ class JacksonAutoTest : AutoMarshallingJsonContract(Jackson) {
         val list = listOf(FirstChild("hello"), SecondChild("world"))
 
         assertThat(body(Response(OK).with(body of list)), equalTo(list))
+    }
+
+    @Test
+    override fun `roundtrip arbitrary map`() {
+        val wrapper = mapOf(
+            "str" to "val1",
+            "num" to BigDecimal("123.1"),
+            "array" to listOf(BigDecimal("1.1"),"stuff"),
+            "map" to mapOf("foo" to "bar"),
+            "bool" to true
+        )
+        val asString = Jackson.asFormatString(wrapper)
+        assertThat(asString.normaliseJson(), equalTo(expectedArbitraryMap))
+        assertThat(Jackson.asA(asString), equalTo(wrapper))
+    }
+
+    @Test
+    override fun `roundtrip arbitrary array`() {
+        val wrapper = listOf(
+            "foo",
+            BigDecimal("123.1"),
+            mapOf("foo" to "bar"),
+            listOf(BigDecimal("1.1"),BigDecimal("2.1")),
+            true
+        )
+        val asString = Jackson.asFormatString(wrapper)
+        assertThat(asString.normaliseJson(), equalTo(expectedAbitraryArray.normaliseJson()))
+        assertThat(Jackson.asA(asString), equalTo(wrapper))
     }
 }
 

--- a/http4k-format/klaxon/src/test/kotlin/org/http4k/format/klaxonJsonTests.kt
+++ b/http4k-format/klaxon/src/test/kotlin/org/http4k/format/klaxonJsonTests.kt
@@ -63,6 +63,14 @@ class KlaxonAutoTest : AutoMarshallingJsonContract(Klaxon) {
     @Disabled("not supported by Klaxon")
     override fun `roundtrip custom boolean`() {
     }
+
+    @Disabled("not supported by Klaxon")
+    override fun `roundtrip arbitrary map`() {
+    }
+
+    @Disabled("not supported by Klaxon")
+    override fun `roundtrip arbitrary array`() {
+    }
 }
 
 class KlaxonAutoEventsTest : AutoMarshallingEventsContract(Klaxon)

--- a/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/ConfigurableKotlinxSerialization.kt
+++ b/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/ConfigurableKotlinxSerialization.kt
@@ -150,7 +150,7 @@ open class ConfigurableKotlinxSerialization(
         }
     }
 
-    override fun <T : Any> asA(input: String, target: KClass<T>): T =  json.parseToJsonElement(input).asA(target)
+    override fun <T : Any> asA(input: String, target: KClass<T>): T = json.parseToJsonElement(input).asA(target)
 
     override fun <T : Any> asA(input: InputStream, target: KClass<T>): T = asA(input.reader().readText(), target)
 

--- a/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/ConfigurableKotlinxSerialization.kt
+++ b/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/ConfigurableKotlinxSerialization.kt
@@ -124,7 +124,8 @@ open class ConfigurableKotlinxSerialization(
                 (it.key as? String ?: return@mapNotNull null) to (it.value?.asJsonObject() ?: nullNode())
             }.toMap(),
         )
-        is Collection<*> -> JsonArray(input.map { it?.asJsonObject() ?: nullNode() })
+        is Iterable<*> -> JsonArray(input.map { it?.asJsonObject() ?: nullNode() })
+        is Array<*> -> JsonArray(input.map { it?.asJsonObject() ?: nullNode() })
         else -> json.encodeToJsonElement(json.serializersModule.serializer(input::class.java), input)
     }
 

--- a/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/ConfigurableKotlinxSerialization.kt
+++ b/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/ConfigurableKotlinxSerialization.kt
@@ -118,15 +118,38 @@ open class ConfigurableKotlinxSerialization(
     }
 
     // auto
-    override fun asJsonObject(input: Any): JsonElement =
-        json.encodeToJsonElement(json.serializersModule.serializer(input::class.java), input)
+    override fun asJsonObject(input: Any): JsonElement = when(input) {
+        is Map<*, *> -> JsonObject(
+            input.mapNotNull {
+                (it.key as? String ?: return@mapNotNull null) to (it.value?.asJsonObject() ?: nullNode())
+            }.toMap(),
+        )
+        is Collection<*> -> JsonArray(input.map { it?.asJsonObject() ?: nullNode() })
+        else -> json.encodeToJsonElement(json.serializersModule.serializer(input::class.java), input)
+    }
+
+    private fun JsonElement.toPrimitive(): Any? {
+        return when(this) {
+            is JsonPrimitive -> content
+                .takeIf { isString }
+                ?: content.toBooleanStrictOrNull()
+                ?: content.toBigDecimalOrNull()
+            is JsonArray -> map { it.toPrimitive() }
+            is JsonObject -> map { it.key to it.value.toPrimitive() }.toMap()
+        }
+    }
 
     override fun <T : Any> asA(j: JsonElement, target: KClass<T>): T {
         @Suppress("UNCHECKED_CAST")
-        return json.decodeFromJsonElement(json.serializersModule.serializer(target.java), j) as T
+        return when {
+            Map::class.java.isAssignableFrom(target.java) -> j.toPrimitive() as T
+            Collection::class.java.isAssignableFrom(target.java) -> j.toPrimitive() as T
+            Array::class.java.isAssignableFrom(target.java) -> j.toPrimitive() as T
+            else -> json.decodeFromJsonElement(json.serializersModule.serializer(target.java), j) as T
+        }
     }
 
-    override fun <T : Any> asA(input: String, target: KClass<T>): T = json.parseToJsonElement(input).asA(target)
+    override fun <T : Any> asA(input: String, target: KClass<T>): T =  json.parseToJsonElement(input).asA(target)
 
     override fun <T : Any> asA(input: InputStream, target: KClass<T>): T = asA(input.reader().readText(), target)
 

--- a/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/KotlinxSerialization.kt
+++ b/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/KotlinxSerialization.kt
@@ -1,10 +1,13 @@
 package org.http4k.format
 
+import org.http4k.format.KotlinxSerialization.asJsonObject
+
 /**
  * To implement custom JSON configuration, create your own object singleton extending
  * ConfigurableKotlinxSerialization, passing in the JSON configuration block
  */
 object KotlinxSerialization : ConfigurableKotlinxSerialization({
     ignoreUnknownKeys = true
-    asConfigurable().withStandardMappings().done()
+    asConfigurable().withStandardMappings()
+        .done()
 })

--- a/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/KotlinxSerialization.kt
+++ b/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/KotlinxSerialization.kt
@@ -1,13 +1,10 @@
 package org.http4k.format
 
-import org.http4k.format.KotlinxSerialization.asJsonObject
-
 /**
  * To implement custom JSON configuration, create your own object singleton extending
  * ConfigurableKotlinxSerialization, passing in the JSON configuration block
  */
 object KotlinxSerialization : ConfigurableKotlinxSerialization({
     ignoreUnknownKeys = true
-    asConfigurable().withStandardMappings()
-        .done()
+    asConfigurable().withStandardMappings().done()
 })

--- a/http4k-format/kotlinx-serialization/src/test/kotlin/org/http4k/format/KotlinxSerializationAutoTest.kt
+++ b/http4k-format/kotlinx-serialization/src/test/kotlin/org/http4k/format/KotlinxSerializationAutoTest.kt
@@ -181,11 +181,6 @@ class KotlinxSerializationAutoTest : AutoMarshallingJsonContract(KotlinxSerializ
     }
 
     @Test
-    @Disabled("kotlinx.serialization does not support default serialization of LinkedHashMap")
-    override fun `roundtrip map`() {
-    }
-
-    @Test
     override fun `fails decoding when a required value is null`() {
         assertThat({ KotlinxSerialization.asA(inputEmptyObject, ArbObject::class) }, throws<Exception>())
     }
@@ -331,4 +326,9 @@ class KotlinxSerializationAutoTest : AutoMarshallingJsonContract(KotlinxSerializ
             .text(StringBiDiMappings.bigDecimal().map(::MappedBigDecimalHolder, MappedBigDecimalHolder::value))
             .done()
     }) {}
+
+    @Test
+    override fun `roundtrip array of string`() {
+        super.`roundtrip array of string`()
+    }
 }

--- a/http4k-format/kotlinx-serialization/src/test/kotlin/org/http4k/format/KotlinxSerializationAutoTest.kt
+++ b/http4k-format/kotlinx-serialization/src/test/kotlin/org/http4k/format/KotlinxSerializationAutoTest.kt
@@ -283,6 +283,32 @@ class KotlinxSerializationAutoTest : AutoMarshallingJsonContract(KotlinxSerializ
         assertThat(KotlinxSerialization.asA(out, ZonesAndLocale::class), equalTo(obj))
     }
 
+    override fun `roundtrip arbitrary map`() {
+        val wrapper = mapOf(
+            "str" to "val1",
+            "num" to BigDecimal("123.1"),
+            "array" to listOf(BigDecimal("1.1"),"stuff"),
+            "map" to mapOf("foo" to "bar"),
+            "bool" to true
+        )
+        val asString = KotlinxSerialization.asFormatString(wrapper)
+        assertThat(asString.normaliseJson(), equalTo(expectedArbitraryMap))
+        assertThat(KotlinxSerialization.asA(asString), equalTo(wrapper))
+    }
+
+    override fun `roundtrip arbitrary array`() {
+        val wrapper = listOf(
+            "foo",
+            BigDecimal("123.1"),
+            mapOf("foo" to "bar"),
+            listOf(BigDecimal("1.1"),BigDecimal("2.1")),
+            true
+        )
+        val asString = KotlinxSerialization.asFormatString(wrapper)
+        assertThat(asString.normaliseJson(), equalTo(expectedAbitraryArray.normaliseJson()))
+        assertThat(KotlinxSerialization.asA(asString), equalTo(wrapper))
+    }
+
     override fun strictMarshaller() = KotlinxSerialization
 
     override fun customMarshaller(): AutoMarshalling =
@@ -326,9 +352,4 @@ class KotlinxSerializationAutoTest : AutoMarshallingJsonContract(KotlinxSerializ
             .text(StringBiDiMappings.bigDecimal().map(::MappedBigDecimalHolder, MappedBigDecimalHolder::value))
             .done()
     }) {}
-
-    @Test
-    override fun `roundtrip array of string`() {
-        super.`roundtrip array of string`()
-    }
 }

--- a/http4k-format/moshi-yaml/src/main/kotlin/org/http4k/format/ConfigurableMoshiYaml.kt
+++ b/http4k-format/moshi-yaml/src/main/kotlin/org/http4k/format/ConfigurableMoshiYaml.kt
@@ -40,10 +40,14 @@ open class ConfigurableMoshiYaml(
         val str = json.asFormatString(input)
         val yaml = yaml()
 
-        return try {
-            yaml.dump(json.asA<Map<String, Any>>(str))
-        } catch (e: Exception) {
-            yaml.dump(str)
+        return when(input) {
+            is Iterable<*> -> yaml.dump(json.asA<List<Any>>(str))
+            is Array<*> -> yaml.dump(json.asA<Array<Any>>(str))
+            else -> try {
+                yaml.dump(json.asA<Map<String, Any>>(str))
+            } catch (e: Exception) {
+                yaml.dump(str)
+            }
         }
     }
 

--- a/http4k-format/moshi-yaml/src/test/kotlin/org/http4k/format/moshiYamlTests.kt
+++ b/http4k-format/moshi-yaml/src/test/kotlin/org/http4k/format/moshiYamlTests.kt
@@ -136,4 +136,5 @@ bool:true
         val wrapper = mapOf("on" to "hello")
         assertThat(MoshiYaml.asFormatString(wrapper), equalTo("on: hello\n"))
     }
+
 }

--- a/http4k-format/moshi-yaml/src/test/kotlin/org/http4k/format/moshiYamlTests.kt
+++ b/http4k-format/moshi-yaml/src/test/kotlin/org/http4k/format/moshiYamlTests.kt
@@ -46,7 +46,23 @@ unknown: "2000-01-01"
     override val expectedMap = "key:value\n" +
         "key2:'123'\n"
 
-    override val expectedArray = "[\"foo\",\"bar\",\"baz\"]\n"
+    override val expectedAbitraryArray = """- foo
+- 123.1
+- foo:bar
+- - 1.1
+  - 2.1
+- true
+"""
+
+    override val expectedArbitraryMap = """str:val1
+num:123.1
+array:
+- 1.1
+- stuff
+map:
+  foo:bar
+bool:true
+"""
 
     override val expectedAutoMarshallingZonesAndLocale = "zoneId:America/Toronto\nzoneOffset:-04:00\nlocale:en-CA\n"
 
@@ -120,5 +136,4 @@ unknown: "2000-01-01"
         val wrapper = mapOf("on" to "hello")
         assertThat(MoshiYaml.asFormatString(wrapper), equalTo("on: hello\n"))
     }
-
 }

--- a/http4k-format/moshi-yaml/src/test/kotlin/org/http4k/format/moshiYamlTests.kt
+++ b/http4k-format/moshi-yaml/src/test/kotlin/org/http4k/format/moshiYamlTests.kt
@@ -46,6 +46,8 @@ unknown: "2000-01-01"
     override val expectedMap = "key:value\n" +
         "key2:'123'\n"
 
+    override val expectedArray = "[\"foo\",\"bar\",\"baz\"]\n"
+
     override val expectedAutoMarshallingZonesAndLocale = "zoneId:America/Toronto\nzoneOffset:-04:00\nlocale:en-CA\n"
 
     override fun strictMarshaller() = object : ConfigurableMoshiYaml(


### PR DESCRIPTION
This might be enough to use `KotlinxSerialization` with an `OpenApi3Renderer`. 

I wasn't bothered enough to make it work for klaxon 🤷 