### PR TITLE
Misc SwaggerUI updates

### DIFF
--- a/http4k-contract/src/main/kotlin/org/http4k/contract/ui/SwaggerUi.kt
+++ b/http4k-contract/src/main/kotlin/org/http4k/contract/ui/SwaggerUi.kt
@@ -20,6 +20,8 @@ fun swaggerUi(
     displayRequestDuration: Boolean = false,
     requestSnippetsEnabled: Boolean = false,
     persistAuthorization: Boolean = false,
+    queryConfigEnabled: Boolean = false,
+    tryItOutEnabled: Boolean = false
 ): RoutingHttpHandler = Filter { next ->
     { req ->
         next(req).let { resp ->
@@ -31,6 +33,8 @@ fun swaggerUi(
                     .replace("%%DISPLAY_REQUEST_DURATION%%", displayRequestDuration.toString())
                     .replace("%%REQUEST_SNIPPETS_ENABLED%%", requestSnippetsEnabled.toString())
                     .replace("%%PERSIST_AUTHORIZATION%%", persistAuthorization.toString())
+                    .replace("%%QUERY_CONFIG_ENABLED%%", queryConfigEnabled.toString())
+                    .replace("%%TRY_IT_OUT_ENABLED%%", tryItOutEnabled.toString())
             ).with(Header.CONTENT_TYPE of ContentType.TEXT_HTML)
         }
     }

--- a/http4k-contract/src/main/resources/org/http4k/contract/ui/public/index.html
+++ b/http4k-contract/src/main/resources/org/http4k/contract/ui/public/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
-  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-standalone-preset.js"></script>
-  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-bundle.js"></script>
-  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui.css"/>
+  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-standalone-preset.js" integrity="sha512-V5Zdt9ZPs6AWG/eQJp9a27pWGO8iBITXxdCD6/VNbO+XdHD8QnhsifVaUKeAkoYumdQZOFy45hPPLZ5aRolGxQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-bundle.js" integrity="sha512-whrtfCIKZ9bFzCoZZFnXQQ6Ms57iASQZhTuI4NMqYFbiWO9PgPA5nBn+oRsl2O5QQYhV0MQ0DQZ9N6Vdk32eFA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui.css" integrity="sha512-soocIs4NXAlVsRdy2Bwp8AtevQNkOtLG3tvP7mfhGhCWXKvNoUvW5zgmMZB75JYk3jgGHM71bPoMjhfOr8IPCg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <title>%%PAGE_TITLE%%</title>
 </head>
 <body>

--- a/http4k-contract/src/main/resources/org/http4k/contract/ui/public/index.html
+++ b/http4k-contract/src/main/resources/org/http4k/contract/ui/public/index.html
@@ -25,7 +25,9 @@
             SwaggerUIBundle.presets.apis,
             SwaggerUIStandalonePreset
           ],
-          layout: "StandaloneLayout"
+          layout: "StandaloneLayout",
+          queryConfigEnabled: %%QUERY_CONFIG_ENABLED%%,
+          tryItOutEnabled: %%TRY_IT_OUT_ENABLED%%
         })
       }
 

--- a/http4k-contract/src/main/resources/org/http4k/contract/ui/public/index.html
+++ b/http4k-contract/src/main/resources/org/http4k/contract/ui/public/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
-  <script src="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-standalone-preset.js"></script>
-  <script src="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-bundle.js"></script>
-  <link rel="stylesheet" href="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui.css"/>
+  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-standalone-preset.js"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-bundle.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui.css"/>
   <title>%%PAGE_TITLE%%</title>
 </head>
 <body>

--- a/http4k-contract/src/main/resources/org/http4k/contract/ui/public/index.html
+++ b/http4k-contract/src/main/resources/org/http4k/contract/ui/public/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
-  <script src="//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-standalone-preset.js"></script>
-  <script src="//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-bundle.js"></script>
-  <link rel="stylesheet" href="//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui.css"/>
+  <script src="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-standalone-preset.js"></script>
+  <script src="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-bundle.js"></script>
+  <link rel="stylesheet" href="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui.css"/>
   <title>%%PAGE_TITLE%%</title>
 </head>
 <body>

--- a/http4k-contract/src/test/resources/org/http4k/contract/ui/SwaggerUiTest.can serve swagger ui.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/ui/SwaggerUiTest.can serve swagger ui.approved
@@ -4,9 +4,9 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
-  <script src="//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-standalone-preset.js"></script>
-  <script src="//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui-bundle.js"></script>
-  <link rel="stylesheet" href="//unpkg.com/swagger-ui-dist@4.15.5/swagger-ui.css"/>
+  <script src="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-standalone-preset.js"></script>
+  <script src="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-bundle.js"></script>
+  <link rel="stylesheet" href="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui.css"/>
   <title>Cat Shelter</title>
 </head>
 <body>

--- a/http4k-contract/src/test/resources/org/http4k/contract/ui/SwaggerUiTest.can serve swagger ui.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/ui/SwaggerUiTest.can serve swagger ui.approved
@@ -25,7 +25,9 @@
             SwaggerUIBundle.presets.apis,
             SwaggerUIStandalonePreset
           ],
-          layout: "StandaloneLayout"
+          layout: "StandaloneLayout",
+          queryConfigEnabled: false,
+          tryItOutEnabled: false
         })
       }
 

--- a/http4k-contract/src/test/resources/org/http4k/contract/ui/SwaggerUiTest.can serve swagger ui.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/ui/SwaggerUiTest.can serve swagger ui.approved
@@ -4,9 +4,9 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
-  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-standalone-preset.js"></script>
-  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-bundle.js"></script>
-  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui.css"/>
+  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-standalone-preset.js" integrity="sha512-V5Zdt9ZPs6AWG/eQJp9a27pWGO8iBITXxdCD6/VNbO+XdHD8QnhsifVaUKeAkoYumdQZOFy45hPPLZ5aRolGxQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-bundle.js" integrity="sha512-whrtfCIKZ9bFzCoZZFnXQQ6Ms57iASQZhTuI4NMqYFbiWO9PgPA5nBn+oRsl2O5QQYhV0MQ0DQZ9N6Vdk32eFA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui.css" integrity="sha512-soocIs4NXAlVsRdy2Bwp8AtevQNkOtLG3tvP7mfhGhCWXKvNoUvW5zgmMZB75JYk3jgGHM71bPoMjhfOr8IPCg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
   <title>Cat Shelter</title>
 </head>
 <body>

--- a/http4k-contract/src/test/resources/org/http4k/contract/ui/SwaggerUiTest.can serve swagger ui.approved
+++ b/http4k-contract/src/test/resources/org/http4k/contract/ui/SwaggerUiTest.can serve swagger ui.approved
@@ -4,9 +4,9 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <meta http-equiv="X-UA-Compatible" content="ie=edge"/>
-  <script src="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-standalone-preset.js"></script>
-  <script src="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-bundle.js"></script>
-  <link rel="stylesheet" href="//unpkg.com/swagger-ui-dist@4.17.0/swagger-ui.css"/>
+  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-standalone-preset.js"></script>
+  <script src="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui-bundle.js"></script>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@4.17.0/swagger-ui.css"/>
   <title>Cat Shelter</title>
 </head>
 <body>

--- a/http4k-graphql/src/main/resources/org/http4k/routing/public/index.html
+++ b/http4k-graphql/src/main/resources/org/http4k/routing/public/index.html
@@ -6,9 +6,9 @@
   <meta name="viewport"
         content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui"/>
   <title>%%TITLE%%</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" integrity="sha512-G0MeOmUp9cjHRfFbOhGN9zRb/65HN5DV1fi1Z5rIy3YWDy5XIEQTVtDrNlA8UtXDFE7/KOE7jr9KimXPTFG6HQ==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
   <link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png"/>
-  <script src="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js" integrity="sha512-QNuOT8ABhMsC3MjG7c+Whp+HipQQKLM83lFqXg5kCzaQGf280UsPfj37FcY9YD44iaom/+OGUVO7BdqyMT362A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
 <style>
   body {

--- a/http4k-graphql/src/main/resources/org/http4k/routing/public/index.html
+++ b/http4k-graphql/src/main/resources/org/http4k/routing/public/index.html
@@ -6,9 +6,9 @@
   <meta name="viewport"
         content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui"/>
   <title>%%TITLE%%</title>
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css"/>
-  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png"/>
-  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css"/>
+  <link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png"/>
+  <script src="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
 </head>
 <style>
   body {
@@ -43,7 +43,7 @@
 </style>
 <body>
 <div id="root">
-  <img src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png" alt=""/>
+  <img src="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png" alt=""/>
   <div class="loading"> Loading
     <span class="title">GraphQL Playground</span>
   </div>

--- a/http4k-graphql/src/test/resources/org/http4k/routing/GraphQLExtensionsTest.can serve playground.approved
+++ b/http4k-graphql/src/test/resources/org/http4k/routing/GraphQLExtensionsTest.can serve playground.approved
@@ -4,9 +4,9 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui"/>
     <title>GraphQL Playground</title>
-    <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css"/>
-    <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png"/>
-    <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css"/>
+    <link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png"/>
+    <script src="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
   </head>
   <style>
   body {
@@ -41,7 +41,7 @@
 </style>
   <body>
     <div id="root">
-      <img src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png" alt=""/>
+      <img src="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png" alt=""/>
       <div class="loading"> Loading
     <span class="title">GraphQL Playground</span>
       </div>

--- a/http4k-graphql/src/test/resources/org/http4k/routing/GraphQLExtensionsTest.can serve playground.approved
+++ b/http4k-graphql/src/test/resources/org/http4k/routing/GraphQLExtensionsTest.can serve playground.approved
@@ -4,9 +4,9 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui"/>
     <title>GraphQL Playground</title>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" integrity="sha512-G0MeOmUp9cjHRfFbOhGN9zRb/65HN5DV1fi1Z5rIy3YWDy5XIEQTVtDrNlA8UtXDFE7/KOE7jr9KimXPTFG6HQ==" crossorigin="anonymous" referrerpolicy="no-referrer"/>
     <link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png"/>
-    <script src="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js" integrity="sha512-QNuOT8ABhMsC3MjG7c+Whp+HipQQKLM83lFqXg5kCzaQGf280UsPfj37FcY9YD44iaom/+OGUVO7BdqyMT362A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   </head>
   <style>
   body {


### PR DESCRIPTION
- chore(deps): upgrade `swagger-ui` from 4.15.5 to 4.17.0
- chore(deps): Use HTTPS for embedded resources where possible
- chore(deps): use [SRI](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) for `swagger-ui` & `graphql-playground-react`
- feat(swagger-ui): add options for queryConfigEnabled and tryItOutEnabled