### PR TITLE
Add swagger ui module that bundles webjar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This list is not intended to be all-encompassing - it will document major and breaking API 
 changes with their rationale when appropriate:
 
+### v4.40.3.0
+- **http4k-format-contract-ui-swagger** : [New module] Easily bundle Swagger UI with `swaggerUiWebjar`. H/T @oharaandrew314
+
 ### v4.40.2.0
 - **http4k-*** : Upgrade some dependency versions.
 - **http4k-client-apache*** : Fix #866 - ApacheClient does not handle SocketException.

--- a/http4k-contract-ui/swagger/build.gradle.kts
+++ b/http4k-contract-ui/swagger/build.gradle.kts
@@ -1,0 +1,10 @@
+description = "Add a locally hosted Swagger UI to your server"
+
+dependencies {
+    api(project(":http4k-contract"))
+    implementation("org.webjars:swagger-ui:4.18.1")
+
+    testImplementation(project(":http4k-testing-approval"))
+    testImplementation(project(path = ":http4k-core", configuration = "testArtifacts"))
+}
+

--- a/http4k-contract-ui/swagger/src/main/kotlin/org/http4k/contract/ui/swagger/swaggerUiWebjar.kt
+++ b/http4k-contract-ui/swagger/src/main/kotlin/org/http4k/contract/ui/swagger/swaggerUiWebjar.kt
@@ -1,0 +1,53 @@
+package org.http4k.contract.ui.swagger
+
+import org.http4k.core.Method
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.core.Uri
+import org.http4k.routing.ResourceLoader
+import org.http4k.routing.RoutingHttpHandler
+import org.http4k.routing.bind
+import org.http4k.routing.routes
+import org.http4k.routing.static
+import kotlin.io.path.Path
+
+fun swaggerUiWebjar(
+    descriptionRoute: Uri,
+    title: String = "Swagger UI",
+    layout: String = "BaseLayout", // also supports StandardLayout
+    deepLinking: Boolean = true,
+    displayOperationId: Boolean = false,
+    displayRequestDuration: Boolean = false,
+    requestSnippetsEnabled: Boolean = false,
+    persistAuthorization: Boolean = false,
+    queryConfigEnabled: Boolean = false,
+    tryItOutEnabled: Boolean = true,
+    webjarPath: String = "/webjars/swagger-ui/4.18.1" // override to use your own bundled distribution
+): RoutingHttpHandler {
+    val initJs = """window.onload = function() {
+    document.title = "$title";
+    SwaggerUIBundle({
+        url: "$descriptionRoute",
+        dom_id: '#swagger-ui',
+        deepLinking: $deepLinking,
+        displayOperationId: $displayOperationId,
+        displayRequestDuration: $displayRequestDuration,
+        requestSnippetsEnabled: $requestSnippetsEnabled,
+        persistAuthorization: $persistAuthorization,
+        presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIStandalonePreset
+        ],
+        layout: "$layout",
+        queryConfigEnabled: $queryConfigEnabled,
+        tryItOutEnabled: $tryItOutEnabled
+    })
+}
+"""
+    return routes(
+        "swagger-initializer.js" bind Method.GET to {
+            Response(Status.OK).body(initJs)
+        },
+        static(ResourceLoader.Classpath( "/META-INF/resources/" + webjarPath.trimStart('/')))
+    )
+}

--- a/http4k-contract-ui/swagger/src/test/kotlin/org/http4k/contract/ui/swagger/SwaggerUiWebjarTest.kt
+++ b/http4k-contract-ui/swagger/src/test/kotlin/org/http4k/contract/ui/swagger/SwaggerUiWebjarTest.kt
@@ -1,0 +1,49 @@
+package org.http4k.contract.ui.swagger
+
+import com.natpryce.hamkrest.assertion.assertThat
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.Status
+import org.http4k.core.Uri
+import org.http4k.hamkrest.hasStatus
+import org.http4k.testing.ApprovalTest
+import org.http4k.testing.Approver
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ApprovalTest::class)
+class SwaggerUiWebjarTest {
+
+    @Test
+    fun `can serve swagger ui index`(approver: Approver) {
+        val handler = swaggerUiWebjar(
+            Uri.of("/spec"),
+            title = "Cat Shelter",
+            displayOperationId = true,
+            requestSnippetsEnabled = true
+        )
+        approver.assertApproved(handler(Request(GET, "")))
+    }
+
+    @Test
+    fun `can serve custom swagger ui initializer`(approver: Approver) {
+        val handler = swaggerUiWebjar(
+            Uri.of("/spec"),
+            title = "Cat Shelter",
+            displayOperationId = true,
+            requestSnippetsEnabled = true
+        )
+        approver.assertApproved(handler(Request(GET, "swagger-initializer.js")))
+    }
+
+    @Test
+    fun `can serve swagger oauth2 redirect`() {
+        val handler = swaggerUiWebjar(
+            Uri.of("/spec"),
+            title = "Cat Shelter",
+            displayOperationId = true,
+            requestSnippetsEnabled = true
+        )
+        assertThat(handler(Request(GET, "oauth2-redirect.html")), hasStatus(Status.OK))
+    }
+}

--- a/http4k-contract-ui/swagger/src/test/resources/org/http4k/contract/ui/swagger/SwaggerUiWebjarTest.can serve custom swagger ui initializer.approved
+++ b/http4k-contract-ui/swagger/src/test/resources/org/http4k/contract/ui/swagger/SwaggerUiWebjarTest.can serve custom swagger ui initializer.approved
@@ -1,0 +1,19 @@
+window.onload = function() {
+    document.title = "Cat Shelter";
+    SwaggerUIBundle({
+        url: "/spec",
+        dom_id: '#swagger-ui',
+        deepLinking: true,
+        displayOperationId: true,
+        displayRequestDuration: false,
+        requestSnippetsEnabled: true,
+        persistAuthorization: false,
+        presets: [
+            SwaggerUIBundle.presets.apis,
+            SwaggerUIStandalonePreset
+        ],
+        layout: "BaseLayout",
+        queryConfigEnabled: false,
+        tryItOutEnabled: true
+    })
+}

--- a/http4k-contract-ui/swagger/src/test/resources/org/http4k/contract/ui/swagger/SwaggerUiWebjarTest.can serve swagger ui index.approved
+++ b/http4k-contract-ui/swagger/src/test/resources/org/http4k/contract/ui/swagger/SwaggerUiWebjarTest.can serve swagger ui index.approved
@@ -1,0 +1,19 @@
+<!-- HTML for static distribution bundle build -->
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <title>Swagger UI</title>
+    <link rel="stylesheet" type="text/css" href="./swagger-ui.css" />
+    <link rel="stylesheet" type="text/css" href="index.css" />
+    <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+    <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+  </head>
+
+  <body>
+    <div id="swagger-ui"></div>
+    <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
+    <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+    <script src="./swagger-initializer.js" charset="UTF-8"> </script>
+  </body>
+</html>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,7 +39,11 @@ include("http4k-bom")
 
 include("http4k-cloudevents")
 include("http4k-cloudnative")
+
 include("http4k-contract")
+"http4k-contract-ui".apply {
+    includeModule("swagger")
+}
 
 "http4k-format".apply {
     includeModule("core")

--- a/src/docs/guide/howto/create_a_swagger_ui/index.md
+++ b/src/docs/guide/howto/create_a_swagger_ui/index.md
@@ -1,20 +1,39 @@
 title: Swagger UI
 description: Create a Swagger UI for your REST API
 
+Http4k's contract module has a few built-in options to render a Swagger UI for your **OpenApi** v2 or v3 description.
+For more detail on generating contracts, see:
+
+- [Http4k Reference: Contracts](/guide/reference/contracts)
+- [http4k How-to: Integrate with OpenAPI](/guide/howto/integrate_with_openapi)
+
+## Thin UI
+
+Rather than host the Swagger UI assets locally, a minimal wrapper will load them from a public CDN.
+This is excellent for applications requiring a minimal footprint (such as serverless functions).
+However, you have less control over the availability and performance of the distribution.
+
 ### Installation (Gradle)
 
 ```groovy
 implementation group: "org.http4k", name: "http4k-contract", version: "4.40.2.0"
 ```
 
-### About
-Http4k's contract module has a built-in method to render a Swagger UI for your **OpenApi** v2 or v3 description.
-For more detail on generating contracts, see:
-
-- [Http4k Reference: Contracts](/guide/reference/contracts)
-- [http4k How-to: Integrate with OpenAPI](/guide/howto/integrate_with_openapi)
-
 ### Example [<img class="octocat"/>](https://github.com/http4k/http4k/blob/master/src/docs/guide/howto/create_a_swagger_ui/example.kt)
 
 <script src="https://gist-it.appspot.com/https://github.com/http4k/http4k/blob/master/src/docs/guide/howto/create_a_swagger_ui/example.kt"></script>
 
+## Bundled UI
+
+Http4k will bundle the Swagger UI distribution into your server.
+This option can be more reliable, but will contribute to a larger jar size.
+
+### Installation (Gradle)
+
+```groovy
+implementation group: "org.http4k", name: "http4k-contract-ui-swagger", version: "4.40.2.0"
+```
+
+### Example [<img class="octocat"/>](https://github.com/http4k/http4k/blob/master/src/docs/guide/howto/create_a_swagger_ui/webjarExample.kt)
+
+<script src="https://gist-it.appspot.com/https://github.com/http4k/http4k/blob/master/src/docs/guide/howto/create_a_swagger_ui/webjarExample.kt"></script>

--- a/src/docs/guide/howto/create_a_swagger_ui/webjarExample.kt
+++ b/src/docs/guide/howto/create_a_swagger_ui/webjarExample.kt
@@ -1,0 +1,30 @@
+package guide.howto.create_a_swagger_ui
+
+import org.http4k.contract.contract
+import org.http4k.contract.ui.swagger.swaggerUiWebjar
+import org.http4k.core.Uri
+import org.http4k.routing.routes
+import org.http4k.server.SunHttp
+import org.http4k.server.asServer
+
+fun main() {
+    // Define a contract, and render an OpenApi 3 spec at "/spec"
+    val api = contract {
+        // add your ContractRoutes as normal
+        descriptionPath = "spec"
+    }
+
+    // Build a Swagger UI based on the OpenApi spec defined at "/spec"
+    val ui = swaggerUiWebjar(
+        descriptionRoute = Uri.of("spec"),
+        title = "Hello Server",
+        displayOperationId = true
+    )
+
+    // Combine our api, spec, and ui; then start a server
+    // The Swagger UI is available on the root "/" path
+    routes(api, ui)
+        .asServer(SunHttp(8080))
+        .start()
+        .block()
+}


### PR DESCRIPTION
Closes #859 

I've arranged this new module in a way so that it should be easy to add a redoc module later.