### PR TITLE
Undertow server upgrades WebSocket connection when valid Connection header provided

### DIFF
--- a/http4k-server/undertow/build.gradle.kts
+++ b/http4k-server/undertow/build.gradle.kts
@@ -6,4 +6,6 @@ dependencies {
     api("io.undertow:undertow-core:_")
     testImplementation(project(path = ":http4k-core", configuration = "testArtifacts"))
     testImplementation(project(path = ":http4k-realtime-core", configuration = "testArtifacts"))
+
+    testImplementation(Testing.junit.jupiter.params)
 }

--- a/http4k-server/undertow/src/main/kotlin/org/http4k/server/Http4kUndertowWebSocketCallback.kt
+++ b/http4k-server/undertow/src/main/kotlin/org/http4k/server/Http4kUndertowWebSocketCallback.kt
@@ -63,7 +63,16 @@ class Http4kWebSocketCallback(private val ws: WsHandler) : WebSocketConnectionCa
 private fun WebSocketHttpExchange.asRequest() = Request(GET, requestURI)
     .headers(requestHeaders.toList().flatMap { h -> h.second.map { h.first to it } })
 
-fun requiresWebSocketUpgrade(): (HttpServerExchange) -> Boolean = {
-    (it.requestHeaders["Connection"]?.any { it.equals("upgrade", true) } ?: false) &&
-        (it.requestHeaders["Upgrade"]?.any { it.equals("websocket", true) } ?: false)
+fun requiresWebSocketUpgrade(): (HttpServerExchange) -> Boolean = { httpServerExchange ->
+    val containsValidConnectionHeader = httpServerExchange.requestHeaders["Connection"]
+        ?.any { headerValue ->
+            headerValue.split(",")
+                .map { it.trim().lowercase() }
+                .contains("upgrade")
+        } ?: false
+
+    val containsValidUpgradeHeader = httpServerExchange.requestHeaders["Upgrade"]
+        ?.any { it.equals("websocket", true) } ?: false
+
+    containsValidConnectionHeader && containsValidUpgradeHeader
 }

--- a/http4k-server/undertow/src/test/kotlin/org/http4k/server/Http4kUndertowWebSocketCallbackKtTest.kt
+++ b/http4k-server/undertow/src/test/kotlin/org/http4k/server/Http4kUndertowWebSocketCallbackKtTest.kt
@@ -1,0 +1,27 @@
+package org.http4k.server
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import io.undertow.server.HttpServerExchange
+import io.undertow.util.HeaderMap
+import io.undertow.util.HttpString
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class Http4kUndertowWebSocketCallbackKtTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = ["upgrade", "Upgrade", "keep-alive, Upgrade"])
+    fun `upgrades when valid Connection header provided`(connectionHeaderValue: String) {
+        val predicate = requiresWebSocketUpgrade()
+        val headerMap = HeaderMap().apply {
+            this.add(HttpString("Connection"), connectionHeaderValue)
+            this.add(HttpString("Upgrade"), "websocket")
+        }
+        val httpServerExchange = HttpServerExchange(null, headerMap, null, 0)
+
+        val requiresWebsocketUpgrade = predicate(httpServerExchange)
+
+        assertThat(requiresWebsocketUpgrade,  equalTo(true))
+    }
+}


### PR DESCRIPTION
Some browsers (Firefox 112.0.1, at least) include a Connection header with a value of "keep-alive, Upgrade" when connecting via the WebSocket Web API. These requests are not currently upgraded when using an Undertow server - this PR addresses that issue.