### PR TITLE
GZip compression level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This list is not intended to be all-encompassing - it will document major and breaking API 
 changes with their rationale when appropriate:
 
-### v4.43.2.0 (uncut)
+### v4.44.0.0 (uncut)
 - **http4k-core** : [Breaking] Allow setting of compression level on GZip filter in both Streaming and Memory mode. To fix change from GzipCompressionMode.Memory/Streaming to GzipCompressionMode.Memory()/Streaming() 
 
 ### v4.43.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This list is not intended to be all-encompassing - it will document major and breaking API 
 changes with their rationale when appropriate:
 
+### v4.43.2.0 (uncut)
+- **http4k-core** : [Breaking] Allow setting of compression level on GZip filter in both Streaming and Memory mode. To fix change from GzipCompressionMode.Memory/GzipCompressionMode.Streaming to GzipCompressionMode.Memory()/GzipCompressionMode.Streaming() 
+
 ### v4.43.1.0
 - **http4k-*** : Upgrade some dependency versions.
 - **http4k-core** : [Fix] #901. Improve performance of GZip in streaming mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This list is not intended to be all-encompassing - it will document major and br
 changes with their rationale when appropriate:
 
 ### v4.43.2.0 (uncut)
-- **http4k-core** : [Breaking] Allow setting of compression level on GZip filter in both Streaming and Memory mode. To fix change from GzipCompressionMode.Memory/GzipCompressionMode.Streaming to GzipCompressionMode.Memory()/GzipCompressionMode.Streaming() 
+- **http4k-core** : [Breaking] Allow setting of compression level on GZip filter in both Streaming and Memory mode. To fix change from GzipCompressionMode.Memory/Streaming to GzipCompressionMode.Memory()/Streaming() 
 
 ### v4.43.1.0
 - **http4k-*** : Upgrade some dependency versions.

--- a/http4k-core/src/main/kotlin/org/http4k/filter/ClientFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ClientFilters.kt
@@ -233,14 +233,14 @@ object ClientFilters {
     /**
      * Support for GZipped responses from clients.
      */
-    fun AcceptGZip(compressionMode: GzipCompressionMode = Memory): Filter =
+    fun AcceptGZip(compressionMode: GzipCompressionMode = Memory()): Filter =
         ResponseFilters.GunZip(compressionMode)
 
     /**
      * Basic GZip and Gunzip support of Request/Response.
      * Only Gunzip responses when the response contains "content-encoding" header containing 'gzip'
      */
-    fun GZip(compressionMode: GzipCompressionMode = Memory): Filter =
+    fun GZip(compressionMode: GzipCompressionMode = Memory()): Filter =
         RequestFilters.GZip(compressionMode)
             .then(ResponseFilters.GunZip(compressionMode))
 

--- a/http4k-core/src/main/kotlin/org/http4k/filter/Gzip.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/Gzip.kt
@@ -57,7 +57,7 @@ else ByteArrayOutputStream().use {
     Body(ByteBuffer.wrap(it.toByteArray()))
 }
 
-fun Body.gzippedStream(compressionLevel: Int = 8): CompressionResult =
+fun Body.gzippedStream(compressionLevel: Int = DEFAULT_COMPRESSION): CompressionResult =
     sampleStream(stream,
         { CompressionResult(Body.EMPTY, null) },
         { compressedStream ->

--- a/http4k-core/src/main/kotlin/org/http4k/filter/Gzip.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/Gzip.kt
@@ -16,12 +16,6 @@ import java.util.zip.Deflater.DEFAULT_COMPRESSION
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
-internal class MyGZIPOutputStream(out: OutputStream?) : GZIPOutputStream(out) {
-    fun setLevel(level: Int) {
-        def.setLevel(level)
-    }
-}
-
 sealed class GzipCompressionMode(
     internal val compress: (Body) -> CompressionResult,
     internal val decompress: (Body) -> Body

--- a/http4k-core/src/main/kotlin/org/http4k/filter/Gzip.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/Gzip.kt
@@ -7,18 +7,30 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.io.InputStream
+import java.io.OutputStream
 import java.io.PushbackInputStream
 import java.nio.ByteBuffer
 import java.util.zip.CRC32
 import java.util.zip.Deflater
+import java.util.zip.Deflater.DEFAULT_COMPRESSION
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
-sealed class GzipCompressionMode(internal val compress: (Body) -> CompressionResult, internal val decompress: (Body) -> Body) {
+internal class MyGZIPOutputStream(out: OutputStream?) : GZIPOutputStream(out) {
+    fun setLevel(level: Int) {
+        def.setLevel(level)
+    }
+}
 
-    object Memory : GzipCompressionMode(Body::gzipped, Body::gunzipped)
+sealed class GzipCompressionMode(
+    internal val compress: (Body) -> CompressionResult,
+    internal val decompress: (Body) -> Body
+) {
+    class Memory(compressionLevel: Int = DEFAULT_COMPRESSION) :
+        GzipCompressionMode({ it.gzipped(compressionLevel) }, Body::gunzippedStream)
 
-    object Streaming : GzipCompressionMode(Body::gzippedStream, Body::gunzippedStream)
+    class Streaming(compressionLevel: Int = DEFAULT_COMPRESSION) :
+        GzipCompressionMode({ it.gzippedStream(compressionLevel) }, Body::gunzippedStream)
 }
 
 data class CompressionResult(
@@ -38,10 +50,10 @@ data class CompressionResult(
             .body(body)
 }
 
-fun Body.gzipped(): CompressionResult = if (payload.array().isEmpty())
+fun Body.gzipped(compressionLevel: Int = DEFAULT_COMPRESSION): CompressionResult = if (payload.array().isEmpty())
     CompressionResult(Body.EMPTY, null)
 else ByteArrayOutputStream().run {
-    GZIPOutputStream(this).use { it.write(payload.array()) }
+    GZIPOutputStreamWith(this, compressionLevel).use { it.write(payload.array()) }
     CompressionResult(Body(ByteBuffer.wrap(toByteArray())), "gzip")
 }
 
@@ -51,10 +63,15 @@ else ByteArrayOutputStream().use {
     Body(ByteBuffer.wrap(it.toByteArray()))
 }
 
-fun Body.gzippedStream(): CompressionResult =
+fun Body.gzippedStream(compressionLevel: Int = 8): CompressionResult =
     sampleStream(stream,
         { CompressionResult(Body.EMPTY, null) },
-        { compressedStream -> CompressionResult(Body(GZippingInputStream(compressedStream)), "gzip") })
+        { compressedStream ->
+            CompressionResult(
+                Body(GZippingInputStream(compressedStream, compressionLevel)),
+                "gzip"
+            )
+        })
 
 fun Body.gunzippedStream(): Body = if (length != null && length == 0L) {
     Body.EMPTY
@@ -64,7 +81,11 @@ fun Body.gunzippedStream(): Body = if (length != null && length == 0L) {
         { compressedStream -> Body(GZIPInputStream(compressedStream)) })
 }
 
-private fun <T> sampleStream(sourceStream: InputStream, actionIfEmpty: () -> T, actionIfHasContent: (InputStream) -> T): T {
+private fun <T> sampleStream(
+    sourceStream: InputStream,
+    actionIfEmpty: () -> T,
+    actionIfHasContent: (InputStream) -> T
+): T {
     val pushbackStream = PushbackInputStream(sourceStream)
     val firstByte = pushbackStream.read()
     return if (firstByte == -1) {
@@ -75,7 +96,13 @@ private fun <T> sampleStream(sourceStream: InputStream, actionIfEmpty: () -> T, 
     }
 }
 
-internal class GZippingInputStream(private val source: InputStream) : InputStream() {
+private fun GZIPOutputStreamWith(out: OutputStream, compressionLevel: Int): GZIPOutputStream = object : GZIPOutputStream(out) {
+    init {
+        def.setLevel(compressionLevel)
+    }
+}
+
+internal class GZippingInputStream(private val source: InputStream, private val compressionLevel: Int) : InputStream() {
 
     companion object {
         // see http://www.zlib.org/rfc-gzip.html#header-trailer
@@ -84,7 +111,8 @@ internal class GZippingInputStream(private val source: InputStream) : InputStrea
             GZIP_MAGIC.toByte(),
             (GZIP_MAGIC shr 8).toByte(),
             Deflater.DEFLATED.toByte(),
-            0, 0, 0, 0, 0, 0, 0)
+            0, 0, 0, 0, 0, 0, 0
+        )
         private const val INITIAL_BUFFER_SIZE = 8192
     }
 
@@ -92,7 +120,7 @@ internal class GZippingInputStream(private val source: InputStream) : InputStrea
         HEADER, DATA, FINALISE, TRAILER, DONE
     }
 
-    private val deflater = Deflater(Deflater.DEFLATED, true)
+    private val deflater = Deflater(Deflater.DEFLATED, true).apply { setLevel(compressionLevel) }
     private val crc = CRC32()
     private var trailer: ByteArrayInputStream? = null
     private val header = ByteArrayInputStream(HEADER_DATA)
@@ -122,6 +150,7 @@ internal class GZippingInputStream(private val source: InputStream) : InputStrea
             }
             bytesRead
         }
+
         State.DATA -> {
             if (!deflater.needsInput()) {
                 deflatePendingInput(readBuffer, readOffset, readLength)
@@ -142,6 +171,7 @@ internal class GZippingInputStream(private val source: InputStream) : InputStrea
                 }
             }
         }
+
         State.FINALISE -> if (deflater.finished()) {
             stage = State.TRAILER
             val crcValue = crc.value.toInt()
@@ -151,6 +181,7 @@ internal class GZippingInputStream(private val source: InputStream) : InputStrea
         } else {
             deflater.deflate(readBuffer, readOffset, readLength, Deflater.FULL_FLUSH)
         }
+
         State.TRAILER -> {
             val trailerStream = trailer ?: error("Trailer stream is null in trailer stage")
             val bytesRead = trailerStream.read(readBuffer, readOffset, readLength)
@@ -159,27 +190,36 @@ internal class GZippingInputStream(private val source: InputStream) : InputStrea
             }
             bytesRead
         }
+
         State.DONE -> -1
     }
 
     private fun deflatePendingInput(readBuffer: ByteArray, readOffset: Int, readLength: Int): Int {
         var bytesCompressed = 0
         while (!deflater.needsInput() && readLength - bytesCompressed > 0) {
-            bytesCompressed += deflater.deflate(readBuffer, readOffset + bytesCompressed, readLength - bytesCompressed, Deflater.FULL_FLUSH)
+            bytesCompressed += deflater.deflate(
+                readBuffer,
+                readOffset + bytesCompressed,
+                readLength - bytesCompressed,
+                Deflater.FULL_FLUSH
+            )
         }
         return bytesCompressed
     }
 
     private fun createTrailer(crcValue: Int, totalIn: Int) =
-        ByteArrayInputStream(byteArrayOf(
-            (crcValue shr 0).toByte(),
-            (crcValue shr 8).toByte(),
-            (crcValue shr 16).toByte(),
-            (crcValue shr 24).toByte(),
-            (totalIn shr 0).toByte(),
-            (totalIn shr 8).toByte(),
-            (totalIn shr 16).toByte(),
-            (totalIn shr 24).toByte()))
+        ByteArrayInputStream(
+            byteArrayOf(
+                (crcValue shr 0).toByte(),
+                (crcValue shr 8).toByte(),
+                (crcValue shr 16).toByte(),
+                (crcValue shr 24).toByte(),
+                (totalIn shr 0).toByte(),
+                (totalIn shr 8).toByte(),
+                (totalIn shr 16).toByte(),
+                (totalIn shr 24).toByte()
+            )
+        )
 
     override fun available(): Int {
         if (stage == State.DONE) {

--- a/http4k-core/src/main/kotlin/org/http4k/filter/RequestFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/RequestFilters.kt
@@ -28,7 +28,7 @@ object RequestFilters {
      * Basic GZipping of Request.
      */
     object GZip {
-        operator fun invoke(compressionMode: GzipCompressionMode = Memory) = Filter { next ->
+        operator fun invoke(compressionMode: GzipCompressionMode = Memory()) = Filter { next ->
             {
                 next(compressionMode.compress(it.body).apply(it))
             }
@@ -39,7 +39,7 @@ object RequestFilters {
      * Basic UnGZipping of Request.
      */
     object GunZip {
-        operator fun invoke(compressionMode: GzipCompressionMode = Memory) = Filter { next ->
+        operator fun invoke(compressionMode: GzipCompressionMode = Memory()) = Filter { next ->
             { request ->
                 request.header("content-encoding")
                     ?.let { if (it.contains("gzip")) it else null }

--- a/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
@@ -73,7 +73,7 @@ object ResponseFilters {
      */
     class GZipContentTypes(
         compressibleContentTypes: Set<ContentType>,
-        private val compressionMode: GzipCompressionMode = Memory
+        private val compressionMode: GzipCompressionMode = Memory()
     ) : Filter {
         private val compressibleMimeTypes = compressibleContentTypes
             .map { it.value }
@@ -103,7 +103,7 @@ object ResponseFilters {
      * Basic GZipping of Response.
      */
     object GZip {
-        operator fun invoke(compressionMode: GzipCompressionMode = Memory) = Filter { next ->
+        operator fun invoke(compressionMode: GzipCompressionMode = Memory()) = Filter { next ->
             { request ->
                 next(request).let {
                     if ((request.header("accept-encoding") ?: "").contains("gzip", true)) {
@@ -118,7 +118,7 @@ object ResponseFilters {
      * Basic UnGZipping of Response.
      */
     object GunZip {
-        operator fun invoke(compressionMode: GzipCompressionMode = Memory) = Filter { next ->
+        operator fun invoke(compressionMode: GzipCompressionMode = Memory()) = Filter { next ->
             { request ->
                 next(request.header("accept-encoding", "gzip")).let { response ->
                     response.header("content-encoding")

--- a/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
@@ -295,7 +295,7 @@ object ServerFilters {
      * Only Gzips responses when request contains "accept-encoding" header containing 'gzip'.
      */
     object GZip {
-        operator fun invoke(compressionMode: GzipCompressionMode = Memory): Filter =
+        operator fun invoke(compressionMode: GzipCompressionMode = Memory()): Filter =
             RequestFilters.GunZip(compressionMode).then(ResponseFilters.GZip(compressionMode))
     }
 
@@ -306,7 +306,7 @@ object ServerFilters {
      */
     class GZipContentTypes(
         private val compressibleContentTypes: Set<ContentType>,
-        private val compressionMode: GzipCompressionMode = Memory
+        private val compressionMode: GzipCompressionMode = Memory()
     ) : Filter {
         override fun invoke(next: HttpHandler) = RequestFilters.GunZip(compressionMode)
             .then(ResponseFilters.GZipContentTypes(compressibleContentTypes, compressionMode))

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ClientFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ClientFiltersTest.kt
@@ -42,7 +42,6 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
 import java.util.concurrent.atomic.AtomicReference
-import java.util.zip.Deflater
 import java.util.zip.Deflater.BEST_SPEED
 
 class ClientFiltersTest {

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ClientFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ClientFiltersTest.kt
@@ -261,7 +261,7 @@ class ClientFiltersTest {
 
         @Test
         fun `gzip request and gunzip streamed response`() {
-            val handler = ClientFilters.GZip(Streaming).then {
+            val handler = ClientFilters.GZip(Streaming()).then {
                 assertThat(it, hasHeader("content-encoding", "gzip").and(hasBody(equalTo<Body>(Body("hello").gzippedStream().body))))
                 Response(OK).header("content-encoding", "gzip").body(Body("hello").gzippedStream().body)
             }
@@ -271,7 +271,7 @@ class ClientFiltersTest {
 
         @Test
         fun `streaming empty bodies are not encoded`() {
-            val handler = ClientFilters.GZip(Streaming).then {
+            val handler = ClientFilters.GZip(Streaming()).then {
                 assertThat(it, hasBody(equalTo<Body>(EMPTY)).and(!hasHeader("content-encoding", "gzip")))
                 Response(OK).body(EMPTY)
             }
@@ -281,7 +281,7 @@ class ClientFiltersTest {
 
         @Test
         fun `streaming encoded empty responses are handled`() {
-            val handler = ClientFilters.GZip(Streaming).then {
+            val handler = ClientFilters.GZip(Streaming()).then {
                 Response(OK).header("content-encoding", "gzip").body(EMPTY)
             }
 
@@ -332,7 +332,7 @@ class ClientFiltersTest {
 
         @Test
         fun `streaming encoded empty responses are handled`() {
-            val handler = ClientFilters.AcceptGZip(Streaming).then {
+            val handler = ClientFilters.AcceptGZip(Streaming()).then {
                 Response(OK).header("content-encoding", "gzip").body(EMPTY)
             }
 
@@ -341,7 +341,7 @@ class ClientFiltersTest {
 
         @Test
         fun `in-memory responses are ungzipped`() {
-            val handler = ClientFilters.AcceptGZip(Memory).then {
+            val handler = ClientFilters.AcceptGZip(Memory()).then {
                 Response(OK).header("content-encoding", "gzip")
                     .body(Body("hello").gzippedStream().body)
             }
@@ -351,7 +351,7 @@ class ClientFiltersTest {
 
         @Test
         fun `streaming responses are ungzipped`() {
-            val handler = ClientFilters.AcceptGZip(Streaming).then {
+            val handler = ClientFilters.AcceptGZip(Streaming()).then {
                 Response(OK).header("content-encoding", "gzip")
                     .body(Body("hello").gzippedStream().body)
             }

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ResponseFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ResponseFiltersTest.kt
@@ -159,7 +159,7 @@ class ResponseFiltersTest {
     inner class GzipStreamFilters {
         @Test
         fun `gunzip response handling sets the accept-encoding header to gzip on requests`() {
-            val handler = ResponseFilters.GunZip(Streaming).then {
+            val handler = ResponseFilters.GunZip(Streaming()).then {
                 assertThat(it, hasHeader("accept-encoding", "gzip"))
                 Response(OK)
             }
@@ -168,21 +168,21 @@ class ResponseFiltersTest {
 
         @Test
         fun `gzip response and adds gzip content encoding if the request has accept-encoding of gzip`() {
-            val zipped = ResponseFilters.GZip(Streaming).then { Response(OK).body("foobar") }
+            val zipped = ResponseFilters.GZip(Streaming()).then { Response(OK).body("foobar") }
             assertThat(zipped(Request(GET, "").header("accept-encoding", "gzip")),
                 hasBody(equalTo<Body>(Body("foobar").gzippedStream().body)).and(hasHeader("content-encoding", "gzip")))
         }
 
         @Test
         fun `do not gzip response nor add content encoding if the request body is empty`() {
-            val zipped = ResponseFilters.GZip(Streaming).then { Response(OK).header("content-type", "text/html;charset=utf-8").body("") }
+            val zipped = ResponseFilters.GZip(Streaming()).then { Response(OK).header("content-type", "text/html;charset=utf-8").body("") }
             assertThat(zipped(Request(GET, "").header("accept-encoding", "gzip")),
                 hasBody(equalTo<Body>(Body.EMPTY)).and(!hasHeader("content-encoding", "gzip")))
         }
 
         @Test
         fun `gzip response and adds gzip content encoding if the request has accept-encoding of gzip and content type is acceptable`() {
-            val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML), Streaming)
+            val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML), Streaming())
                 .then { Response(OK).header("content-type", "text/html").body("foobar") }
             assertThat(zipped(Request(GET, "").header("accept-encoding", "gzip")),
                 hasBody(equalTo<Body>(Body("foobar").gzippedStream().body)).and(hasHeader("content-encoding", "gzip")))
@@ -190,27 +190,27 @@ class ResponseFiltersTest {
 
         @Test
         fun `gzip response and adds gzip content encoding if the request has accept-encoding of gzip and content type with a charset is acceptable`() {
-            val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML), Streaming).then { Response(OK).header("content-type", "text/html;charset=utf-8").body("foobar") }
+            val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML), Streaming()).then { Response(OK).header("content-type", "text/html;charset=utf-8").body("foobar") }
             assertThat(zipped(Request(GET, "").header("accept-encoding", "gzip")),
                 hasBody(equalTo<Body>(Body("foobar").gzippedStream().body)).and(hasHeader("content-encoding", "gzip")))
         }
 
         @Test
         fun `do not gzip response if content type is missing`() {
-            val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML), Streaming).then { Response(OK).body("unzipped") }
+            val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML), Streaming()).then { Response(OK).body("unzipped") }
             assertThat(zipped(Request(GET, "").header("accept-encoding", "gzip")), hasBody(equalTo<Body>(Body("unzipped"))).and(!hasHeader("content-encoding", "gzip")))
         }
 
         @Test
         fun `do not gzip response if content type is not acceptable`() {
-            val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML), Streaming).then { Response(OK).header("content-type", "image/png").body("unzipped") }
+            val zipped = ResponseFilters.GZipContentTypes(setOf(ContentType.TEXT_HTML), Streaming()).then { Response(OK).header("content-type", "image/png").body("unzipped") }
             assertThat(zipped(Request(GET, "").header("accept-encoding", "gzip")), hasBody(equalTo<Body>(Body("unzipped"))).and(!hasHeader("content-encoding", "gzip")))
         }
 
         @Test
         fun `gunzip response which has gzip content encoding`() {
             fun assertSupportsUnzipping(body: String) {
-                val handler = ResponseFilters.GunZip(Streaming).then { Response(OK).header("content-encoding", "gzip").body(Body(body).gzipped().body) }
+                val handler = ResponseFilters.GunZip(Streaming()).then { Response(OK).header("content-encoding", "gzip").body(Body(body).gzipped().body) }
                 assertThat(handler(Request(GET, "")), hasBody(body).and(hasHeader("content-encoding", "gzip")))
             }
             assertSupportsUnzipping("foobar")
@@ -219,7 +219,7 @@ class ResponseFiltersTest {
 
         @Test
         fun `gunzip empty response which has gzip content encoding`() {
-            val handler = ResponseFilters.GunZip(Streaming).then { Response(OK).header("content-encoding", "gzip").body(Body.EMPTY) }
+            val handler = ResponseFilters.GunZip(Streaming()).then { Response(OK).header("content-encoding", "gzip").body(Body.EMPTY) }
             assertThat(handler(Request(GET, "")), hasBody("").and(hasHeader("content-encoding", "gzip")))
         }
     }

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
@@ -360,7 +360,7 @@ class ServerFiltersTest {
     inner class GzipStreamFilters {
         @Test
         fun `gunzip request and gzip response`() {
-            val handler = ServerFilters.GZip(Streaming).then {
+            val handler = ServerFilters.GZip(Streaming()).then {
                 assertThat(it, hasBody(equalTo<String>("hello")))
                 Response(OK).body(Body("hello"))
             }
@@ -371,7 +371,7 @@ class ServerFiltersTest {
 
         @Test
         fun `handle empty messages with incorrect content-encoding`() {
-            val handler = ServerFilters.GZip(Streaming).then {
+            val handler = ServerFilters.GZip(Streaming()).then {
                 assertThat(it, hasBody(equalTo<Body>(Body.EMPTY)))
                 Response(OK).body(it.body)
             }
@@ -382,7 +382,7 @@ class ServerFiltersTest {
 
         @Test
         fun `passes through non-gzipped request`() {
-            val handler = ServerFilters.GZip(Streaming).then {
+            val handler = ServerFilters.GZip(Streaming()).then {
                 assertThat(it, hasBody("hello"))
                 Response(OK).body("hello")
             }
@@ -392,7 +392,7 @@ class ServerFiltersTest {
 
         @Test
         fun `gunzip request and gzip response with matching content type`() {
-            val handler = ServerFilters.GZipContentTypes(setOf(ContentType.TEXT_PLAIN), Streaming).then {
+            val handler = ServerFilters.GZipContentTypes(setOf(ContentType.TEXT_PLAIN), Streaming()).then {
                 assertThat(it, hasBody(equalTo<String>("hello")))
                 Response(OK).header("content-type", "text/plain").body(Body("hello"))
             }
@@ -403,7 +403,7 @@ class ServerFiltersTest {
 
         @Test
         fun `gunzip request and do not gzip response with unmatched content type`() {
-            val handler = ServerFilters.GZipContentTypes(setOf(TEXT_HTML), Streaming).then {
+            val handler = ServerFilters.GZipContentTypes(setOf(TEXT_HTML), Streaming()).then {
                 assertThat(it, hasBody(equalTo<String>("hello")))
                 Response(OK).header("content-type", "text/plain").body(it.body)
             }
@@ -414,7 +414,7 @@ class ServerFiltersTest {
 
         @Test
         fun `passes through non-gzipped request despite content type`() {
-            val handler = ServerFilters.GZipContentTypes(setOf(TEXT_HTML), Streaming).then {
+            val handler = ServerFilters.GZipContentTypes(setOf(TEXT_HTML), Streaming()).then {
                 assertThat(it, hasBody("hello"))
                 Response(OK).body("hello")
             }


### PR DESCRIPTION
[Breaking] Allow setting of compression level on GZip filter in both Streaming and Memory mode
To fix change from GzipCompressionMode.Memory/Streaming to GzipCompressionMode.Memory()/Streaming() 