### PR TITLE
Allow SameSite cookie attributes in lowercase and caps

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/cookie/Cookie.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/cookie/Cookie.kt
@@ -84,7 +84,7 @@ data class Cookie(
         }
 
         private fun String.parseSameSite() = try {
-            SameSite.valueOf(this)
+            SameSite.valueOf(this.lowercase().replaceFirstChar { it.uppercaseChar() })
         } catch (_: IllegalArgumentException) {
             null
         }

--- a/http4k-core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
@@ -227,4 +227,13 @@ class CookieTest {
 
         assertThat(Cookie.parse("foo=bar; SameSite=Unknown"), equalTo(expected))
     }
+
+    @Test
+    fun `forgives SameSite attributes that aren't strictly correct`() {
+        val expected = Cookie("foo", "bar", sameSite = Lax)
+
+        assertThat(Cookie.parse("foo=bar; SameSite=lax"), equalTo(expected))
+        assertThat(Cookie.parse("foo=bar; SameSite=Lax"), equalTo(expected))
+        assertThat(Cookie.parse("foo=bar; SameSite=LAX"), equalTo(expected))
+    }
 }


### PR DESCRIPTION
I saw an all lowercase `Lax` on google.com