### PR TITLE
Gracefully handle JavaWebSocket events when http4k adapter not yet registered

### DIFF
--- a/http4k-server/websocket/src/main/kotlin/org/http4k/server/websocket/JavaWebSocket.kt
+++ b/http4k-server/websocket/src/main/kotlin/org/http4k/server/websocket/JavaWebSocket.kt
@@ -127,7 +127,7 @@ private fun createServer(
     }
 
     override fun onError(conn: WebSocket?, ex: Exception) {
-        conn?.adapter()?.triggerError(ex) ?: throw ex
+        conn?.adapter()?.triggerError(ex)
     }
 
     override fun onStart() = onServerStart()

--- a/http4k-server/websocket/src/main/kotlin/org/http4k/server/websocket/JavaWebSocket.kt
+++ b/http4k-server/websocket/src/main/kotlin/org/http4k/server/websocket/JavaWebSocket.kt
@@ -98,8 +98,8 @@ private fun createServer(
             }
         }
 
-        wsHandler(upgradeRequest)(wsAdapter)
         conn.setAttachment(wsAdapter)
+        wsHandler(upgradeRequest)(wsAdapter)
     }
 
     override fun onClose(conn: WebSocket, code: Int, reason: String?, remote: Boolean) {

--- a/http4k-server/websocket/src/main/kotlin/org/http4k/server/websocket/JavaWebSocket.kt
+++ b/http4k-server/websocket/src/main/kotlin/org/http4k/server/websocket/JavaWebSocket.kt
@@ -102,34 +102,35 @@ private fun createServer(
         conn.setAttachment(wsAdapter)
     }
 
-    override fun onClose(conn: WebSocket, code: Int, reason: String?, remote: Boolean) = conn.withAdapter { ws ->
-        ws.triggerClose(WsStatus(code, reason ?: ""))
+    override fun onClose(conn: WebSocket, code: Int, reason: String?, remote: Boolean) {
+        conn.adapter()?.triggerClose(WsStatus(code, reason ?: ""))
     }
 
-    override fun onMessage(conn: WebSocket, message: ByteBuffer) = conn.withAdapter { ws ->
-        try {
-            ws.triggerMessage(WsMessage(MemoryBody(message)))
-        } catch (e: Throwable) {
-            ws.triggerError(e)
+    override fun onMessage(conn: WebSocket, message: ByteBuffer) {
+        conn.adapter()?.let { ws ->
+            try {
+                ws.triggerMessage(WsMessage(MemoryBody(message)))
+            } catch (e: Throwable) {
+                ws.triggerError(e)
+            }
         }
     }
 
-    override fun onMessage(conn: WebSocket, message: String) = conn.withAdapter { ws ->
-        try {
-            ws.triggerMessage(WsMessage(message))
-        } catch (e: Throwable) {
-            ws.triggerError(e)
+    override fun onMessage(conn: WebSocket, message: String) {
+        conn.adapter()?.let { ws ->
+            try {
+                ws.triggerMessage(WsMessage(message))
+            } catch(e: Throwable) {
+                ws.triggerError(e)
+            }
         }
     }
 
-    override fun onError(conn: WebSocket?, ex: Exception) = conn.withAdapter { ws ->
-        ws.triggerError(ex)
+    override fun onError(conn: WebSocket?, ex: Exception) {
+        conn?.adapter()?.triggerError(ex) ?: throw ex
     }
 
     override fun onStart() = onServerStart()
 }
 
-private fun WebSocket?.withAdapter(fn: (PushPullAdaptingWebSocket) -> Unit) {
-    if (this == null) return
-    fn(getAttachment())
-}
+private fun WebSocket.adapter(): PushPullAdaptingWebSocket? = getAttachment()


### PR DESCRIPTION
If any WebSocket events are sent (such as a close) during the `WsHandler` invocation, it would result in an NPE and potentially kill the server.  This fix attempts to tackle the problem from two directions:

1. Register the `PushPullAdaptingWebSocket` before processing the upgrade request
2. If the `PushPullAdaptingWebSocket` hasn't been registered, gracefully avoid an NPE