### PR TITLE
read sns event with null Subject value

### DIFF
--- a/http4k-serverless/lambda/src/main/kotlin/org/http4k/format/SNSEventAdapter.kt
+++ b/http4k-serverless/lambda/src/main/kotlin/org/http4k/format/SNSEventAdapter.kt
@@ -28,7 +28,7 @@ object SNSEventAdapter : JsonAdapter<SNSEvent>() {
                                     "SigningCertUrl" -> signingCertUrl = nextString()
                                     "MessageId" -> messageId = nextString()
                                     "Message" -> message = nextString()
-                                    "Subject" -> subject = nextString()
+                                    "Subject" -> subject = nextStringOrNull()
                                     "UnsubscribeUrl" -> unsubscribeUrl = nextString()
                                     "Type" -> type = nextString()
                                     "SignatureVersion" -> signatureVersion = nextString()
@@ -90,3 +90,5 @@ object SNSEventAdapter : JsonAdapter<SNSEvent>() {
         }
     }
 }
+
+private fun JsonReader.nextStringOrNull() = if (peek() == JsonReader.Token.NULL) nextNull() else nextString()

--- a/http4k-serverless/lambda/src/test/kotlin/org/http4k/format/AwsLambdaMoshiTest.kt
+++ b/http4k-serverless/lambda/src/test/kotlin/org/http4k/format/AwsLambdaMoshiTest.kt
@@ -35,6 +35,7 @@ import org.http4k.format.AwsLambdaMoshi.asFormatString
 import org.http4k.lens.Header.CONTENT_TYPE
 import org.http4k.testing.Approver
 import org.http4k.testing.JsonApprovalTest
+import org.http4k.testing.assertApproved
 import org.joda.time.DateTime
 import org.joda.time.DateTimeZone.UTC
 import org.joda.time.format.ISODateTimeFormat
@@ -204,6 +205,41 @@ class AwsLambdaMoshiTest {
                 }
             )
         })
+    }
+
+    @Test
+    fun `SNS event - read null subject`() {
+        val actual = javaClass.getResourceAsStream("AwsLambdaMoshiTest.SNS event - read null subject.approved")!!
+            .reader().readText()
+            .let { asA<SNSEvent>(it) }
+
+        val expected = SNSEvent().apply {
+            records = listOf(
+                SNSEvent.SNSRecord().apply {
+                    eventSource = "eventSource"
+                    eventSubscriptionArn = "eventSubscriptionArn"
+                    eventVersion = "eventVersion"
+                    setSns(SNSEvent.SNS().apply {
+                        signingCertUrl = "signingCertUrl"
+                        messageId = "messageId"
+                        message = "message"
+                        subject = null
+                        unsubscribeUrl = "unsubscribeUrl"
+                        type = "type"
+                        signatureVersion = "type"
+                        signature = "signature"
+                        topicArn = "topicArn"
+                        timestamp = DateTime(0, UTC)
+                        messageAttributes = mapOf("msgAttrName" to SNSEvent.MessageAttribute().apply {
+                            type = "type"
+                            value = "value"
+                        })
+                    })
+                }
+            )
+        }
+
+        assertThat(expected, equalTo(actual))
     }
 
     @Test

--- a/http4k-serverless/lambda/src/test/resources/org/http4k/format/AwsLambdaMoshiTest.SNS event - read null subject.approved
+++ b/http4k-serverless/lambda/src/test/resources/org/http4k/format/AwsLambdaMoshiTest.SNS event - read null subject.approved
@@ -1,0 +1,27 @@
+{
+  "Records": [
+    {
+      "EventSource": "eventSource",
+      "EventSubscriptionArn": "eventSubscriptionArn",
+      "EventVersion": "eventVersion",
+      "Sns": {
+        "SigningCertUrl": "signingCertUrl",
+        "MessageId": "messageId",
+        "Message": "message",
+        "Subject": null,
+        "UnsubscribeUrl": "unsubscribeUrl",
+        "Type": "type",
+        "SignatureVersion": "type",
+        "Signature": "signature",
+        "TopicArn": "topicArn",
+        "Timestamp": "1970-01-01T00:00:00.000Z",
+        "MessageAttributes": {
+          "msgAttrName": {
+            "Type": "type",
+            "Value": "value"
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
If the SNS event json has a `null` `Subject` value, the deserializer fails with an exception.  This does not occur if the property is missing.  This update will make that property null-safe.

The standard approval workflow does not work for this test.  We want to assert we can properly read a hand-crafted JSON file, rather than compare some output to a JSON file.  Please let me know if there's a better way to do this than what I've done.