### PR TITLE
Remove note regarding using the http4k implementation of By as it was…

### DIFF
--- a/src/docs/guide/reference/webdriver/index.md
+++ b/src/docs/guide/reference/webdriver/index.md
@@ -27,9 +27,7 @@ A basic Selenium WebDriver API implementation for http4k HttpHandlers, which run
 | Frames|no||
 | Multiple windows|no||
 
-Use the API like any other WebDriver implementation, by simply passing your app HttpHandler to construct it. Note that we now support version 4 of the API, which has deprecated the old `By` implementations. 
-http4k ships with a custom set of JSoup `By` implementations, so be sure to import `org.http4k.webdriver.By` instead of the old `org.openqa.selenium.By` ones (which will fail with a `ClassCastException` 
-when used).
+Use the API like any other WebDriver implementation, by simply passing your app HttpHandler to construct it.
 
 #### Code [<img class="octocat"/>](https://github.com/http4k/http4k/blob/master/src/docs/guide/reference/webdriver/example.kt)
 


### PR DESCRIPTION
Remove note regarding importing the http4k implementation of `By` (`org.http4k.webdriver.By`) as it was deleted in the following commit: [https://github.com/http4k/http4k/commit/974a582f79f066bde6ef93945eb20c66915a81a0](https://github.com/http4k/http4k/commit/974a582f79f066bde6ef93945eb20c66915a81a0)