### PR TITLE
Request with UriTemplate parameters

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/http.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/http.kt
@@ -259,6 +259,13 @@ interface Request : HttpMessage {
 
         operator fun invoke(method: Method, template: UriTemplate, version: String = HTTP_1_1): Request =
             RoutedRequest(Request(method, template.toString(), version), template)
+
+        operator fun invoke(
+            method: Method,
+            template: UriTemplate,
+            parameters: Map<String, String>,
+            version: String = HTTP_1_1
+        ): Request = RoutedRequest(Request(method, template.generate(parameters), version), template)
     }
 }
 


### PR DESCRIPTION
There's an easy way of instantiate `RoutedRequest` with `UriTemplate`, but not with applied properties.

This MR adds this as another `invoke` to `Request`