### PR TITLE
Override all `Request` and `Response` mutators for routed messages to…

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/routing/messages.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/routing/messages.kt
@@ -4,7 +4,9 @@ import org.http4k.core.Body
 import org.http4k.core.Headers
 import org.http4k.core.Method
 import org.http4k.core.Request
+import org.http4k.core.RequestSource
 import org.http4k.core.Response
+import org.http4k.core.Status
 import org.http4k.core.Uri
 import org.http4k.core.UriTemplate
 import java.io.InputStream
@@ -30,13 +32,23 @@ data class RoutedRequest(private val delegate: Request, override val xUriTemplat
 
     override fun query(name: String, value: String?): Request = RoutedRequest(delegate.query(name, value), xUriTemplate)
 
+    override fun removeQuery(name: String): Request = RoutedRequest(delegate.removeQuery(name), xUriTemplate)
+
+    override fun removeQueries(prefix: String): Request = RoutedRequest(delegate.removeQueries(prefix), xUriTemplate)
+
+    override fun source(source: RequestSource): Request = RoutedRequest(delegate.source(source), xUriTemplate)
+
     override fun header(name: String, value: String?): Request = RoutedRequest(delegate.header(name, value), xUriTemplate)
 
     override fun headers(headers: Headers): Request = RoutedRequest(delegate.headers(headers), xUriTemplate)
 
     override fun replaceHeader(name: String, value: String?): Request = RoutedRequest(delegate.replaceHeader(name, value), xUriTemplate)
 
+    override fun replaceHeaders(source: Headers): Request = RoutedRequest(delegate.replaceHeaders(source), xUriTemplate)
+
     override fun removeHeader(name: String): Request = RoutedRequest(delegate.removeHeader(name), xUriTemplate)
+
+    override fun removeHeaders(prefix: String): Request = RoutedRequest(delegate.removeHeaders(prefix), xUriTemplate)
 
     override fun body(body: Body): Request = RoutedRequest(delegate.body(body), xUriTemplate)
 
@@ -54,13 +66,21 @@ class RoutedResponse(private val delegate: Response, override val xUriTemplate: 
 
     override fun header(name: String, value: String?): Response = RoutedResponse(delegate.header(name, value), xUriTemplate)
 
+    override fun headers(headers: Headers): Response = RoutedResponse(delegate.headers(headers), xUriTemplate)
+
     override fun replaceHeader(name: String, value: String?): Response = RoutedResponse(delegate.replaceHeader(name, value), xUriTemplate)
 
+    override fun replaceHeaders(source: Headers): Response = RoutedResponse(delegate.replaceHeaders(source), xUriTemplate)
+
     override fun removeHeader(name: String): Response = RoutedResponse(delegate.removeHeader(name), xUriTemplate)
+
+    override fun removeHeaders(prefix: String): Response = RoutedResponse(delegate.removeHeaders(prefix), xUriTemplate)
 
     override fun body(body: Body): Response = RoutedResponse(delegate.body(body), xUriTemplate)
 
     override fun body(body: String): Response = RoutedResponse(delegate.body(body), xUriTemplate)
 
     override fun body(body: InputStream, length: Long?): Response = RoutedResponse(delegate.body(body, length), xUriTemplate)
+
+    override fun status(new: Status): Response = RoutedResponse(delegate.status(new), xUriTemplate)
 }

--- a/http4k-core/src/test/kotlin/org/http4k/routing/RoutedMessageTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/routing/RoutedMessageTest.kt
@@ -8,6 +8,7 @@ import org.http4k.core.HttpMessage
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
+import org.http4k.core.RequestSource
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.core.Status.Companion.OK
@@ -53,6 +54,9 @@ class RoutedMessageTest {
         assertThat(request.uri(Uri.of("/changed")), isA<RoutedRequest>())
         assertThat(request.query("foo", "bar"), isA<RoutedRequest>())
         assertThat(request.headers(listOf("foo" to "bar")), isA<RoutedRequest>())
+        assertThat(request.removeQuery("foo"), isA<RoutedRequest>())
+        assertThat(request.removeQueries("foo"), isA<RoutedRequest>())
+        assertThat(request.source(RequestSource("localhost")), isA<RoutedRequest>())
 
         checkMessageFields<RoutedRequest>(request)
     }
@@ -61,13 +65,18 @@ class RoutedMessageTest {
     fun `response manipulations maintain the same type`() {
         val response = RoutedResponse(Response(NOT_FOUND), template)
 
+        assertThat(response.status(OK), isA<RoutedResponse>())
+
         checkMessageFields<RoutedResponse>(response)
     }
 
     private inline fun <reified T : Any> checkMessageFields(request: HttpMessage) {
         assertThat(request.header("foo", "bar"), isA<T>())
+        assertThat(request.headers(listOf("foo" to "bar")), isA<T>())
         assertThat(request.replaceHeader("foo", "bar"), isA<T>())
+        assertThat(request.replaceHeaders(listOf("foo" to "bar")), isA<T>())
         assertThat(request.removeHeader("foo"), isA<T>())
+        assertThat(request.removeHeaders("foot"), isA<T>())
         assertThat(request.body("foo"), isA<T>())
         assertThat(request.body(Body.EMPTY), isA<T>())
         assertThat(request.body("foo".byteInputStream()), isA<T>())


### PR DESCRIPTION
… ensure proper return type.

Looks like several mutator methods in `RoutedRequest` and `RoutedResponse` are not overridden so they are returning the delegate message type.

Example:
```kotlin
import org.http4k.core.Method
import org.http4k.core.Request
import org.http4k.core.UriTemplate
import org.http4k.core.with
import org.http4k.lens.Path
import org.http4k.lens.Query
import org.http4k.lens.int
import org.http4k.lens.string

fun main() {
  val name = Path.string().of("name")
  val size = Query.int().optional("size")

  val template = UriTemplate.from("/foo/{name}")

  val request = Request(Method.GET, template) // RoutedRequest
    .with(name of "bar") // RoutedRequest
    .with(size of 1) // MemoryRequest

  print(request)
}
```