### PR TITLE
Scan all constructors for parameter descriptions

### DIFF
--- a/http4k-contract/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/jacksonExt.kt
+++ b/http4k-contract/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/jacksonExt.kt
@@ -55,12 +55,19 @@ object JacksonFieldMetadataRetrievalStrategy : FieldMetadataRetrievalStrategy {
         FieldMetadata(target.javaClass.findPropertyDescription(fieldName)?.let { mapOf("description" to it) }
             ?: emptyMap())
 
+    /**
+     * Scan all constructors until one contains the property named [name] and has an [JsonPropertyDescription]
+     * annotation with non-null value.
+     *
+     * By scanning multiple constructors, this also works in cases with generated constructors and no-arg constructors.
+     */
     private fun Class<Any>.findPropertyDescription(name: String): String? =
-        kotlin.constructors.firstOrNull()?.let {
-            it.parameters
-                .firstOrNull { p -> p.kind == KParameter.Kind.VALUE && p.name == name }
-                ?.let { p ->
-                    p.annotations.filterIsInstance<JsonPropertyDescription>().firstOrNull()?.value
-                } ?: superclass?.findPropertyDescription(name)
-        } ?: superclass?.findPropertyDescription(name)
+        kotlin.constructors.asSequence()
+            .mapNotNull { constructor ->
+                constructor.parameters.find { parameter ->
+                    parameter.kind == KParameter.Kind.VALUE && parameter.name == name
+                }
+            }
+            .map { parameter -> parameter.annotations.filterIsInstance<JsonPropertyDescription>().firstOrNull() }
+            .firstNotNullOfOrNull { annotation -> annotation?.value } ?: superclass?.findPropertyDescription(name)
 }

--- a/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/openapi/v3/JacksonFieldMetadataRetrievalStrategyTest.kt
+++ b/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/openapi/v3/JacksonFieldMetadataRetrievalStrategyTest.kt
@@ -45,4 +45,30 @@ class JacksonFieldMetadataRetrievalStrategyTest {
             equalTo(FieldMetadata.empty)
         )
     }
+
+    /**
+     * Emulate a class annotated with `kotlinx.serialization`'s `@Serializable`.
+     */
+    class ModelWithMultipleConstructors {
+        val describedField: String
+
+        constructor(@JsonPropertyDescription("My description") describedField: String) {
+            this.describedField = describedField
+        }
+
+        /**
+         * This constructor is usually generated from `@Serializable`.
+         */
+        constructor(generatedField: Int, describedField: String, anotherGeneratedField: Any) {
+            this.describedField = describedField
+        }
+    }
+
+    @Test
+    fun `extract description when multiple constructors are present`() {
+        assertThat(
+            JacksonFieldMetadataRetrievalStrategy(ModelWithMultipleConstructors(""), "describedField"),
+            equalTo(FieldMetadata(mapOf("description" to "My description")))
+        )
+    }
 }


### PR DESCRIPTION
Fixes #750

## Background

When using `kotlinx.serialization` `@Serializable` for data classes in conjuction with the Jackson OpenApi generator, http4k will fail to pick up annotations on data classes.

Here is an example data class with `@Serializable`:
![image](https://github.com/http4k/http4k/assets/7364831/ddd1f2e4-e76e-4f76-b00a-59d3fcc087e4)

It will generate/compile code like this:
![image](https://github.com/http4k/http4k/assets/7364831/fc8020e1-9f7f-4235-9209-657578963c08)
![image](https://github.com/http4k/http4k/assets/7364831/a765a8a3-ae4f-4253-a7a3-10ff48b51e6f)

That `Deprecated` constructor is a hidden and generated constructor.
When http4k tries to find annotations, this one is being selected instead of the original constructor.

## Fix

Scan all constructors instead of just the first.
I used sequence, so we don't crawl all constructors needlessly, it should only go one-by-one until a description is found.

A test case has been added.
I use a class like this:
![image](https://github.com/http4k/http4k/assets/7364831/0181a8dd-7428-4bcf-85b2-45e045ac4402)

which tries to emulate the `@Serializable` class.
The compiled code looks like 
![image](https://github.com/http4k/http4k/assets/7364831/0f5c1215-c308-4479-882b-119f2e96a73d)
.

## Lint

I didn't find any resources or commands for linting this project.
Thus, code may be formatted incorrectly.

Just edit any code or remove comments if you dislike them.