### PR TITLE
Fix bug where spaces are not deduplicated. Merge duplicated headers

### DIFF
--- a/http4k-aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
+++ b/http4k-aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
@@ -26,13 +26,16 @@ internal data class AwsCanonicalRequest(val value: String, val signedHeaders: St
         }
 
         private fun Request.signedHeaders(): String =
-            headers.map { it.first.lowercase(getDefault()) }.sorted().joinToString(";")
+            headers.map { it.first.lowercase(getDefault()) }.toSet().sorted().joinToString(";")
 
+        private val multipleSpaces = Regex("\\s+")
         private fun Request.canonicalHeaders(): String = headers
-            .map { it.first.lowercase(getDefault()) to it.second?.replace("\\s+", " ")?.trim() }
-            .map { it.first + ":" + it.second }
-            .sorted()
-            .joinToString("\n")
+            .map { it.first.lowercase(getDefault()) to (it.second?.replace(multipleSpaces, " ")?.trim() ?: "") }
+            .groupBy ({ it.first }) { it.second }
+            .mapValues { it.value.joinToString(",") }
+            .toList()
+            .sortedBy { it.first }
+            .joinToString("\n") { it.first + ":" + it.second }
 
         private fun Request.canonicalQueryString(): String =
             uri.query.toParameters()

--- a/http4k-aws/src/test/kotlin/org/http4k/aws/AwsCanonicalRequestTest.kt
+++ b/http4k-aws/src/test/kotlin/org/http4k/aws/AwsCanonicalRequestTest.kt
@@ -10,6 +10,9 @@ import org.http4k.security.HmacSha256
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
 
+/**
+ * See the spec at [docs.aws.amazon.com](https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request).
+ */
 class AwsCanonicalRequestTest {
 
     private val canonicalPayload =
@@ -75,5 +78,33 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""))
 
 
 0fa4d114b9fbb132f096d727713aab9ea8d415b69c86053b6d2c819c4eb95db6"""))
+    }
+
+    @Test
+    fun `converts headers to canonical form`() {
+        val request = Request(GET, "http://www.google.com/")
+            .header("duplicate", "a")
+            .header("duplicate", "b")
+            .header("untrimmed", " surrounded with spaces ")
+            .header("multi-spaces", "got  multiple   spaces      inside")
+            .header("UPPERCASE", "x")
+        val canonical = AwsCanonicalRequest.of(
+            request, canonicalPayload
+        )
+
+        assertThat(
+            canonical.value, equalTo(
+                """GET
+/
+
+duplicate:a,b
+multi-spaces:got multiple spaces inside
+untrimmed:surrounded with spaces
+uppercase:x
+
+duplicate;multi-spaces;untrimmed;uppercase
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""
+            )
+        )
     }
 }


### PR DESCRIPTION
Fixes #947

https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-canonical-request

The duplicate header issue is solved by grouping header values before sorting.
I turn it to a `Map<Header key, List<Header value>>` before sorting headers, then join the list of values with `,`.