### PR TITLE
Tweak normalisation according to AWS encoding rules

### DIFF
--- a/http4k-aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
+++ b/http4k-aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
@@ -40,6 +40,9 @@ internal data class AwsCanonicalRequest(val value: String, val signedHeaders: St
                 .sorted()
                 .joinToString("&")
 
-        private fun Uri.normalisedPath() = if (path.isBlank()) "/" else path.split("/").joinToString("/") { it.urlEncoded() }
+        private fun Uri.normalisedPath() = if (path.isBlank()) "/" else path.split("/")
+            .joinToString("/") {
+                it.urlEncoded().replace("+", "%20").replace("*", "%2A").replace("%7E", "~")
+            }
     }
 }

--- a/http4k-aws/src/test/kotlin/org/http4k/aws/AwsCanonicalRequestTest.kt
+++ b/http4k-aws/src/test/kotlin/org/http4k/aws/AwsCanonicalRequestTest.kt
@@ -41,9 +41,21 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""))
 
     @Test
     fun `normalises path`() {
-        val canonical = AwsCanonicalRequest.of(Request(GET, "http://www.google.com/a:b:c/d e/f"), canonicalPayload)
+        val canonical = AwsCanonicalRequest.of(Request(GET, "http://www.google.com/a:b:c/d e/*f/~g"), canonicalPayload)
         assertThat(canonical.value, equalTo("""GET
-/a%3Ab%3Ac/d+e/f
+/a%3Ab%3Ac/d%20e/%2Af/~g
+
+
+
+
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""))
+    }
+
+    @Test
+    fun `normalises short path`() {
+        val canonical = AwsCanonicalRequest.of(Request(GET, "http://www.google.com/"), canonicalPayload)
+        assertThat(canonical.value, equalTo("""GET
+/
 
 
 


### PR DESCRIPTION
Fixes #656

I looked at the symbols in https://github.com/aws/aws-sdk-java/blob/c639a88cc22b3282da450afec180be6ed08880e6/aws-java-sdk-core/src/main/java/com/amazonaws/util/SdkHttpUtils.java#L80-L85
and added special replacement rules accordingly.