### PR TITLE
JsonConverter extension methods to create auto body lenses directly

### DIFF
--- a/http4k-format/kondor-json/src/test/kotlin/org/http4k/format/KondorJsonAutoMarshallingJsonTest.kt
+++ b/http4k-format/kondor-json/src/test/kotlin/org/http4k/format/KondorJsonAutoMarshallingJsonTest.kt
@@ -3,8 +3,19 @@ package org.http4k.format
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.startsWith
-import com.ubertob.kondor.json.*
+import com.ubertob.kondor.json.JAny
+import com.ubertob.kondor.json.JBigDecimal
+import com.ubertob.kondor.json.JBigInteger
+import com.ubertob.kondor.json.JField
+import com.ubertob.kondor.json.JInt
+import com.ubertob.kondor.json.JMap
+import com.ubertob.kondor.json.JString
+import com.ubertob.kondor.json.JStringRepresentable
+import com.ubertob.kondor.json.array
+import com.ubertob.kondor.json.bool
 import com.ubertob.kondor.json.jsonnode.JsonNodeObject
+import com.ubertob.kondor.json.obj
+import com.ubertob.kondor.json.str
 import org.http4k.core.ContentType
 import org.http4k.core.Method
 import org.http4k.core.Request
@@ -32,7 +43,6 @@ import org.http4k.lens.StringBiDiMappings.zoneOffset
 import org.http4k.lens.StringBiDiMappings.zonedDateTime
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import java.util.*
 
 class KondorJsonAutoMarshallingJsonTest : AutoMarshallingJsonContract(
     KondorJson {
@@ -112,6 +122,15 @@ class KondorJsonAutoMarshallingJsonTest : AutoMarshallingJsonContract(
     }
 
     @Test
+    fun `roundtrip arbitrary object to and from ws body`() {
+        val body = customMarshaller().wsAutoBody(ArbObject::class).toLens()
+
+        val obj = ArbObject("hello", ArbObject("world", null, listOf(1), true), emptyList(), false)
+
+        assertThat(body(body(obj)), equalTo(obj))
+    }
+
+    @Test
     fun `default content type`() {
         val body = customMarshaller().autoBody<ArbObject>().toLens()
 
@@ -142,6 +161,23 @@ class KondorJsonAutoMarshallingJsonTest : AutoMarshallingJsonContract(
             .exceptionOrNull()!!.message!!, startsWith("Error reading property <string> of node <[root]"))
     }
 
+    @Test
+    fun `roundtrip arbitrary object to and from body using converter body lens`() {
+        val body = JArbObject.autoBody().toLens()
+
+        val obj = ArbObject("hello", ArbObject("world", null, listOf(1), true), emptyList(), false)
+
+        assertThat(body(Response(Status.OK).with(body of obj)), equalTo(obj))
+    }
+
+    @Test
+    fun `roundtrip arbitrary object to and from ws body using converter body lens`() {
+        val body = JArbObject.wsAutoBody().toLens()
+
+        val obj = ArbObject("hello", ArbObject("world", null, listOf(1), true), emptyList(), false)
+
+        assertThat(body(body(obj)), equalTo(obj))
+    }
 }
 
 private object JInOnly : JStringRepresentable<InOnly>() {


### PR DESCRIPTION
This PR adds the ability to create auto body lenses directly from JsonConverters, instead of going through a KondonJson instance, which is useful when there is only one converter involved.