### PR TITLE
upgrade compromised commons-codec version

### DIFF
--- a/http4k-server/apache4/build.gradle.kts
+++ b/http4k-server/apache4/build.gradle.kts
@@ -3,5 +3,6 @@ description = "Http4k HTTP Server built on top of Apache httpcore"
 dependencies {
     api(project(":http4k-core"))
     api("org.apache.httpcomponents:httpcore:_")
+    api("commons-codec:commons-codec:_") // override version provided by httpcore (Cxeb68d52e-5509)
     testImplementation(project(path = ":http4k-core", configuration = "testArtifacts"))
 }


### PR DESCRIPTION
A transitive vulnerability was found in the latest httpcomponents httpcore.  Overriding the transitive dependency should protect http4k.

https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/