### PR TITLE
Improve support for radio buttons and radio groups in the http4k-testing-webdriver

### DIFF
--- a/http4k-testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
+++ b/http4k-testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
@@ -102,8 +102,11 @@ data class JSoupWebElement(private val navigate: Navigate, private val getURL: G
     override fun click() {
         when {
             isA("a") -> navigate(Request(GET, element.attr("href")))
-            isCheckable() -> if (isSelected) clear()
-            else element.attr("checked", "checked")
+
+            isA("input") && element.attr("type") == "checkbox" ->
+                if (isSelected) clear() else element.attr("checked", "checked")
+
+            isA("input") && element.attr("type") == "radio" -> element.attr("checked", "checked")
 
             isA("option") -> {
                 val currentSelectIsMultiple = current("select")?.element?.hasAttr("multiple") == true

--- a/http4k-testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
+++ b/http4k-testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
@@ -106,7 +106,12 @@ data class JSoupWebElement(private val navigate: Navigate, private val getURL: G
             isA("input") && element.attr("type") == "checkbox" ->
                 if (isSelected) clear() else element.attr("checked", "checked")
 
-            isA("input") && element.attr("type") == "radio" -> element.attr("checked", "checked")
+            isA("input") && element.attr("type") == "radio" -> {
+                if (element.hasAttr("name")) {
+                    current("form")?.findElements(By.tagName("input"))?.filter { it.getAttribute("name") == element.attr("name") }?.forEach { it.clear() }
+                }
+                element.attr("checked", "checked")
+            }
 
             isA("option") -> {
                 val currentSelectIsMultiple = current("select")?.element?.hasAttr("multiple") == true

--- a/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/JSoupWebElementTest.kt
+++ b/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/JSoupWebElementTest.kt
@@ -46,6 +46,14 @@ class JSoupWebElementTest {
         </form>
         """)).findElement(By.tagName("form"))!!
 
+    private fun radioGroupForm() = JSoupWebElement(navigate, getURL, Jsoup.parse("""
+        <form>
+            <input id="radio11" name="group1" type="radio" value="group1value1" checked/>
+            <input id="radio12" name="group1" type="radio" value="group1value2"/>
+            <input id="radio21" name="group2" type="radio" value="group2value1" checked/>
+        </form>
+        """)).findElement(By.tagName("form"))!!
+
     @Test
     fun `find sub elements`() = assertThat(element().findElements(By.tagName("span"))[0].text, equalTo("hello"))
 
@@ -106,6 +114,16 @@ class JSoupWebElementTest {
         assertThat(input.isSelected, equalTo(true))
         input.click()
         assertThat(input.isSelected, equalTo(true))
+    }
+
+    @Test
+    fun `click radio to clear others in radio group`() {
+        val form = radioGroupForm()
+
+        form.findElement(By.id("radio12")).click()
+        assertThat(form.findElement(By.id("radio11")).isSelected, equalTo(false))
+        assertThat(form.findElement(By.id("radio12")).isSelected, equalTo(true))
+        assertThat(form.findElement(By.id("radio21")).isSelected, equalTo(true))
     }
 
     @Test

--- a/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/JSoupWebElementTest.kt
+++ b/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/JSoupWebElementTest.kt
@@ -100,6 +100,15 @@ class JSoupWebElementTest {
     }
 
     @Test
+    fun `click radio to remain checked`() {
+        val input = input("radio")
+        input.click()
+        assertThat(input.isSelected, equalTo(true))
+        input.click()
+        assertThat(input.isSelected, equalTo(true))
+    }
+
+    @Test
     fun `click link`() {
         element("a").click()
         assertThat(newLocation, equalTo(GET to "/link"))


### PR DESCRIPTION
This PR allows the http4k webdriver to simulate radio buttons:

- Clicking on a selected radio input leaves the radio input selected
- Clicking on a radio input clears any other radio inputs in the same radio group