### PR TITLE
Update documentation to reflect Pebble model binding

### DIFF
--- a/src/docs/guide/reference/templating/index.md
+++ b/src/docs/guide/reference/templating/index.md
@@ -49,4 +49,19 @@ The examples below are for Handlebars, but the others have the same APIs:
 ### Notes for Rocker
 Rocker differs slightly from the dynamic templating engines in that it generates Java classes at compile time. In order to fit this into the http4k model, we have created a special superclass `RockerViewModel` (which combines the Rocker and the http4k `ViewModel` interfaces into a common supertype). This should be used as the `extendsModelClass` property in the generation process by configuration. Note that as the generated classes are Java and NOT Kotlin, Java syntax should be used inside the view files (which need to be named `Xyz.rocker.html`).
 
+### Notes for Pebble
+The way the underlying model is exposed for Pebble templates differs from the rest of the templating engines.
+The properties of the `ViewModel` object are bound to the view context under a `model` key, rather than directly into the template context itself.  
+
+This means that the `model.` prefix is required to access the properties of the underlying object in a Pebble template.
+
+In other words, rendering a `firstName` property, for example, is done using:
+```
+{{ model.firstName }}
+```
+instead of 
+```
+{{ firstName }}
+```
+
 [http4k]: https://http4k.org


### PR DESCRIPTION
This PR addresses the documentation changes to reflect the fact that Pebble templates will require a `model.` prefix to access the underlying model for the view.