### PR TITLE
Make EnvironmentKey.secret a BiDiLens

### DIFF
--- a/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/env/Authority.kt
+++ b/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/env/Authority.kt
@@ -1,5 +1,7 @@
 package org.http4k.cloudnative.env
 
+import org.http4k.core.Uri
+
 data class Authority(val host: Host, val port: Port? = null) {
     override fun toString() = host.value + (port?.let { ":${it.value}" } ?: "")
 
@@ -13,3 +15,6 @@ data class Authority(val host: Host, val port: Port? = null) {
         }
     }
 }
+
+fun Authority.asHttpsUri() = Uri(scheme = "https", userInfo = "", port = port?.value, host = host.value, path = "", query = "", fragment = "")
+fun Authority.asHttpUri() = Uri(scheme = "http", userInfo = "", port = port?.value, host = host.value, path = "", query = "", fragment = "")

--- a/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/env/Secret.kt
+++ b/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/env/Secret.kt
@@ -32,7 +32,7 @@ class Secret(input: ByteArray) : Closeable {
     }.apply { close() }
 
     override fun close(): Unit = run {
-        value.get().apply { (0 until size).forEach { this[it] = 0 } }
+        value.get().apply { indices.forEach { this[it] = 0 } }
         value.set(ByteArray(0))
     }
 }

--- a/http4k-cloudnative/src/main/kotlin/org/http4k/lens/cloudNativeExt.kt
+++ b/http4k-cloudnative/src/main/kotlin/org/http4k/lens/cloudNativeExt.kt
@@ -9,8 +9,9 @@ import org.http4k.cloudnative.env.Timeout
 fun StringBiDiMappings.host() = nonBlank().map(::Host, Host::value)
 fun StringBiDiMappings.port() = int().map(::Port, Port::value)
 fun StringBiDiMappings.authority() = nonBlank().map({ Authority(it) }, Authority::toString)
+fun StringBiDiMappings.secret() = nonEmpty().map({ Secret(it) }, { secret -> secret.use { it } })
 
-fun <IN : Any> BiDiLensSpec<IN, String>.secret() = nonEmptyString().bytes().map(::Secret)
+fun <IN : Any> BiDiLensSpec<IN, String>.secret() = map(StringBiDiMappings.secret())
 fun <IN : Any> BiDiLensSpec<IN, String>.host() = map(StringBiDiMappings.host())
 fun <IN : Any> BiDiLensSpec<IN, String>.port() = map(StringBiDiMappings.port())
 fun <IN : Any> BiDiLensSpec<IN, String>.authority() = map(StringBiDiMappings.authority())

--- a/http4k-cloudnative/src/test/kotlin/org/http4k/cloudnative/env/AuthorityTest.kt
+++ b/http4k-cloudnative/src/test/kotlin/org/http4k/cloudnative/env/AuthorityTest.kt
@@ -3,6 +3,7 @@ package org.http4k.cloudnative.env
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.throws
+import org.http4k.core.Uri
 import org.junit.jupiter.api.Test
 
 class AuthorityTest {
@@ -18,5 +19,17 @@ class AuthorityTest {
     fun `check toString`() {
         assertThat(Authority(Host.localhost, Port(80)).toString(), equalTo("localhost:80"))
         assertThat(Authority(Host.localhost).toString(), equalTo("localhost"))
+    }
+
+    @Test
+    fun `as http uri`() {
+        assertThat(Authority("localhost:123").asHttpUri(), equalTo(Uri.of("http://localhost:123")))
+        assertThat(Authority("localhost").asHttpUri(), equalTo(Uri.of("http://localhost")))
+    }
+
+    @Test
+    fun `as https uri`() {
+        assertThat(Authority("localhost:123").asHttpsUri(), equalTo(Uri.of("https://localhost:123")))
+        assertThat(Authority("localhost").asHttpsUri(), equalTo(Uri.of("https://localhost")))
     }
 }

--- a/http4k-cloudnative/src/test/kotlin/org/http4k/cloudnative/env/EnvironmentTest.kt
+++ b/http4k-cloudnative/src/test/kotlin/org/http4k/cloudnative/env/EnvironmentTest.kt
@@ -3,6 +3,7 @@ package org.http4k.cloudnative.env
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.throws
+import org.http4k.lens.secret
 import org.junit.jupiter.api.Test
 import java.io.File
 import java.io.FileNotFoundException
@@ -59,6 +60,16 @@ class EnvironmentTest {
 
         assertThat(finalEnv["FOO"], equalTo("bob"))
         assertThat(default(finalEnv), equalTo("bill"))
+    }
+
+    @Test
+    fun `defaults secret`() {
+        val secret = EnvironmentKey.secret().required("PASSWORD")
+        val env = Environment.defaults(secret of Secret("hunter2"))
+
+        env[secret].use { password ->
+            assertThat(password, equalTo("hunter2"))
+        }
     }
 
     @Test


### PR DESCRIPTION
Given

```kotlin
val secretKey = EnvironmentKey.secret().required("PASS")
val fooKey = EnvironmentKey.required("FOO")
```

When building a test environment, I want to be able to use

```kotlin
val env = Environment.defaults(
    secretKey of Secret("hunter2"),
    fooKey of "bar"
)
```

but the best I can do is

```kotlin
val env = Enviromment.from(
    secretKey.meta.name of "hunter2"
) overrides Environment.defaults(
    fooKey of "bar"
)
```

So I've updated `EnvironmentKey.secret` to return a `BiDiLens`, which gives the functionality I'm looking for.  However, I wonder if I'm approaching this from the wrong direction.  If `EnvironmentKey.secret` returns a `Lens`, then I don't see how my intended usage doesn't work out of the box.  Perhaps I lack sufficient understanding of the internals of the lens system.  Is what I've done the right approach?

