### PR TITLE
Support redirects in Http4kWebDriver's emulation of a client's host header

### DIFF
--- a/http4k-testing/webdriver/src/main/kotlin/org/http4k/webdriver/Http4kWebDriver.kt
+++ b/http4k-testing/webdriver/src/main/kotlin/org/http4k/webdriver/Http4kWebDriver.kt
@@ -23,8 +23,7 @@ import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZoneOffset.UTC
-import java.util.Date
-import java.util.UUID
+import java.util.*
 import org.http4k.core.cookie.Cookie as HCookie
 
 typealias Navigate = (Request) -> Unit
@@ -35,11 +34,12 @@ interface Http4KNavigation : Navigation {
 }
 
 class Http4kWebDriver(initialHandler: HttpHandler, clock: Clock = Clock.systemDefaultZone()) : WebDriver {
-    val handler = ClientFilters.FollowRedirects()
-        .then(ClientFilters.Cookies(clock, cookieStorage()))
-        .then(Filter { next -> { request -> latestUri = request.uri.toString(); next(request) } })
-        .then(Filter { next -> { request -> next(request.header("host", latestHost)) } })
-        .then(initialHandler)
+    val handler =
+        Filter { next -> { request -> next(request.header("host", latestHost)) } }
+            .then(ClientFilters.FollowRedirects())
+            .then(ClientFilters.Cookies(clock, cookieStorage()))
+            .then(Filter { next -> { request -> latestUri = request.uri.toString(); next(request) } })
+            .then(initialHandler)
 
     private var current: Page? = null
     private var activeElement: WebElement? = null

--- a/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
+++ b/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
@@ -7,6 +7,7 @@ import org.http4k.core.Method
 import org.http4k.core.Method.POST
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
+import org.http4k.core.Status.Companion.SEE_OTHER
 import org.http4k.core.Uri
 import org.http4k.core.cookie.cookie
 import org.http4k.core.cookie.cookies
@@ -287,6 +288,19 @@ class Http4kWebDriverTest {
         assertThat(driver.pageSource, equalTo("foo.com:5000"))
         driver.navigate().to("http://baz.com/")
         assertThat(driver.pageSource, equalTo("baz.com"))
+    }
+
+    @Test
+    fun `Set the host header when redirecting to a URL`() {
+        val driver = Http4kWebDriver({ req ->
+            when (req.header("host")) {
+                "redirect.com" -> Response(SEE_OTHER).header("location", "http://destination.com")
+                else -> Response(OK).body(req.header("host") ?: "none")
+            }
+        })
+
+        driver.navigate().to("http://redirect.com")
+        assertThat(driver.pageSource, equalTo("destination.com"))
     }
 
     private fun WebDriver.assertOnPage(expected: String) {


### PR DESCRIPTION
Currently redirect chains to a different host will all have the host header of the domain that triggered the first redirect, not the true host header that would be seen from a browser following the redirects.