### PR TITLE
Allow changing the host option for Undertow

### DIFF
--- a/http4k-server/undertow/src/main/kotlin/org/http4k/server/Undertow.kt
+++ b/http4k-server/undertow/src/main/kotlin/org/http4k/server/Undertow.kt
@@ -17,7 +17,8 @@ import java.net.InetSocketAddress
 class Undertow(
     val port: Int = 8000,
     val enableHttp2: Boolean,
-    override val stopMode: StopMode = StopMode.Immediate
+    override val stopMode: StopMode = StopMode.Immediate,
+    val host: String = "0.0.0.0",
 ) : PolyServerConfig {
     constructor(port: Int = 8000) : this(port, false)
     constructor(port: Int = 8000, enableHttp2: Boolean) : this(port, enableHttp2, StopMode.Immediate)
@@ -43,7 +44,7 @@ class Undertow(
 
         return object : Http4kServer {
             val server = Undertow.builder()
-                .addHttpListener(port, "0.0.0.0")
+                .addHttpListener(port, host)
                 .setServerOption(ENABLE_HTTP2, enableHttp2)
                 .setWorkerThreads(32 * Runtime.getRuntime().availableProcessors())
                 .setHandler(handlerWithSse).build()


### PR DESCRIPTION
The current implementation of the Undertow Http4kServer always binds itself to `0.0.0.0`. This binds it to _all_ IPv4-enabled network interfaces. 

Binding to _all_ IPv4-enabled network interfaces is often not a good idea from a security point of view. For example, binding to local interfaces only (`127.0.0.1`) is usually sufficient for local development and does not expose the application on public network interfaces.

It's also not sufficient when IPv6 is desired.

This change simply adds the option to override the binding host as desired  - for undertow only. I have kept the change as minimal as possible to avoid introducing a breaking change. One could also think about whether the default should be adjusted.