### PR TITLE
aws presigner to accept credentials provider

### DIFF
--- a/http4k-aws/src/main/kotlin/org/http4k/aws/AwsPreSignRequests.kt
+++ b/http4k-aws/src/main/kotlin/org/http4k/aws/AwsPreSignRequests.kt
@@ -5,42 +5,44 @@ import org.http4k.filter.Payload
 import java.time.Clock
 import java.time.Duration
 
-class AwsPreSignRequests(
-    private val scope: AwsCredentialScope,
-    private val credentialsProvider: () -> AwsCredentials,
-    private val clock: Clock = Clock.systemUTC()
-) {
-    constructor(scope: AwsCredentialScope, credentials: AwsCredentials, clock: Clock = Clock.systemUTC()) : this(
+fun interface AwsPreRequestSigner : (Request, Duration) -> AwsPreSignedRequest
+
+fun AwsPreRequestSigner(scope: AwsCredentialScope, credentials: AwsCredentials, clock: Clock = Clock.systemUTC()) =
+    AwsPreRequestSigner(
         scope = scope,
         credentialsProvider = { credentials },
         clock = clock
     )
 
-    operator fun invoke(request: Request, expires: Duration): AwsPreSignedRequest {
-        val awsDate = AwsRequestDate.of(clock.instant())
-        val credentials = credentialsProvider()
+fun AwsPreRequestSigner(
+    scope: AwsCredentialScope,
+    credentialsProvider: () -> AwsCredentials,
+    clock: Clock = Clock.systemUTC()
+): AwsPreRequestSigner = AwsPreRequestSigner { request, expires ->
+    val awsDate = AwsRequestDate.of(clock.instant())
+    val credentials = credentialsProvider()
 
-        val fullRequest = request
-            .replaceHeader("Host", request.uri.host)
-            .let { it.query("X-Amz-SignedHeaders", it.signedHeaders()) }
-            .query("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
-            .query("X-Amz-Date", awsDate.full)
-            .query("X-Amz-Credential", "${credentials.accessKey}/${scope.datedScope(awsDate)}")
-            .query("X-Amz-Expires", expires.seconds.toString())
-            .let {
-                if (credentials.sessionToken != null) it.query(
-                    "X-Amz-Security-Token",
-                    credentials.sessionToken
-                ) else it
-            }
+    val fullRequest = request
+        .replaceHeader("Host", request.uri.host)
+        .let { it.query("X-Amz-SignedHeaders", it.signedHeaders()) }
+        .query("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
+        .query("X-Amz-Date", awsDate.full)
+        .query("X-Amz-Credential", "${credentials.accessKey}/${scope.datedScope(awsDate)}")
+        .query("X-Amz-Expires", expires.seconds.toString())
+        .let {
+            if (credentials.sessionToken != null) it.query(
+                "X-Amz-Security-Token",
+                credentials.sessionToken
+            ) else it
+        }
 
-        val canonicalRequest = AwsCanonicalRequest.of(fullRequest, Payload.Mode.Unsigned(request))
-        val signature = AwsSignatureV4Signer.sign(canonicalRequest, scope, credentials, awsDate)
+    val canonicalRequest =
+        AwsCanonicalRequest.of(fullRequest, Payload.Mode.Unsigned(request))
+    val signature = AwsSignatureV4Signer.sign(canonicalRequest, scope, credentials, awsDate)
 
-        return AwsPreSignedRequest(
-            uri = fullRequest.query("X-Amz-Signature", signature).uri,
-            signedHeaders = fullRequest.headers,
-            expires = clock.instant() + expires
-        )
-    }
+    AwsPreSignedRequest(
+        uri = fullRequest.query("X-Amz-Signature", signature).uri,
+        signedHeaders = fullRequest.headers,
+        expires = clock.instant() + expires
+    )
 }

--- a/http4k-aws/src/main/kotlin/org/http4k/aws/AwsPreSignRequests.kt
+++ b/http4k-aws/src/main/kotlin/org/http4k/aws/AwsPreSignRequests.kt
@@ -7,12 +7,23 @@ import java.time.Duration
 
 class AwsPreSignRequests(
     private val scope: AwsCredentialScope,
-    private val credentials: AwsCredentials,
+    private val credentialsProvider: () -> AwsCredentials,
     private val clock: Clock = Clock.systemDefaultZone()
 ) {
+    constructor(
+        scope: AwsCredentialScope,
+        credentials: AwsCredentials,
+        clock: Clock = Clock.systemDefaultZone()
+    ): this(
+        scope = scope,
+        credentialsProvider = { credentials },
+        clock = clock
+    )
+
     operator fun invoke(request: Request, expires: Duration): AwsPreSignedRequest {
         val time = clock.instant()
         val awsDate = AwsRequestDate.of(time)
+        val credentials = credentialsProvider()
 
         val fullRequest = request
             .replaceHeader("Host", request.uri.host)

--- a/http4k-aws/src/test/kotlin/org/http4k/aws/AwsPreRequestSignerTest.kt
+++ b/http4k-aws/src/test/kotlin/org/http4k/aws/AwsPreRequestSignerTest.kt
@@ -13,12 +13,12 @@ import java.time.Duration
 import java.time.Instant
 import java.time.ZoneOffset
 
-class AwsPreSignRequestsTest {
+class AwsPreRequestSignerTest {
 
     @Test
     fun `signed with standard credentials`() {
         val time = Instant.parse("2013-05-24T00:00:00Z")
-        val signer = AwsPreSignRequests(
+        val signer = AwsPreRequestSigner(
             scope = AwsCredentialScope("us-east-1", "s3"),
             credentialsProvider = { AwsCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY") },
             clock = Clock.fixed(time, ZoneOffset.UTC)
@@ -44,7 +44,7 @@ class AwsPreSignRequestsTest {
 
     @Test
     fun `signed with STS credentials`() {
-        val signer = AwsPreSignRequests(
+        val signer = AwsPreRequestSigner(
             scope = AwsCredentialScope("us-east-1", "s3"),
             credentials = AwsCredentials(
                 accessKey = "AKIAIOSFODNN7EXAMPLE",

--- a/http4k-aws/src/test/kotlin/org/http4k/aws/AwsPreSignRequestsTest.kt
+++ b/http4k-aws/src/test/kotlin/org/http4k/aws/AwsPreSignRequestsTest.kt
@@ -20,7 +20,7 @@ class AwsPreSignRequestsTest {
         val time = Instant.parse("2013-05-24T00:00:00Z")
         val signer = AwsPreSignRequests(
             clock = Clock.fixed(time, ZoneOffset.UTC),
-            credentials = AwsCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+            credentialsProvider = { AwsCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY") },
             scope = AwsCredentialScope("us-east-1", "s3")
         )
         val request = Request(Method.GET, "https://examplebucket.s3.amazonaws.com/test.txt")

--- a/http4k-aws/src/test/kotlin/org/http4k/aws/AwsPreSignRequestsTest.kt
+++ b/http4k-aws/src/test/kotlin/org/http4k/aws/AwsPreSignRequestsTest.kt
@@ -19,9 +19,9 @@ class AwsPreSignRequestsTest {
     fun `signed with standard credentials`() {
         val time = Instant.parse("2013-05-24T00:00:00Z")
         val signer = AwsPreSignRequests(
-            clock = Clock.fixed(time, ZoneOffset.UTC),
+            scope = AwsCredentialScope("us-east-1", "s3"),
             credentialsProvider = { AwsCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY") },
-            scope = AwsCredentialScope("us-east-1", "s3")
+            clock = Clock.fixed(time, ZoneOffset.UTC)
         )
         val request = Request(Method.GET, "https://examplebucket.s3.amazonaws.com/test.txt")
         val signed = signer(request, Duration.ofHours(24))
@@ -45,13 +45,13 @@ class AwsPreSignRequestsTest {
     @Test
     fun `signed with STS credentials`() {
         val signer = AwsPreSignRequests(
-            clock = Clock.fixed(Instant.parse("2013-05-24T00:00:00Z"), ZoneOffset.UTC),
+            scope = AwsCredentialScope("us-east-1", "s3"),
             credentials = AwsCredentials(
                 accessKey = "AKIAIOSFODNN7EXAMPLE",
                 secretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
                 sessionToken = "SESSION_TOKEN"
             ),
-            scope = AwsCredentialScope("us-east-1", "s3")
+            clock = Clock.fixed(Instant.parse("2013-05-24T00:00:00Z"), ZoneOffset.UTC)
         )
         val request = Request(Method.GET, "https://examplebucket.s3.amazonaws.com/test.txt")
         val signed = request


### PR DESCRIPTION
I forgot to support a credentials provider.  Here it is.

I think I know how @daviddenton would have architected this. Rather than have a class with multiple constructors, there would have been an `object AwsPresignRequests` with two `operator fun invoke` functions (or just two top-level `AwsPresignedRequest` functions) that return a `(Request, Duration) -> AwsPresignedRequest`.

It makes no real difference to the user, but if you would prefer I stick to the established http4k style, I don't mind changing it.