### PR TITLE
Fix error with AwsCanonicalRequest path normalization

### DIFF
--- a/http4k-aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
+++ b/http4k-aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
@@ -44,6 +44,7 @@ internal data class AwsCanonicalRequest(val value: String, val signedHeaders: St
             .joinToString("/") {
                 it.urlEncoded().replace("+", "%20").replace("*", "%2A").replace("%7E", "~")
             }
+            .let { if (it.startsWith("/")) it else "/$it" }
     }
 }
 

--- a/http4k-aws/src/test/kotlin/org/http4k/aws/AwsCanonicalRequestTest.kt
+++ b/http4k-aws/src/test/kotlin/org/http4k/aws/AwsCanonicalRequestTest.kt
@@ -5,7 +5,9 @@ import com.natpryce.hamkrest.equalTo
 import org.http4k.core.Body
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
+import org.http4k.core.Uri
 import org.http4k.filter.CanonicalPayload
+import org.http4k.routing.path
 import org.http4k.security.HmacSha256
 import org.junit.jupiter.api.Test
 import java.nio.ByteBuffer
@@ -52,6 +54,16 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""))
 
 
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""))
+    }
+
+    @Test
+    fun `normalises path without leading slash`() {
+        val withLeadingSlash =
+            AwsCanonicalRequest.of(Request(GET, Uri.of("http://www.google.com/foo")), canonicalPayload)
+        val withoutLeadingSlash =
+            AwsCanonicalRequest.of(Request(GET, Uri.of("http://www.google.com").path("foo")), canonicalPayload)
+
+        assertThat(withLeadingSlash, equalTo(withoutLeadingSlash))
     }
 
     @Test


### PR DESCRIPTION
Without this, creating a URI such as the one below would lead to an `AwsCanonicalRequest` that doesn't match what Amazon expects.

`Uri.of("http://www.google.com").path("foo")`

whereas this would be valid

`Uri.of("http://www.google.com/foo")`

This fix will ensure both of them would result in the expected `AwsCanonicalRequest`