### PR TITLE
Upgrade gradle to 8.5

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -145,7 +145,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
     case $MAX_FD in #(
       max*)
         # In POSIX sh, ulimit -H is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         MAX_FD=$( ulimit -H -n ) ||
             warn "Could not query maximum file descriptor limit"
     esac
@@ -153,7 +153,7 @@ if ! "$cygwin" && ! "$darwin" && ! "$nonstop" ; then
       '' | soft) :;; #(
       *)
         # In POSIX sh, ulimit -n is undefined. That's why the result is checked to see if it worked.
-        # shellcheck disable=SC3045
+        # shellcheck disable=SC2039,SC3045
         ulimit -n "$MAX_FD" ||
             warn "Could not set maximum file descriptor limit to $MAX_FD"
     esac
@@ -202,11 +202,11 @@ fi
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
-# Collect all arguments for the java command;
-#   * $DEFAULT_JVM_OPTS, $JAVA_OPTS, and $GRADLE_OPTS can contain fragments of
-#     shell script including quotes and variable substitutions, so put them in
-#     double quotes to make sure that they get re-expanded; and
-#   * put everything else in single quotes, so that it's not re-expanded.
+# Collect all arguments for the java command:
+#   * DEFAULT_JVM_OPTS, JAVA_OPTS, JAVA_OPTS, and optsEnvironmentVar are not allowed to contain shell fragments,
+#     and any embedded shellness will be escaped.
+#   * For example: A user cannot expect ${Hostname} to be expanded, as it is an environment variable and will be
+#     treated as '${Hostname}' itself on the command line.
 
 set -- \
         "-Dorg.gradle.appname=$APP_BASE_NAME" \


### PR DESCRIPTION
tl;dr:
```
BUILD SUCCESSFUL in 5m 27s
622 actionable tasks: 622 executed
```


```
~/git/efasel-http4k$ ./gradlew check
Starting a Gradle Daemon, 2 busy and 2 incompatible Daemons could not be reused, use --status for details

> Task :http4k-template-rocker:compileTestRocker
[main] INFO com.fizzed.rocker.compiler.JavaGeneratorMain - Parsing 3 rocker template files
[main] INFO com.fizzed.rocker.compiler.JavaGeneratorMain - Generated 3 rocker java source files
[main] INFO com.fizzed.rocker.compiler.JavaGeneratorMain - Generated rocker configuration /home/fase01/git/efasel-http4k/http4k-template/rocker/out/test/classes/rocker-compiler.conf

> Task :http4k-contract:generateOpenApi3AutoClient
There were issues with the specification, but validation has been explicitly disabled.
Errors: 
        -attribute webhooks is unexpected

Could not compute datatypeWithEnum from kotlin.Int, null
Empty operationId found for path: post foobar_/doo. Renamed to auto-generated operationId: foobar_DooPost
Could not compute datatypeWithEnum from kotlin.String, null
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
#                                                                              #
# This generator's contributed by Jim Schubert (https://github.com/jimschubert)#
# Please support his work directly via https://patreon.com/jimschubert 🙏      #
################################################################################
Successfully generated code to .

> Task :http4k-contract:generateOpenApi3Client
There were issues with the specification, but validation has been explicitly disabled.
Errors: 
        -attribute webhooks is unexpected

Could not compute datatypeWithEnum from kotlin.Int, null
Empty operationId found for path: post foobar_/doo. Renamed to auto-generated operationId: foobar_DooPost
Could not compute datatypeWithEnum from kotlin.String, null
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
#                                                                              #
# This generator's contributed by Jim Schubert (https://github.com/jimschubert)#
# Please support his work directly via https://patreon.com/jimschubert 🙏      #
################################################################################
Successfully generated code to .

> Task :http4k-contract:generateOpenApi2Client
Illegal schema found with array type but no items, items must be defined for array schemas:
 class ArraySchema {
    class Schema {
        type: array
        format: null
        $ref: null
        description: intField
        title: null
        multipleOf: null
        maximum: null
        exclusiveMaximum: null
        minimum: null
        exclusiveMinimum: null
        maxLength: null
        minLength: null
        pattern: null
        maxItems: null
        minItems: null
        uniqueItems: null
        maxProperties: null
        minProperties: null
        required: null
        not: null
        properties: null
        additionalProperties: null
        nullable: null
        readOnly: null
        writeOnly: null
        example: null
        externalDocs: null
        deprecated: null
        discriminator: null
        xml: null
    }
}
Illegal schema found with array type but no items, items must be defined for array schemas:
 class ArraySchema {
    class Schema {
        type: array
        format: null
        $ref: null
        description: intField
        title: null
        multipleOf: null
        maximum: null
        exclusiveMaximum: null
        minimum: null
        exclusiveMinimum: null
        maxLength: null
        minLength: null
        pattern: null
        maxItems: null
        minItems: null
        uniqueItems: null
        maxProperties: null
        minProperties: null
        required: null
        not: null
        properties: null
        additionalProperties: null
        nullable: null
        readOnly: null
        writeOnly: null
        example: null
        externalDocs: null
        deprecated: null
        discriminator: null
        xml: null
    }
}
Undefined array inner type for `i`. Default to String.
Could not compute datatypeWithEnum from kotlin.String, null
################################################################################
# Thanks for using OpenAPI Generator.                                          #
# Please consider donation to help us maintain this project 🙏                 #
# https://opencollective.com/openapi_generator/donate                          #
#                                                                              #
# This generator's contributed by Jim Schubert (https://github.com/jimschubert)#
# Please support his work directly via https://patreon.com/jimschubert 🙏      #
################################################################################
Successfully generated code to .

> Task :http4k-multipart:compileJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-client-apache:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-client-helidon:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-client-apache4:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-client-jetty:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-client-okhttp:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-server-apache:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-server-apache4:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-contract-jsonschema:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-server-helidon:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-server-jetty:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-server-ktorcio:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-server-ktornetty:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :compileTestKotlin
w: file:///home/fase01/git/efasel-http4k/src/docs/blog/documenting_apis_with_openapi/1_route.kt:19:59 Parameter 'req' is never used, could be renamed to _
w: file:///home/fase01/git/efasel-http4k/src/docs/blog/typesafe_configuration/pre/secrets.kt:10:14 Parameter 'secretKey' is never used
w: file:///home/fase01/git/efasel-http4k/src/docs/guide/howto/leverage_graphql/example.kt:79:18 'context(Any!): ExecutionInput.Builder!' is deprecated. Deprecated in Java
w: file:///home/fase01/git/efasel-http4k/src/docs/guide/howto/serve_websockets/example_automarshalling.kt:23:25 Parameter 'req' is never used, could be renamed to _
w: file:///home/fase01/git/efasel-http4k/src/docs/guide/reference/clients/example_http.kt:44:9 Variable 'customClient' is never used
w: file:///home/fase01/git/efasel-http4k/src/docs/guide/reference/opentelemetry/example_tracing.kt:4:39 'AwsXrayPropagator' is deprecated. Deprecated in Java
w: file:///home/fase01/git/efasel-http4k/src/docs/guide/reference/opentelemetry/example_tracing.kt:23:32 'AwsXrayPropagator' is deprecated. Deprecated in Java

> Task :http4k-server-netty:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-server-ratpack:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-server-jetty11:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-core:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-server-undertow:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-serverless-lambda:compileTestKotlin
w: file:///home/fase01/git/efasel-http4k/http4k-serverless/lambda/src/examples/kotlin/example_event_handling.kt:36:51 Parameter 'env' is never used, could be renamed to _

> Task :http4k-template-rocker:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

> Task :http4k-testing-servirtium:compileTestJava
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] target value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
3 warnings

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.5/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD SUCCESSFUL in 5m 27s
622 actionable tasks: 622 executed
```
