### PR TITLE
Fix handlebars import in htmx example

### DIFF
--- a/src/docs/guide/reference/htmx/index.md
+++ b/src/docs/guide/reference/htmx/index.md
@@ -8,7 +8,7 @@ dependencies {
     implementation(platform("org.http4k:http4k-bom:5.13.0.0"))
     implementation("org.http4k:http4k-htmx")
 
-    implementation("org.http4k:http4k-handlebars") // for example
+    implementation("org.http4k:http4k-template-handlebars") // Handlebars
 }
 ```
 


### PR DESCRIPTION
The current import of the handlebars template engine in the htmx example is not working. (Probably outdated?)
This fixes that tiny bug.