### PR TITLE
Make HelidonClient support query parameters

### DIFF
--- a/http4k-client/helidon/src/test/kotlin/org/http4k/client/HelidonClientTest.kt
+++ b/http4k-client/helidon/src/test/kotlin/org/http4k/client/HelidonClientTest.kt
@@ -1,20 +1,32 @@
 package org.http4k.client
 
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
 import io.helidon.webclient.api.WebClient
+import org.http4k.client.HelidonClient.makeHelidonRequest
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
 import org.http4k.server.ApacheServer
-import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 import java.time.Duration
 
 class HelidonClientTest : HttpClientContract(
     ::ApacheServer, HelidonClient(),
     HelidonClient(WebClient.builder().readTimeout(Duration.ofMillis(100)).build())
 ) {
-    override fun `supports query parameter list`() = Assumptions.assumeTrue(false, "Unsupported client feature")
-
     @Disabled
     override fun `fails with no protocol`() {
     }
+
+    @Test
+    fun `query parameters are preserved in requests made by the Helidon client`(){
+        val helidonQuery = WebClient.create()
+            .makeHelidonRequest(Request(GET, "http://localhost?p1=foo&p2=123&p1=bar"))
+            .resolvedUri()
+            .writeableQuery()
+            .rawValue()
+
+        assertThat(helidonQuery, equalTo("p1=foo&p1=bar&p2=123"))
+    }
 }
-
-


### PR DESCRIPTION
The use of Helidon's `uri(String uri)` encodes the string value which breaks the extraction of query parameters.

This change uses the Helidon WebClient API to copy query parameters into a Helidon request.