### PR TITLE
Make clients honor the memory body mode when a request body is an input stream

### DIFF
--- a/http4k-client/apache/src/test/kotlin/org/http4k/client/ApacheClientTest.kt
+++ b/http4k-client/apache/src/test/kotlin/org/http4k/client/ApacheClientTest.kt
@@ -26,7 +26,8 @@ class ApacheClientTest : HttpClientContract(::ApacheServer, ApacheClient(),
                 .setResponseTimeout(Timeout.ofMilliseconds(100))
                 .build()
         ).build()
-        , responseBodyMode = Stream)) {
+        , responseBodyMode = Stream)),
+    HttpClientWithMemoryModeContract {
 
     @Test
     fun `connect timeout is handled`() {

--- a/http4k-client/apache4/src/test/kotlin/org/http4k/client/Apache4ClientTest.kt
+++ b/http4k-client/apache4/src/test/kotlin/org/http4k/client/Apache4ClientTest.kt
@@ -27,7 +27,8 @@ class Apache4ClientTest : HttpClientContract(
                     .build()
             ).build(), responseBodyMode = Stream
     )
-) {
+),
+    HttpClientWithMemoryModeContract {
 
     @Test
     fun `connect timeout is handled`() {

--- a/http4k-client/fuel/src/main/kotlin/org/http4k/client/Fuel.kt
+++ b/http4k-client/fuel/src/main/kotlin/org/http4k/client/Fuel.kt
@@ -4,6 +4,8 @@ import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Method
 import com.github.kittinunf.fuel.core.ResponseResultOf
 import org.http4k.core.BodyMode
+import org.http4k.core.BodyMode.Memory
+import org.http4k.core.BodyMode.Stream
 import org.http4k.core.Parameters
 import org.http4k.core.Request
 import org.http4k.core.Response
@@ -20,7 +22,7 @@ private typealias FuelResult = com.github.kittinunf.result.Result<ByteArray, Fue
 private typealias FuelFuel = com.github.kittinunf.fuel.Fuel
 
 class Fuel(
-    private val bodyMode: BodyMode = BodyMode.Memory,
+    private val bodyMode: BodyMode = Memory,
     private val timeout: Duration = Duration.ofSeconds(15)
 ) :
     DualSyncAsyncHttpHandler {
@@ -55,5 +57,10 @@ class Fuel(
             .timeout(timeout.toMillisPart())
             .timeoutRead(timeout.toMillisPart())
             .header(headers.toParametersMap())
-            .body(bodyMode(body.stream).stream)
+            .also { fuelRequest ->
+                when (bodyMode) {
+                    Memory -> fuelRequest.body(body.payload.array())
+                    Stream -> fuelRequest.body(body.stream)
+                }
+            }
 }

--- a/http4k-client/fuel/src/test/kotlin/org/http4k/client/FuelTest.kt
+++ b/http4k-client/fuel/src/test/kotlin/org/http4k/client/FuelTest.kt
@@ -5,12 +5,13 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.Duration
 
-class FuelTest : HttpClientContract(::ApacheServer, Fuel(), Fuel(timeout = Duration.ofMillis(100))) {
+class FuelTest :
+    HttpClientContract(::ApacheServer, Fuel(), Fuel(timeout = Duration.ofMillis(100))),
+    HttpClientWithMemoryModeContract {
+
     @Test
     @Disabled
     override fun `can send multiple headers with same name`() {
         super.`can send multiple headers with same name`()
     }
 }
-
-

--- a/http4k-client/helidon/src/test/kotlin/org/http4k/client/HelidonClientTest.kt
+++ b/http4k-client/helidon/src/test/kotlin/org/http4k/client/HelidonClientTest.kt
@@ -14,7 +14,9 @@ import java.time.Duration
 class HelidonClientTest : HttpClientContract(
     ::ApacheServer, HelidonClient(),
     HelidonClient(WebClient.builder().readTimeout(Duration.ofMillis(100)).build())
-) {
+),
+    HttpClientWithMemoryModeContract {
+
     @Disabled
     override fun `fails with no protocol`() {
     }

--- a/http4k-client/jetty/src/main/kotlin/org/http4k/client/JettyClient.kt
+++ b/http4k-client/jetty/src/main/kotlin/org/http4k/client/JettyClient.kt
@@ -1,12 +1,12 @@
 package org.http4k.client
 
-import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.BufferingResponseListener
+import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.InputStreamRequestContent
 import org.eclipse.jetty.client.InputStreamResponseListener
 import org.eclipse.jetty.client.Result
-import org.eclipse.jetty.http.HttpFields
 import org.eclipse.jetty.http.HttpCookieStore
+import org.eclipse.jetty.http.HttpFields
 import org.http4k.client.PreCannedJettyHttpClients.defaultJettyHttpClient
 import org.http4k.core.BodyMode
 import org.http4k.core.Headers

--- a/http4k-client/jetty/src/main/kotlin/org/http4k/client/JettyClient.kt
+++ b/http4k-client/jetty/src/main/kotlin/org/http4k/client/JettyClient.kt
@@ -94,8 +94,9 @@ object JettyClient {
 
             private fun HttpClient.newRequest(request: Request) =
                 newRequest(request.uri.toString()).method(request.method.name)
-                .headers { fields -> request.headers.toParametersMap().forEach { fields.put(it.key, it.value)}}
-                .body(InputStreamRequestContent(request.body.stream)).let(requestModifier)
+                    .headers { fields -> request.headers.toParametersMap().forEach { fields.put(it.key, it.value) } }
+                    .body(InputStreamRequestContent(request.body.stream))
+                    .let(requestModifier)
 
             private fun JettyRequest.timeoutOrMax() = if (timeout <= 0) Long.MAX_VALUE else timeout
 

--- a/http4k-client/jetty/src/main/kotlin/org/http4k/client/JettyClient.kt
+++ b/http4k-client/jetty/src/main/kotlin/org/http4k/client/JettyClient.kt
@@ -1,6 +1,7 @@
 package org.http4k.client
 
 import org.eclipse.jetty.client.BufferingResponseListener
+import org.eclipse.jetty.client.ByteBufferRequestContent
 import org.eclipse.jetty.client.HttpClient
 import org.eclipse.jetty.client.InputStreamRequestContent
 import org.eclipse.jetty.client.InputStreamResponseListener
@@ -95,7 +96,12 @@ object JettyClient {
             private fun HttpClient.newRequest(request: Request) =
                 newRequest(request.uri.toString()).method(request.method.name)
                     .headers { fields -> request.headers.toParametersMap().forEach { fields.put(it.key, it.value) } }
-                    .body(InputStreamRequestContent(request.body.stream))
+                    .body(
+                        when (bodyMode) {
+                            BodyMode.Memory -> ByteBufferRequestContent(request.body.payload)
+                            BodyMode.Stream -> InputStreamRequestContent(request.body.stream)
+                        }
+                    )
                     .let(requestModifier)
 
             private fun JettyRequest.timeoutOrMax() = if (timeout <= 0) Long.MAX_VALUE else timeout

--- a/http4k-client/jetty/src/test/kotlin/org/http4k/client/JettyClientTest.kt
+++ b/http4k-client/jetty/src/test/kotlin/org/http4k/client/JettyClientTest.kt
@@ -2,4 +2,6 @@ package org.http4k.client
 
 import org.http4k.server.ApacheServer
 
-class JettyClientTest : HttpClientContract(::ApacheServer, JettyClient(), JettyClient(requestModifier = timeout))
+class JettyClientTest :
+    HttpClientContract(::ApacheServer, JettyClient(), JettyClient(requestModifier = timeout)),
+    HttpClientWithMemoryModeContract

--- a/http4k-client/okhttp/src/test/kotlin/org/http4k/client/OkHttpTest.kt
+++ b/http4k-client/okhttp/src/test/kotlin/org/http4k/client/OkHttpTest.kt
@@ -2,4 +2,6 @@ package org.http4k.client
 
 import org.http4k.server.ApacheServer
 
-class OkHttpTest : HttpClientContract(::ApacheServer, OkHttp(), OkHttp(timeout))
+class OkHttpTest :
+    HttpClientContract(::ApacheServer, OkHttp(), OkHttp(timeout)),
+    HttpClientWithMemoryModeContract

--- a/http4k-core/src/test/kotlin/org/http4k/client/Java8HttpClientTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/client/Java8HttpClientTest.kt
@@ -16,7 +16,8 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
 class Java8HttpClientTest : HttpClientContract(::ApacheServer, Java8HttpClient(),
     ApacheClient(HttpClients.custom()
         .setDefaultRequestConfig(RequestConfig.custom().setResponseTimeout(100, MILLISECONDS).build()).build()
-        , responseBodyMode = BodyMode.Stream)){
+        , responseBodyMode = BodyMode.Stream)),
+    HttpClientWithMemoryModeContract {
 
     @Test
     fun `allow configuring read timeout`(){

--- a/http4k-core/src/test/kotlin/org/http4k/client/JavaHttpClientTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/client/JavaHttpClientTest.kt
@@ -17,7 +17,8 @@ class JavaHttpClientTest : HttpClientContract(
     ::ApacheServer,
     JavaHttpClient(),
     JavaHttpClient { it.timeout(Duration.ofMillis(100)) },
-) {
+),
+    HttpClientWithMemoryModeContract {
 
     @Disabled("unsupported by the underlying java client")
     override fun `handles response with custom status message`() {

--- a/http4k-core/src/testFixtures/kotlin/org/http4k/client/HttpClientWithMemoryModeContract.kt
+++ b/http4k-core/src/testFixtures/kotlin/org/http4k/client/HttpClientWithMemoryModeContract.kt
@@ -1,0 +1,25 @@
+package org.http4k.client
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.core.HttpHandler
+import org.http4k.core.Method.POST
+import org.http4k.core.Request
+import org.junit.jupiter.api.Test
+
+interface HttpClientWithMemoryModeContract {
+    val client: HttpHandler
+    val port: Int
+
+    @Test
+    fun `honors the memory body mode when a request body is an input stream`(){
+        val expectedBody = "hello world"
+
+        val request = Request(POST, "http://localhost:$port/echo").body(expectedBody.byteInputStream())
+
+        val response = client(request)
+
+        assertThat(request.bodyString(), equalTo(expectedBody))
+        assertThat(response.bodyString(), equalTo(expectedBody))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,8 @@ refreshVersions {
     }
 }
 
+gradle.startParameter.isContinueOnFailure = true
+
 fun String.includeModule(name: String) {
     val projectName = "$this-$name"
     include(":$projectName")


### PR DESCRIPTION
Requests prepared by `AwsSdkClient` set the body as an input stream which gets consumed when the `PrintRequestAndResponse` filter is combined with specific clients, resulting in the server receiving an empty request body.

The introduction of `HttpClientWithMemoryModeContract` helped identify and fix the impacted clients:
- `http4k-client-fuel`
- `http4k-client-jetty`
