### PR TITLE
Implement KondorJsonSchemaCreator

### DIFF
--- a/http4k-contract/jsonschema/build.gradle.kts
+++ b/http4k-contract/jsonschema/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
     api(project(":http4k-format-core"))
 
     implementation(project(":http4k-format-jackson"))
+    implementation(project(":http4k-format-kondor-json"))
     implementation("dev.forkhandles:values4k:_")
     implementation("dev.forkhandles:data4k:_")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/http4k-contract/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/KondorJsonSchemaCreator.kt
+++ b/http4k-contract/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/KondorJsonSchemaCreator.kt
@@ -1,0 +1,50 @@
+package org.http4k.contract.jsonschema.v3
+
+import com.ubertob.kondor.json.jsonnode.JsonNode
+import org.http4k.contract.jsonschema.JsonSchema
+import org.http4k.contract.jsonschema.JsonSchemaCreator
+import org.http4k.format.KondorJson
+
+class KondorJsonSchemaCreator(
+    private val json: KondorJson,
+    private val refLocationPrefix: String = "components/schema",
+) : JsonSchemaCreator<Any, JsonNode> {
+    private val delegate = JsonToJsonSchema(json)
+
+    override fun toSchema(obj: Any, overrideDefinitionId: String?, refModelNamePrefix: String?): JsonSchema<JsonNode> {
+        try {
+            if (obj is JsonNode) return delegate.toSchema(obj, overrideDefinitionId, refModelNamePrefix)
+            if (obj is Enum<*>) return toEnumSchema(obj, refModelNamePrefix, overrideDefinitionId)
+
+            val schema = json.converterFor(obj).schema()
+            val definitionId = overrideDefinitionId ?: obj::class.simpleName ?: return JsonSchema(schema)
+
+            val reference = (refModelNamePrefix ?: "") + definitionId
+            val schemaRef = json {
+                obj("\$ref" to string("#/$refLocationPrefix/$reference"))
+            }
+
+            return JsonSchema(schemaRef, setOf(reference to schema))
+        } catch (e: Exception) {
+            return delegate.toSchema(json.obj(), overrideDefinitionId, refModelNamePrefix)
+        }
+    }
+
+    private fun toEnumSchema(
+        obj: Enum<*>,
+        refModelNamePrefix: String?,
+        overrideDefinitionId: String?,
+    ): JsonSchema<JsonNode> {
+        val newDefinition = json.obj(
+            "example" to json.string(obj.name),
+            "type" to json.string("string"),
+            "enum" to json.array(obj.javaClass.enumConstants.map { json.string(it.name) })
+        )
+        val definitionId =
+            (refModelNamePrefix.orEmpty()) + (overrideDefinitionId ?: ("object" + newDefinition.hashCode()))
+        return JsonSchema(
+            json { obj("\$ref" to string("#/$refLocationPrefix/$definitionId")) },
+            setOf(definitionId to newDefinition)
+        )
+    }
+}

--- a/http4k-contract/openapi/build.gradle.kts
+++ b/http4k-contract/openapi/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     testImplementation("dev.forkhandles:values4k:_")
     testImplementation(project(":http4k-format-jackson"))
     testImplementation(project(":http4k-format-argo"))
+    testImplementation(project(":http4k-format-kondor-json"))
     testImplementation(project(":http4k-testing-approval"))
     testImplementation(testFixtures(project(":http4k-core")))
     testImplementation(testFixtures(project(":http4k-security-oauth")))

--- a/http4k-contract/openapi/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
+++ b/http4k-contract/openapi/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
@@ -11,7 +11,6 @@ import org.http4k.contract.Tag
 import org.http4k.contract.WebCallback
 import org.http4k.contract.jsonschema.JsonSchema
 import org.http4k.contract.jsonschema.v2.value
-import org.http4k.contract.jsonschema.v3.JsonToJsonSchema
 import org.http4k.contract.openapi.ApiInfo
 import org.http4k.contract.openapi.ApiRenderer
 import org.http4k.contract.openapi.OpenApiExtension
@@ -293,9 +292,9 @@ class OpenApi3<NODE : Any>(
 
         return SchemaContent(jsonSchema, message.bodyString().safeParse())
     }
-
+    
     private fun String.toSchema(definitionId: String? = null) = safeParse()
-        ?.let { JsonToJsonSchema(json, "components/schemas").toSchema(it, definitionId, null) }
+        ?.let { apiRenderer.toSchema(it, definitionId, null) }
         ?: JsonSchema(json.obj(), emptySet())
 
     private fun List<Security>.combineFull(): Render<NODE> = {

--- a/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3KondorTest.kt
+++ b/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3KondorTest.kt
@@ -1,0 +1,128 @@
+package org.http4k.contract.openapi.v3
+
+import com.ubertob.kondor.json.JAny
+import com.ubertob.kondor.json.jsonnode.JsonNode
+import com.ubertob.kondor.json.jsonnode.JsonNodeObject
+import com.ubertob.kondor.json.num
+import com.ubertob.kondor.json.obj
+import com.ubertob.kondor.json.str
+import org.http4k.contract.ContractRendererContract
+import org.http4k.contract.contract
+import org.http4k.contract.jsonschema.JsonSchema
+import org.http4k.contract.jsonschema.v3.KondorJsonSchemaCreator
+import org.http4k.contract.meta
+import org.http4k.contract.openapi.AddSimpleFieldToRootNode
+import org.http4k.contract.openapi.ApiInfo
+import org.http4k.contract.openapi.ApiRenderer
+import org.http4k.core.HttpMessage
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.core.Uri
+import org.http4k.format.KondorJson
+import org.http4k.format.autoBody
+import org.http4k.routing.bind
+import org.http4k.testing.Approver
+import org.junit.jupiter.api.Test
+
+private data class NestedObject(val aNullField: String?, val aNumberField: Int)
+private data class TopLevelObject(val nestedObject: NestedObject)
+
+private object JNestedObject : JAny<NestedObject>() {
+    private val aNullField by str(NestedObject::aNullField)
+    private val aNumberField by num(NestedObject::aNumberField)
+
+    override fun JsonNodeObject.deserializeOrThrow(): NestedObject =
+        NestedObject(
+            aNullField = +aNullField,
+            aNumberField = +aNumberField
+        )
+}
+
+private object JTopLevelObject : JAny<TopLevelObject>() {
+    private val nestedObject by obj(JNestedObject, TopLevelObject::nestedObject)
+
+    override fun JsonNodeObject.deserializeOrThrow(): TopLevelObject =
+        TopLevelObject(
+            nestedObject = +nestedObject
+        )
+}
+
+private val kondor = KondorJson {
+    register(TopLevelObject::class, JTopLevelObject)
+}
+
+class OpenApi3KondorTest : ContractRendererContract<JsonNode>(
+    kondor,
+    OpenApi3(
+        apiInfo = ApiInfo("title", "1.2", "module description"),
+        json = kondor,
+        apiRenderer = KondorOpenApi3Renderer(kondor, OpenApi3ApiRenderer(kondor)),
+        servers = listOf(ApiServer(Uri.of("http://localhost:8000"))),
+        extensions = listOf(AddSimpleFieldToRootNode),
+    )
+) {
+    @Test
+    override fun `renders as expected`(approver: Approver) {
+        /*
+            This scrubbing approver is necessary because the actual definition IDs being generated are not deterministic,
+            as they're backed by data class hashcodes. In reality, this shouldn't be a problem for anyone using Kondor
+            since it's expected that you'd define data classes for your data, rather than providing examples using
+            arbitrary json.
+         */
+        val scrubbingApprover = object : Approver {
+            override fun <T : HttpMessage> assertApproved(httpMessage: T) {
+                val scrubbedBody = Regex("""/[a-zA-Z0-9_-]*(object-?\d+)"""").findAll(httpMessage.bodyString())
+                    .map { it.groupValues[1] }
+                    .toSet()
+                    .foldIndexed(httpMessage.bodyString()) { index, acc, original ->
+                        acc.replace(original, "generatedDefinitionId${index + 1}")
+                    }
+
+                println(scrubbedBody)
+
+                approver.assertApproved(httpMessage.body(scrubbedBody))
+            }
+        }
+
+        super.`renders as expected`(scrubbingApprover)
+    }
+
+    @Test
+    fun `renders json schema bodies that use data classes`(approver: Approver) {
+        val topLevelObjectLens = JTopLevelObject.autoBody().toLens()
+        val example = TopLevelObject(NestedObject(null, 123))
+
+        val router = "/basepath" bind contract {
+            renderer = rendererToUse
+
+            routes += "/body_json_schema_data_class" meta {
+                receiving(topLevelObjectLens to example)
+            } bindContract Method.POST to { _ -> Response(Status.OK) }
+
+            routes += "/body_json_schema_data_class_with_definition_id" meta {
+                receiving(topLevelObjectLens to example, "OverriddenDefinitionId", "a_prefix_")
+            } bindContract Method.POST to { _ -> Response(Status.OK) }
+        }
+
+        approver.assertApproved(router(Request(Method.GET, "/basepath?the_api_key=somevalue")))
+    }
+
+    // this serves as an example of how the KondorJsonToJsonSchema can be used to render the OpenApi3 contract
+    private class KondorOpenApi3Renderer(
+        kondorJson: KondorJson,
+        private val delegate: OpenApi3ApiRenderer<JsonNode>,
+        refLocationPrefix: String = "components/schemas",
+    ) : ApiRenderer<Api<JsonNode>, JsonNode> by delegate {
+        private val jsonToJsonSchema = KondorJsonSchemaCreator(kondorJson, refLocationPrefix)
+
+        override fun toSchema(
+            obj: Any,
+            overrideDefinitionId: String?,
+            refModelNamePrefix: String?,
+        ): JsonSchema<JsonNode> {
+            return jsonToJsonSchema.toSchema(obj, overrideDefinitionId, refModelNamePrefix)
+        }
+    }
+}

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.duplicate schema models are not rendered.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.duplicate schema models are not rendered.approved
@@ -1,0 +1,85 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "title",
+    "version": "1.2",
+    "description": "module description"
+  },
+  "tags": [
+  ],
+  "paths": {
+    "/{enum}": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          ""
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/enum"
+            },
+            "in": "path",
+            "name": "enum",
+            "required": true,
+            "description": null
+          }
+        ],
+        "responses": {
+        },
+        "security": [
+        ],
+        "operationId": "get_enum",
+        "deprecated": false
+      },
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          ""
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/enum"
+            },
+            "in": "path",
+            "name": "enum",
+            "required": true,
+            "description": null
+          }
+        ],
+        "responses": {
+        },
+        "security": [
+        ],
+        "operationId": "post_enum",
+        "deprecated": false
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "enum": {
+        "example": "bar",
+        "type": "string",
+        "enum": [
+          "bar",
+          "bing"
+        ]
+      }
+    },
+    "securitySchemes": {
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8000",
+      "description": ""
+    }
+  ],
+  "x-extension": [
+    "extensionField"
+  ]
+}

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
@@ -1,0 +1,1112 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "title",
+    "version": "1.2",
+    "description": "module description"
+  },
+  "tags": [
+    {
+      "name": "hello",
+      "description": "world"
+    },
+    {
+      "name": "tag1",
+      "description": null
+    },
+    {
+      "name": "tag3",
+      "description": "tag3 description"
+    }
+  ],
+  "paths": {
+    "/basepath/and_auth": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "and1": [
+            ],
+            "and2": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathAnd_auth",
+        "deprecated": false
+      }
+    },
+    "/basepath/basic_auth": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "basicAuth": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathBasic_auth",
+        "deprecated": false
+      }
+    },
+    "/basepath/bearer_auth": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "bearerAuth": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathBearer_auth",
+        "deprecated": false
+      }
+    },
+    "/basepath/body_form": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "b": {
+                    "type": "boolean",
+                    "description": "booleanField"
+                  },
+                  "i": {
+                    "type": "array",
+                    "description": "intField",
+                    "items": {
+                      "type": "integer"
+                    }
+                  },
+                  "s": {
+                    "type": "string",
+                    "description": "stringField"
+                  },
+                  "e": {
+                    "type": "string",
+                    "description": "enumField"
+                  },
+                  "j": {
+                    "type": "object",
+                    "description": "jsonField"
+                  }
+                },
+                "required": [
+                  "b",
+                  "j"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathBody_form",
+        "deprecated": false
+      }
+    },
+    "/basepath/body_form_example": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "b": {
+                    "type": "boolean",
+                    "description": "booleanField"
+                  },
+                  "j": {
+                    "type": "object",
+                    "description": "jsonField"
+                  }
+                },
+                "required": [
+                  "b",
+                  "j"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathBody_form_example",
+        "deprecated": false
+      }
+    },
+    "/basepath/body_json_list_schema": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": [
+                {
+                  "aNumberField": 123
+                }
+              ],
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/generatedDefinitionId1"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathBody_json_list_schema",
+        "deprecated": false
+      }
+    },
+    "/basepath/body_json_noschema": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathBody_json_noschema",
+        "deprecated": false
+      }
+    },
+    "/basepath/body_json_response": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "normal",
+            "content": {
+              "application/json": {
+                "example": {
+                  "aNullField": null,
+                  "aNumberField": 123
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/generatedDefinitionId1"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathBody_json_response",
+        "deprecated": false
+      }
+    },
+    "/basepath/body_json_schema": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "anAnotherObject": {
+                  "aNullField": null,
+                  "aNumberField": 123
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/prefix_someDefinitionId"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathBody_json_schema",
+        "deprecated": false
+      }
+    },
+    "/basepath/body_negotiated": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "custom/v1": {
+              "schema": {
+              }
+            },
+            "custom/v2": {
+              "schema": {
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "custom/v1": {
+                "schema": {
+                }
+              },
+              "custom/v2": {
+                "schema": {
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathBody_negotiated",
+        "deprecated": false
+      }
+    },
+    "/basepath/body_receiving_string": {
+      "post": {
+        "summary": "body_receiving_string",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "text/plain": {
+              "schema": {
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathBody_receiving_string",
+        "deprecated": false
+      }
+    },
+    "/basepath/body_string": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "getBasepathBody_string",
+        "deprecated": false
+      }
+    },
+    "/basepath/callback_with_body": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathCallback_with_body",
+        "deprecated": false,
+        "callbacks": {
+          "foobar": {
+            "/doo": {
+              "post": {
+                "summary": "<unknown>",
+                "description": null,
+                "parameters": [
+                ],
+                "requestBody": {
+                  "content": {
+                    "application/json": {
+                      "example": [
+                        {
+                          "aNumberField": 123
+                        }
+                      ],
+                      "schema": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/components/schemas/generatedDefinitionId1"
+                        }
+                      }
+                    }
+                  },
+                  "required": true
+                },
+                "responses": {
+                  "200": {
+                    "description": "normal",
+                    "content": {
+                      "application/json": {
+                        "example": {
+                          "aNullField": null,
+                          "aNumberField": 123
+                        },
+                        "schema": {
+                          "$ref": "#/components/schemas/generatedDefinitionId1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "deprecated": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "/basepath/cookies": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "cookie",
+            "name": "b",
+            "required": true,
+            "description": "requiredCookie"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "cookie",
+            "name": "s",
+            "required": false,
+            "description": "optionalCookie"
+          }
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathCookies",
+        "deprecated": false
+      }
+    },
+    "/basepath/descriptions": {
+      "get": {
+        "summary": "endpoint",
+        "description": "some rambling description of what this thing actually does",
+        "tags": [
+          "tag1",
+          "tag3"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "echoMessage",
+        "deprecated": true
+      }
+    },
+    "/basepath/headers": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/e"
+            },
+            "in": "header",
+            "name": "e",
+            "required": false,
+            "description": "enumHeader"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/generatedDefinitionId2"
+            },
+            "in": "header",
+            "name": "j",
+            "required": false,
+            "description": "jsonHeader"
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "header",
+            "name": "b",
+            "required": true,
+            "description": "booleanHeader"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "header",
+            "name": "s",
+            "required": false,
+            "description": "stringHeader"
+          },
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "header",
+            "name": "i",
+            "required": false,
+            "description": "intHeader"
+          }
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathHeaders",
+        "deprecated": false
+      }
+    },
+    "/basepath/multipart-fields": {
+      "put": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "stringField": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "fileField": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "jsonField": {
+                    "type": "object"
+                  }
+                },
+                "required": [
+                  "stringField",
+                  "fileField",
+                  "jsonField"
+                ]
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "putBasepathMultipart_fields",
+        "deprecated": false
+      }
+    },
+    "/basepath/nometa": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "getBasepathNometa",
+        "deprecated": false
+      }
+    },
+    "/basepath/oauth2_auth": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "oauthSecurityAuthCode": [
+              "user"
+            ]
+          }
+        ],
+        "operationId": "postBasepathOauth2_auth",
+        "deprecated": false
+      }
+    },
+    "/basepath/or_auth": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "or1": [
+            ]
+          },
+          {
+            "or2": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathOr_auth",
+        "deprecated": false
+      }
+    },
+    "/basepath/paths/{firstName}/bertrand/{age}/{foo}": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/foo"
+            },
+            "in": "path",
+            "name": "foo",
+            "required": true,
+            "description": null
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "name": "firstName",
+            "required": true,
+            "description": null
+          },
+          {
+            "schema": {
+              "type": "boolean"
+            },
+            "in": "path",
+            "name": "age",
+            "required": true,
+            "description": null
+          }
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathPaths_firstName_Bertrand_age__foo",
+        "deprecated": false
+      }
+    },
+    "/basepath/produces_and_consumes": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "getBasepathProduces_and_consumes",
+        "deprecated": false
+      }
+    },
+    "/basepath/queries": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "$ref": "#/components/schemas/e"
+            },
+            "in": "query",
+            "name": "e",
+            "required": false,
+            "description": "enumQuery"
+          },
+          {
+            "schema": {
+              "$ref": "#/components/schemas/generatedDefinitionId2"
+            },
+            "in": "query",
+            "name": "j",
+            "required": false,
+            "description": "jsonQuery"
+          },
+          {
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "boolean"
+              }
+            },
+            "in": "query",
+            "name": "b",
+            "required": true,
+            "description": "booleanQuery"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "in": "query",
+            "name": "s",
+            "required": false,
+            "description": "stringQuery"
+          },
+          {
+            "schema": {
+              "type": "integer"
+            },
+            "in": "query",
+            "name": "i",
+            "required": false,
+            "description": "intQuery"
+          },
+          {
+            "schema": {
+              "type": "array",
+              "items": {
+                "example": "bar",
+                "type": "string",
+                "enum": [
+                  "bar",
+                  "bing"
+                ]
+              }
+            },
+            "in": "query",
+            "name": "el",
+            "required": false,
+            "description": "enumQueryList"
+          }
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathQueries",
+        "deprecated": false
+      }
+    },
+    "/basepath/returning": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "403": {
+            "description": "no way jose",
+            "content": {
+              "application/json": {
+                "example": {
+                  "aString": "a message of some kind"
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/generatedDefinitionId3"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "postBasepathReturning",
+        "deprecated": false
+      }
+    }
+  },
+  "webhooks": {
+    "foobar": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": [
+                {
+                  "aNumberField": 123
+                }
+              ],
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/generatedDefinitionId1"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "normal",
+            "content": {
+              "application/json": {
+                "example": {
+                  "aNullField": null,
+                  "aNumberField": 123
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/generatedDefinitionId1"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": false
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "foo": {
+        "example": "bar",
+        "type": "string",
+        "enum": [
+          "bar",
+          "bing"
+        ]
+      },
+      "e": {
+        "example": "bar",
+        "type": "string",
+        "enum": [
+          "bar",
+          "bing"
+        ]
+      },
+      "generatedDefinitionId2": {
+        "type": "object",
+        "required": [
+        ],
+        "properties": {
+        }
+      },
+      "generatedDefinitionId1": {
+        "type": "object",
+        "required": [
+        ],
+        "properties": {
+          "aNumberField": {
+            "type": "integer",
+            "example": 123
+          }
+        }
+      },
+      "prefix_generatedDefinitionId1": {
+        "type": "object",
+        "required": [
+        ],
+        "properties": {
+          "aNumberField": {
+            "type": "integer",
+            "example": 123
+          }
+        }
+      },
+      "prefix_someDefinitionId": {
+        "type": "object",
+        "required": [
+        ],
+        "properties": {
+          "anAnotherObject": {
+            "$ref": "#/components/schemas/prefix_generatedDefinitionId1"
+          }
+        }
+      },
+      "generatedDefinitionId3": {
+        "type": "object",
+        "required": [
+        ],
+        "properties": {
+          "aString": {
+            "type": "string",
+            "example": "a message of some kind"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "basicAuth": {
+        "scheme": "basic",
+        "type": "http"
+      },
+      "and1": {
+        "scheme": "basic",
+        "type": "http"
+      },
+      "and2": {
+        "scheme": "basic",
+        "type": "http"
+      },
+      "or1": {
+        "scheme": "basic",
+        "type": "http"
+      },
+      "or2": {
+        "scheme": "basic",
+        "type": "http"
+      },
+      "oauthSecurityAuthCode": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://github.com/login/oauth/authorize",
+            "tokenUrl": "https://github.com/login/oauth/access_token",
+            "scopes": {
+              "user": ""
+            }
+          }
+        }
+      },
+      "bearerAuth": {
+        "scheme": "bearer",
+        "type": "http"
+      },
+      "api_key": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "the_api_key"
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8000",
+      "description": ""
+    }
+  ],
+  "x-extension": [
+    "extensionField"
+  ]
+}

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders json schema bodies that use data classes.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders json schema bodies that use data classes.approved
@@ -1,0 +1,137 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "title",
+    "version": "1.2",
+    "description": "module description"
+  },
+  "tags": [
+  ],
+  "paths": {
+    "/basepath/body_json_schema_data_class": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "nestedObject": {
+                  "aNullField": null,
+                  "aNumberField": 123
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/TopLevelObject"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+        },
+        "security": [
+        ],
+        "operationId": "postBasepathBody_json_schema_data_class",
+        "deprecated": false
+      }
+    },
+    "/basepath/body_json_schema_data_class_with_definition_id": {
+      "post": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "example": {
+                "nestedObject": {
+                  "aNullField": null,
+                  "aNumberField": 123
+                }
+              },
+              "schema": {
+                "$ref": "#/components/schemas/a_prefix_OverriddenDefinitionId"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+        },
+        "security": [
+        ],
+        "operationId": "postBasepathBody_json_schema_data_class_with_definition_id",
+        "deprecated": false
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TopLevelObject": {
+        "type": "object",
+        "properties": {
+          "nestedObject": {
+            "type": "object",
+            "properties": {
+              "aNullField": {
+                "type": "string"
+              },
+              "aNumberField": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "aNumberField"
+            ]
+          }
+        },
+        "required": [
+          "nestedObject"
+        ]
+      },
+      "a_prefix_OverriddenDefinitionId": {
+        "type": "object",
+        "properties": {
+          "nestedObject": {
+            "type": "object",
+            "properties": {
+              "aNullField": {
+                "type": "string"
+              },
+              "aNumberField": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "aNumberField"
+            ]
+          }
+        },
+        "required": [
+          "nestedObject"
+        ]
+      }
+    },
+    "securitySchemes": {
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8000",
+      "description": ""
+    }
+  ],
+  "x-extension": [
+    "extensionField"
+  ]
+}

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.when enabled renders description including its own path.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.when enabled renders description including its own path.approved
@@ -1,0 +1,74 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "title",
+    "version": "1.2",
+    "description": "module description"
+  },
+  "tags": [
+  ],
+  "paths": {
+    "": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          ""
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "get",
+        "deprecated": false
+      }
+    },
+    "/docs": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          ""
+        ],
+        "parameters": [
+        ],
+        "responses": {
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "description",
+        "deprecated": false
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+    },
+    "securitySchemes": {
+      "api_key": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "the_api_key"
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8000",
+      "description": ""
+    }
+  ],
+  "x-extension": [
+    "extensionField"
+  ]
+}

--- a/http4k-format/kondor-json/src/main/kotlin/org/http4k/format/KondorJson.kt
+++ b/http4k-format/kondor-json/src/main/kotlin/org/http4k/format/KondorJson.kt
@@ -180,7 +180,7 @@ class KondorJson(
             "JsonConverter for '$target' has not been registered"
         } as JsonConverter<T, *>
 
-    private fun converterFor(input: Any): JsonConverter<*, *> =
+    fun converterFor(input: Any): JsonConverter<*, *> =
         requireNotNull(converters.entries.find { it.key.isInstance(input) }) {
             "JsonConverter for '${input::class}' has not been registered"
         }.value


### PR DESCRIPTION
This PR adds a KondorJsonSchemaCreator which can be used to produce well defined schemas via Kondor's inbuilt schema generation capabilities.