### PR TITLE
Static handlers serve an index.html file from a subdirectory

### DIFF
--- a/http4k-core/src/test/kotlin/org/http4k/routing/StaticPrefixRoutingTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/routing/StaticPrefixRoutingTest.kt
@@ -4,7 +4,6 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
-import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.core.Status.Companion.OK
 import org.http4k.routing.ResourceLoader.Companion.Classpath
 import org.junit.jupiter.api.BeforeEach
@@ -49,7 +48,8 @@ class StaticPrefixRoutingTest {
     @Test
     fun `test static resource bar - bar`() {
         val result = app(Request(GET, "/bar/bar/"))
-        assertThat(result.status, equalTo(NOT_FOUND)) // because index.html is read only for root
+        assertThat(result.status, equalTo(OK))
+        assertThat(result.bodyString(), equalTo("contents of bar/bar/index.html"))
     }
 
     @Test

--- a/http4k-core/src/testFixtures/kotlin/org/http4k/routing/StaticRoutingHttpHandlerTest.kt
+++ b/http4k-core/src/testFixtures/kotlin/org/http4k/routing/StaticRoutingHttpHandlerTest.kt
@@ -186,12 +186,44 @@ open class StaticRoutingHttpHandlerTest : RoutingHttpHandlerContract() {
     }
 
     @Test
-    fun `cannot serve a directory`() {
+    fun `Classpath ResourceLoader cannot serve a directory without an index file`() {
         val handler = "/svc" bind static()
-        val request = Request(GET, of("/svc/org"))
+        val request = Request(GET, of("/svc/org/http4k"))
         val criteria = hasStatus(NOT_FOUND)
 
         assertThat(handler.matchAndInvoke(request), absent())
+        assertThat(handler(request), criteria)
+    }
+
+    @Test
+    fun `Classpath ResourceLoader can serve a directory with an index file`() {
+        val handler = "/svc" bind static()
+        val request = Request(GET, of("/svc/org"))
+        val criteria =
+            hasStatus(OK) and hasBody("hello from the io index.html") and hasHeader("Content-type", TEXT_HTML.value)
+
+        assertThat(handler.matchAndInvoke(request), present(criteria))
+        assertThat(handler(request), criteria)
+    }
+
+    @Test
+    fun `Directory ResourceLoader cannot serve a directory without an index file`() {
+        val handler = "/svc" bind static(ResourceLoader.Directory("../http4k-core/src/test/resources"))
+        val request = Request(GET, of("/svc/org/http4k"))
+        val criteria = hasStatus(NOT_FOUND)
+
+        assertThat(handler.matchAndInvoke(request), absent())
+        assertThat(handler(request), criteria)
+    }
+
+    @Test
+    fun `Directory ResourceLoader can serve a directory with an index file`() {
+        val handler = "/svc" bind static(ResourceLoader.Directory("../http4k-core/src/test/resources"))
+        val request = Request(GET, of("/svc/org"))
+        val criteria =
+            hasStatus(OK) and hasBody("hello from the io index.html") and hasHeader("Content-type", TEXT_HTML.value)
+
+        assertThat(handler.matchAndInvoke(request), present(criteria))
         assertThat(handler(request), criteria)
     }
 


### PR DESCRIPTION
I had to attempt to load the directory path, and then load it with `/index.html` if that was null - because it's not possible to determine whether a path is a directory or not when doing `javaClass.getResource`.

I have still left `convertPath` adding `/index.html` when it encounters `/` or an empty string. All tests will pass without this, but it seemed to me that the root path will always be `/index.html` so convertPath is doing the right thing. By leaving this in convertPath it means that `load(...)` will be called once with `/index.html` rather than being called twice.

Another approach would have been to make determining whether to add `/index.html` to the path the responsibility of the `ResourceLoader`. The `ResourceLoader.Directory` is able to determine whether the path is a directory or not and so it could serve up the index.html in a single step.

Right now the only reason that directories aren't being served up is because they don't usually have a suffix, are being categorised as `OCTET_STREAM` and then are disregarded. Things could be weird if someone has a directory called `/foo.html/`. I don't think I've made this any worse.