### PR TITLE
Fix bug in webdriver form submission + a method for relative Uri resolution.

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
@@ -129,7 +129,7 @@ fun Uri.relative(relative: Uri): Uri {
 private fun String.normalizePath(): String {
     fun String.replacePrefix(original: String, newPrefix: String): String = newPrefix + (removePrefix(original))
     fun String.removeLastSegment(): String = lastIndexOf('/').let { this.slice(0..<it) }
-    fun String.secondIndexOf(char: Char): Int = indexOf(char, indexOf(char) + 1);
+    fun String.secondIndexOf(char: Char): Int = indexOf(char, indexOf(char) + 1)
     fun String.firstSegment() = when {
         startsWith("/") -> if (secondIndexOf('/') == -1) this else slice(0..<secondIndexOf('/'))
         else -> if (indexOf('/') == -1) this else slice(0..<indexOf('/'))

--- a/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
@@ -108,7 +108,7 @@ fun Uri.appendToPath(pathToAppend: String?): Uri =
 
 fun Uri.relative(relative: String): Uri = if (relative == "") this else this.relative(Uri.of(relative))
 
-// Impletmentation of relative resolution as per [RFC3986 5.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.2)
+// Implementation of relative resolution as per [RFC3986 5.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.2)
 fun Uri.relative(relative: Uri): Uri {
     fun String.merge(relativePath: String): String {
         return when {

--- a/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
@@ -105,3 +105,65 @@ fun Uri.extend(uri: Uri): Uri =
 fun Uri.appendToPath(pathToAppend: String?): Uri =
     if (pathToAppend.isNullOrBlank()) this
     else copy(path = (path.removeSuffix("/") + "/" + pathToAppend.removePrefix("/")))
+
+fun Uri.relative(relative: String): Uri = if (relative == "") this else this.relative(Uri.of(relative))
+
+// Impletmentation of relative resolution as per [RFC3986 5.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.2)
+fun Uri.relative(relative: Uri): Uri {
+    fun String.merge(relativePath: String): String {
+        return when {
+            this == "" -> if (relativePath[0] == '/') relativePath else "/$relativePath"
+            else -> lastIndexOf('/').let { this.slice(0..(it)) } + relativePath
+        }
+    }
+
+    return when {
+        relative.scheme != "" -> relative
+        relative.authority != "" -> Uri(scheme, relative.userInfo, relative.host, relative.port, relative.path, relative.query, relative.fragment)
+        relative.path == "" -> Uri(scheme, userInfo, host, port, path, if (relative.query == "") query else relative.query, relative.fragment)
+        relative.path.startsWith("/") -> Uri(scheme, userInfo, host, port, relative.path.normalizePath(), relative.query, relative.fragment)
+        else -> Uri(scheme, userInfo, host, port, path.merge(relative.path).normalizePath(), relative.query, relative.fragment)
+    }
+}
+
+private fun String.normalizePath(): String {
+    fun String.replacePrefix(original: String, newPrefix: String): String = newPrefix + (removePrefix(original))
+    fun String.removeLastSegment(): String = lastIndexOf('/').let { this.slice(0..<it) }
+    fun String.secondIndexOf(char: Char): Int = indexOf(char, indexOf(char) + 1);
+    fun String.firstSegment() = when {
+        startsWith("/") -> if (secondIndexOf('/') == -1) this else slice(0..<secondIndexOf('/'))
+        else -> if (indexOf('/') == -1) this else slice(0..<indexOf('/'))
+    }
+
+    var input = this
+    var output = ""
+
+    while (input.isNotBlank()) {
+        when {
+            input.startsWith("./") -> input = input.removePrefix("./")
+            input.startsWith("../") -> input = input.removePrefix("../")
+            input.startsWith("/./") -> input = input.replacePrefix("/./", "/")
+            input.startsWith("/../") -> {
+                input = input.replacePrefix("/../", "/")
+                output = output.removeLastSegment()
+            }
+            input.firstSegment() == "/.." -> {
+                input = input.replacePrefix("/..", "/")
+                output = output.removeLastSegment()
+            }
+
+            input.firstSegment() == "/." -> input = input.replacePrefix("/.", "/")
+
+            input == "." -> input = ""
+            input == ".." -> input = ""
+            else -> {
+                val newFirstSegment: String = input.firstSegment()
+
+                input = input.removePrefix(newFirstSegment)
+                output += newFirstSegment
+            }
+        }
+    }
+
+    return output
+}

--- a/http4k-core/src/test/kotlin/org/http4k/core/UriTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/UriTest.kt
@@ -4,6 +4,9 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 
 class UriTest {
     @Test
@@ -77,11 +80,13 @@ class UriTest {
 
     @Test
     fun can_remove_parameter() {
-        assertThat(Uri.of(value = "http://ignore")
-            .query("a", "b")
-            .query("c", "d")
-            .query("a", "c")
-            .removeQuery("a").toString(), equalTo("http://ignore?c=d"))
+        assertThat(
+            Uri.of(value = "http://ignore")
+                .query("a", "b")
+                .query("c", "d")
+                .query("a", "c")
+                .removeQuery("a").toString(), equalTo("http://ignore?c=d")
+        )
     }
 
     @Test
@@ -107,8 +112,14 @@ class UriTest {
 
     @Test
     fun `can extend existing uri`() {
-        assertThat(Uri.of("http://ignore?foo=bar").extend(Uri.of("/?abc=xyz#bob")), equalTo(Uri.of("http://ignore/?foo=bar&abc=xyz#bob")))
-        assertThat(Uri.of("http://ignore?foo=bar#bob").extend(Uri.of("/?abc=xyz")), equalTo(Uri.of("http://ignore/?foo=bar&abc=xyz#bob")))
+        assertThat(
+            Uri.of("http://ignore?foo=bar").extend(Uri.of("/?abc=xyz#bob")),
+            equalTo(Uri.of("http://ignore/?foo=bar&abc=xyz#bob"))
+        )
+        assertThat(
+            Uri.of("http://ignore?foo=bar#bob").extend(Uri.of("/?abc=xyz")),
+            equalTo(Uri.of("http://ignore/?foo=bar&abc=xyz#bob"))
+        )
     }
 
     @Test
@@ -118,5 +129,64 @@ class UriTest {
         val queryParametersEncodedUri = unEncodedUri.queryParametersEncoded()
         assertThat(queryParametersEncodedUri.toString(), equalTo(encodedUri))
         assertThat(queryParametersEncodedUri.queries(), equalTo(listOf("q1" to "encode me pls", "q2" to "encode me 2")))
+    }
+
+    // Test cases adapted from [reference resolution examples of RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-5.4)
+    @ParameterizedTest(name = "base {0}, relative path {1}, maps to {2} ")
+    @MethodSource("relativeUriTestData")
+    fun `handles relative URIs`(baseUri: Uri, relativeUri: String, expected: Uri) {
+        assertThat(baseUri.relative(relativeUri), equalTo(expected))
+    }
+
+    companion object {
+        @JvmStatic
+        fun relativeUriTestData(): List<Arguments> {
+            return listOf(
+                // [Normal Examples](https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.1)
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "", Uri.of("http://a/b/c/d?q#f")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "http://e/f/g/h?i#j", Uri.of("http://e/f/g/h?i#j")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g:h", Uri.of("g:h")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g", Uri.of("http://a/b/c/g")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "./g", Uri.of("http://a/b/c/g")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g/", Uri.of("http://a/b/c/g/")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "/g", Uri.of("http://a/g")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "//g", Uri.of("http://g")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "?y", Uri.of("http://a/b/c/d?y")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g?y", Uri.of("http://a/b/c/g?y")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g?y/./x", Uri.of("http://a/b/c/g?y/./x")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "#s", Uri.of("http://a/b/c/d?q#s")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g#s", Uri.of("http://a/b/c/g#s")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g#s/./x", Uri.of("http://a/b/c/g#s/./x")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g?y#s", Uri.of("http://a/b/c/g?y#s")),
+//                Arguments.of(Uri.of("http://a/b/c/d?q#f"), ";x", Uri.of("http://a/b/c/d;x")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g;x", Uri.of("http://a/b/c/g;x")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g;x?y#s", Uri.of("http://a/b/c/g;x?y#s")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), ".", Uri.of("http://a/b/c/")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "./", Uri.of("http://a/b/c/")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "..", Uri.of("http://a/b/")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "../", Uri.of("http://a/b/")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "../g", Uri.of("http://a/b/g")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "../..", Uri.of("http://a/")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "../../", Uri.of("http://a/")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "../../g", Uri.of("http://a/g")),
+
+                // [Abnormal Examples](https://datatracker.ietf.org/doc/html/rfc3986#section-5.4.2)
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "../../../g", Uri.of("http://a/g")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "./../../../g", Uri.of("http://a/g")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "/./g", Uri.of("http://a/g")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "/../g", Uri.of("http://a/g")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g.", Uri.of("http://a/b/c/g.")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), ".g", Uri.of("http://a/b/c/.g")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g..", Uri.of("http://a/b/c/g..")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "..g", Uri.of("http://a/b/c/..g")),
+
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "./../g", Uri.of("http://a/b/g")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "./g/.", Uri.of("http://a/b/c/g/")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g/./h", Uri.of("http://a/b/c/g/h")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g/../h", Uri.of("http://a/b/c/h")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), "g;x=1/./y", Uri.of("http://a/b/c/g;x=1/y")),
+                Arguments.of(Uri.of("http://a/b/c/d?q#f"), ".g;x=1/../y", Uri.of("http://a/b/c/y")),
+                )
+        }
     }
 }

--- a/http4k-testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
+++ b/http4k-testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
@@ -84,7 +84,7 @@ data class JSoupWebElement(private val navigate: Navigate, private val getURL: G
             val formActionUri = Uri.of(actionString)
             val current = getURL()?.let { Uri.of(it) }
             val formUri = current?.relative(formActionUri) ?: formActionUri
-            val postRequest = Request(method, formUri.toString()).with(body of form)
+            val postRequest = Request(method, formUri).with(body of form)
 
             if (method == POST) navigate(postRequest)
             else navigate(Request(method, formUri.query(postRequest.bodyString())).body(""))

--- a/http4k-testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
+++ b/http4k-testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
@@ -6,6 +6,7 @@ import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
 import org.http4k.core.Uri
+import org.http4k.core.relative
 import org.http4k.core.with
 import org.http4k.lens.FormField
 import org.http4k.lens.Validator
@@ -79,17 +80,14 @@ data class JSoupWebElement(private val navigate: Navigate, private val getURL: G
                 *(form.fields.map { FormField.multi.optional(it.key) }.toTypedArray())
             ).toLens()
 
-            val formTarget = Uri.of(it.element.attr("action") ?: "")
-            val current = getURL()
-            val action = when {
-                formTarget.host == "" && formTarget.path == "" && current != null -> Uri.of(current)
-                formTarget.host == "" && current != null -> Uri.of(current).path(formTarget.path)
-                else -> formTarget
-            }
-            val postRequest = Request(method, action.toString()).with(body of form)
+            val actionString = it.element.attr("action") ?: ""
+            val formActionUri = Uri.of(actionString)
+            val current = getURL()?.let { Uri.of(it) }
+            val formUri = current?.relative(formActionUri) ?: formActionUri
+            val postRequest = Request(method, formUri.toString()).with(body of form)
 
             if (method == POST) navigate(postRequest)
-            else navigate(Request(method, action.query(postRequest.bodyString())).body(""))
+            else navigate(Request(method, formUri.query(postRequest.bodyString())).body(""))
         }
     }
 
@@ -118,7 +116,8 @@ data class JSoupWebElement(private val navigate: Navigate, private val getURL: G
 
             isA("input") && element.attr("type") == "radio" -> {
                 if (element.hasAttr("name")) {
-                    current("form")?.findElements(By.tagName("input"))?.filter { it.getAttribute("name") == element.attr("name") }?.forEach { it.clear() }
+                    current("form")?.findElements(By.tagName("input"))
+                        ?.filter { it.getAttribute("name") == element.attr("name") }?.forEach { it.clear() }
                 }
                 element.attr("checked", "checked")
             }


### PR DESCRIPTION
Hey!

Noticed a bug in the way that the webdriver resolves a URIs from the `action` attribute of a form. Thought the best way to fix it would be to implement relative URIs as in [RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-5.2), which I stuck as an extension function on a `Uri` and made public as it seemed useful.

Should have some more tomorrow.

Thanks!