### PR TITLE
Adding a space between method name and URI when naming spans for Opentelemetry tracing

### DIFF
--- a/http4k-opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
+++ b/http4k-opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
@@ -126,7 +126,7 @@ internal fun <T : HttpMessage> getter(textMapPropagator: TextMapPropagator) = ob
 
 val defaultSpanNamer: (Request) -> String = {
     when (it) {
-        is RoutedRequest -> it.method.name + it.xUriTemplate
+        is RoutedRequest -> it.method.name + " " + it.xUriTemplate
         else -> it.method.name
     }
 }


### PR DESCRIPTION
Hi! 

Spotted this while setting up tracing. 
Currently, this ends up by default generating span names like "GET/liveness" rather than "GET /liveness"

Thanks!