### PR TITLE
Multipart forms in the webdriver, including sending files

### DIFF
--- a/http4k-testing/webdriver/build.gradle.kts
+++ b/http4k-testing/webdriver/build.gradle.kts
@@ -4,4 +4,7 @@ dependencies {
     api(project(":http4k-core"))
     api("org.seleniumhq.selenium:selenium-api:_")
     api("org.jsoup:jsoup:_")
+    implementation(project(mapOf("path" to ":http4k-multipart")))
+    testImplementation(project(mapOf("path" to ":http4k-multipart")))
+    testImplementation(project(mapOf("path" to ":http4k-multipart")))
 }

--- a/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverFormTest.kt
+++ b/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverFormTest.kt
@@ -1,0 +1,252 @@
+package org.http4k.webdriver
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.startsWith
+import org.http4k.core.Method.GET
+import org.http4k.core.Method.POST
+import org.http4k.core.MultipartFormBody
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.core.Uri
+import org.http4k.routing.bind
+import org.http4k.routing.routes
+import org.junit.jupiter.api.Test
+import org.openqa.selenium.By
+import java.io.File
+import java.nio.file.Files
+import kotlin.io.path.createTempFile
+
+class Http4kWebDriverFormTest {
+    private val driver = Http4kWebDriver({ req ->
+        val body = File("src/test/resources/test.html").readText()
+        Response(Status.OK).body(
+            body
+                .replace("FORMMETHOD", POST.name)
+                .replace("THEMETHOD", req.method.name)
+                .replace("THEBODY", req.bodyString())
+                .replace("THEURL", req.uri.toString())
+                .replace("THETIME", System.currentTimeMillis().toString())
+                .replace("ACTION", "action=\"/form\"")
+        )
+    })
+
+    @Test
+    fun `POSTing a form prefixes with the original host in the URL`() {
+        val driver = Http4kWebDriver(
+            routes(
+                "/submit" bind { Response(Status.OK).body(it.uri.toString()) },
+                "/" bind { req ->
+                    val body = File("src/test/resources/test.html").readText()
+                    Response(Status.OK).body(
+                        body
+                            .replace("FORMMETHOD", POST.name)
+                            .replace("THEMETHOD", req.method.name)
+                            .replace("THEBODY", req.bodyString())
+                            .replace("THEURL", req.uri.toString())
+                            .replace("THETIME", System.currentTimeMillis().toString())
+                            .replace("ACTION", """action="/submit"""")
+                    )
+                })
+        )
+        driver.navigate().to(Uri.of("http://host/"))
+        driver.findElement(By.id("button"))!!.submit()
+        assertThat(
+            driver.pageSource,
+            equalTo("http://host/submit")
+        )
+    }
+
+    @Test
+    fun `POST form`() {
+        driver.get("https://example.com/bob")
+        driver.findElement(By.id("button"))!!.submit()
+        driver.assertOnPage("https://example.com/form")
+        assertThat(
+            driver.findElement(By.tagName("thebody"))!!.text,
+            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
+        )
+        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+    }
+
+    @Test
+    fun `POST form via button click`() {
+        driver.get("/bob")
+        driver.findElement(By.id("resetbutton"))!!.click()
+        driver.assertOnPage("/bob")
+        driver.findElement(By.id("button"))!!.click()
+        driver.assertOnPage("/form")
+        assertThat(
+            driver.findElement(By.tagName("thebody"))!!.text,
+            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
+        )
+        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+    }
+
+    @Test
+    fun `POST form with empty action`() {
+        var loadCount = 0
+        val driver = Http4kWebDriver({ req ->
+            loadCount++
+            val body = File("src/test/resources/test.html").readText()
+            Response(Status.OK).body(
+                body
+                    .replace("FORMMETHOD", POST.name)
+                    .replace("THEMETHOD", req.method.name)
+                    .replace("THEBODY", req.bodyString())
+                    .replace("THEURL", req.uri.toString())
+                    .replace("THETIME", System.currentTimeMillis().toString())
+                    .replace("ACTION", "action")
+            )
+        })
+
+        val n0 = loadCount
+        driver.get("http://example.com/bob")
+        driver.findElement(By.id("button"))!!.submit()
+        driver.assertOnPage("http://example.com/bob")
+        assertThat(loadCount, equalTo(n0 + 2))
+        assertThat(
+            driver.findElement(By.tagName("thebody"))!!.text,
+            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
+        )
+        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+    }
+
+    @Test
+    fun `POST form with action set to empty string`() {
+        var loadCount = 0
+        val driver = Http4kWebDriver({ req ->
+            loadCount++
+            val body = File("src/test/resources/test.html").readText()
+            Response(Status.OK).body(
+                body
+                    .replace("FORMMETHOD", POST.name)
+                    .replace("THEMETHOD", req.method.name)
+                    .replace("THEBODY", req.bodyString())
+                    .replace("THEURL", req.uri.toString())
+                    .replace("THETIME", System.currentTimeMillis().toString())
+                    .replace("ACTION", "action=\"\"")
+            )
+        })
+        val n0 = loadCount
+        driver.get("http://127.0.0.1/bob")
+        driver.findElement(By.id("button"))!!.submit()
+        driver.assertOnPage("http://127.0.0.1/bob")
+        assertThat(loadCount, equalTo(n0 + 2))
+        assertThat(
+            driver.findElement(By.tagName("thebody"))!!.text,
+            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
+        )
+        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+    }
+
+    @Test
+    fun `POST form with action set to fragment with no leading slash replaces last part of current base path`() {
+        val driver = Http4kWebDriver({ req ->
+            val body = File("src/test/resources/test.html").readText()
+            Response(Status.OK).body(
+                body
+                    .replace("FORMMETHOD", POST.name)
+                    .replace("THEMETHOD", req.method.name)
+                    .replace("THEBODY", req.bodyString())
+                    .replace("THEURL", req.uri.toString())
+                    .replace("THETIME", System.currentTimeMillis().toString())
+                    .replace("ACTION", "action=\"fragmentWithNoLeadingSlash\"")
+            )
+        })
+
+        driver.get("http://example.com/bob/was/here/today")
+        driver.findElement(By.id("button"))!!.submit()
+        driver.assertCurrentUrl("http://example.com/bob/was/here/fragmentWithNoLeadingSlash")
+    }
+
+
+    @Test
+    fun `GET form`() {
+        val driver = Http4kWebDriver({ req ->
+            val body = File("src/test/resources/test.html").readText()
+            Response(Status.OK).body(
+                body
+                    .replace("FORMMETHOD", GET.name)
+                    .replace("THEMETHOD", req.method.name)
+                    .replace("THEBODY", req.bodyString())
+                    .replace("THEURL", req.uri.toString())
+                    .replace("THETIME", System.currentTimeMillis().toString())
+                    .replace("ACTION", "action=\"/form\"")
+            )
+        })
+
+        driver.get("/bob")
+        driver.findElement(By.id("button"))!!.submit()
+        driver.assertOnPage("/form?text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
+        assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo(""))
+        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("GET"))
+    }
+
+    @Test
+    fun `POST form with an empty text box`() {
+        driver.get("https://example.com/bob")
+        driver.findElement(By.tagName("textarea"))!!.sendKeys("")
+        driver.findElement(By.id("button"))!!.submit()
+        driver.assertOnPage("https://example.com/form")
+        assertThat(
+            driver.findElement(By.tagName("thebody"))!!.text,
+            equalTo("text1=textValue&checkbox1=checkbox&textarea1=&select1=option1&select1=option2&button=yes")
+        )
+        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+    }
+
+
+    // https://www.w3.org/TR/html401/interact/forms.html#h-17.13
+    @Test
+    fun `POST form via input of type 'submit' click`() {
+        driver.get("https://example.com/bob")
+        driver.findElement(By.id("input-submit"))!!.click()
+        driver.assertOnPage("https://example.com/form")
+        assertThat(
+            driver.findElement(By.tagName("thebody"))!!.text,
+            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2")
+        )
+        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+    }
+
+    @Test
+    fun `POST form - activated submit buttons ('input' elements) are submitted with the form`() {
+        driver.get("https://example.com/bob")
+        driver.findElement(By.id("only-send-when-activated"))!!.submit()
+        driver.assertOnPage("https://example.com/form")
+        assertThat(
+            driver.findElement(By.tagName("thebody"))!!.text,
+            equalTo("text1=textValue&checkbox1=checkbox&only-send-when-activated=only-send-when-activated&textarea1=textarea&select1=option1&select1=option2")
+        )
+        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+    }
+
+    @Test
+    fun `POST form - a form that has an 'enctype' of 'multipart form-data' transmits its data as a multipart form`() {
+        val driver = Http4kWebDriver({ req ->
+            val body = File("src/test/resources/file_upload_test.html").readText()
+            if (req.method == GET) return@Http4kWebDriver Response(Status.OK).body(body)
+
+            val formBody = MultipartFormBody.from(req)
+            val file = formBody.file("file")!!
+
+            Response(Status.OK).body(body
+                .replace("ENCODING", req.header("content-type")!!)
+                .replace("FILENAME", file.filename)
+                .replace("FILECONTENT", file.content.asString()))
+        })
+
+        val fileContent = "hello mum"
+        val filePath = createTempFile("file-upload-test", ".txt")
+        Files.newBufferedWriter(filePath).use { it.write(fileContent) }
+
+        driver.get("https://example.com/bob")
+        driver.findElement(By.tagName("input"))!!.sendKeys(filePath.toString())
+        driver.findElement(By.tagName("button"))!!.submit()
+
+        assertThat(driver, hasElement(By.tagName("theformencoding"), hasText(startsWith("multipart/form-data"))))
+        assertThat(driver, hasElement(By.tagName("thefilename"), hasText(equalTo(filePath.fileName.toString()))))
+        assertThat(driver, hasElement(By.tagName("thefilecontent"), hasText(equalTo(fileContent))))
+    }
+}

--- a/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverFormTest.kt
+++ b/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverFormTest.kt
@@ -51,10 +51,7 @@ class Http4kWebDriverFormTest {
         )
         driver.navigate().to(Uri.of("http://host/"))
         driver.findElement(By.id("button"))!!.submit()
-        assertThat(
-            driver.pageSource,
-            equalTo("http://host/submit")
-        )
+        assertThat(driver.pageSource, equalTo("http://host/submit"))
     }
 
     @Test
@@ -62,11 +59,8 @@ class Http4kWebDriverFormTest {
         driver.get("https://example.com/bob")
         driver.findElement(By.id("button"))!!.submit()
         driver.assertOnPage("https://example.com/form")
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+        assertThat(driver, showsWeSentTheBody("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes"))
+        assertThat(driver, showsWeUsedTheMethod("POST"))
     }
 
     @Test
@@ -76,11 +70,8 @@ class Http4kWebDriverFormTest {
         driver.assertOnPage("/bob")
         driver.findElement(By.id("button"))!!.click()
         driver.assertOnPage("/form")
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+        assertThat(driver, showsWeSentTheBody("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes"))
+        assertThat(driver, showsWeUsedTheMethod("POST"))
     }
 
     @Test
@@ -105,11 +96,8 @@ class Http4kWebDriverFormTest {
         driver.findElement(By.id("button"))!!.submit()
         driver.assertOnPage("http://example.com/bob")
         assertThat(loadCount, equalTo(n0 + 2))
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+        assertThat(driver, showsWeSentTheBody("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes"))
+        assertThat(driver, showsWeUsedTheMethod("POST"))
     }
 
     @Test
@@ -133,11 +121,8 @@ class Http4kWebDriverFormTest {
         driver.findElement(By.id("button"))!!.submit()
         driver.assertOnPage("http://127.0.0.1/bob")
         assertThat(loadCount, equalTo(n0 + 2))
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+        assertThat(driver, showsWeSentTheBody("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes"))
+        assertThat(driver, showsWeUsedTheMethod("POST"))
     }
 
     @Test
@@ -157,7 +142,7 @@ class Http4kWebDriverFormTest {
 
         driver.get("http://example.com/bob/was/here/today")
         driver.findElement(By.id("button"))!!.submit()
-        driver.assertCurrentUrl("http://example.com/bob/was/here/fragmentWithNoLeadingSlash")
+        assertThat(driver, hasCurrentUrl("http://example.com/bob/was/here/fragmentWithNoLeadingSlash"))
     }
 
 
@@ -179,8 +164,9 @@ class Http4kWebDriverFormTest {
         driver.get("/bob")
         driver.findElement(By.id("button"))!!.submit()
         driver.assertOnPage("/form?text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
-        assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo(""))
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("GET"))
+
+        assertThat(driver, showsWeSentTheBody(""))
+        assertThat(driver, showsWeUsedTheMethod("GET"))
     }
 
     @Test
@@ -189,11 +175,8 @@ class Http4kWebDriverFormTest {
         driver.findElement(By.tagName("textarea"))!!.sendKeys("")
         driver.findElement(By.id("button"))!!.submit()
         driver.assertOnPage("https://example.com/form")
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=&select1=option1&select1=option2&button=yes")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+        assertThat(driver, showsWeSentTheBody("text1=textValue&checkbox1=checkbox&textarea1=&select1=option1&select1=option2&button=yes"))
+        assertThat(driver, showsWeUsedTheMethod("POST"))
     }
 
 
@@ -203,11 +186,8 @@ class Http4kWebDriverFormTest {
         driver.get("https://example.com/bob")
         driver.findElement(By.id("input-submit"))!!.click()
         driver.assertOnPage("https://example.com/form")
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+        assertThat(driver, showsWeSentTheBody("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2"))
+        assertThat(driver, showsWeUsedTheMethod("POST"))
     }
 
     @Test
@@ -215,11 +195,10 @@ class Http4kWebDriverFormTest {
         driver.get("https://example.com/bob")
         driver.findElement(By.id("only-send-when-activated"))!!.submit()
         driver.assertOnPage("https://example.com/form")
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&only-send-when-activated=only-send-when-activated&textarea1=textarea&select1=option1&select1=option2")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
+        val expectedFormBody = "text1=textValue&checkbox1=checkbox&only-send-when-activated=only-send-when-activated&textarea1=textarea&select1=option1&select1=option2"
+
+        assertThat(driver, showsWeSentTheBody(expectedFormBody))
+        assertThat(driver, showsWeUsedTheMethod("POST"))
     }
 
     @Test
@@ -263,3 +242,6 @@ class Http4kWebDriverFormTest {
         assertThat(driver, hasElement(By.tagName("theotherformfields"), hasText(equalTo(expectedOtherFields))))
     }
 }
+
+private fun showsWeSentTheBody(body: String) = hasElement(By.tagName("thebody"), hasText(equalTo(body)))
+private fun showsWeUsedTheMethod(method: String) = hasElement(By.tagName("themethod"), hasText(equalTo(method)))

--- a/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
+++ b/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverTest.kt
@@ -1,35 +1,22 @@
 package org.http4k.webdriver
 
-import com.natpryce.hamkrest.MatchResult
-import com.natpryce.hamkrest.Matcher
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.present
-import com.natpryce.hamkrest.startsWith
-import org.http4k.core.Method
-import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
-import org.http4k.core.MultipartFormBody
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.Status.Companion.SEE_OTHER
 import org.http4k.core.Uri
 import org.http4k.core.cookie.cookie
 import org.http4k.core.cookie.cookies
-import org.http4k.routing.bind
-import org.http4k.routing.routes
 import org.junit.jupiter.api.Test
 import org.openqa.selenium.By
 import org.openqa.selenium.Cookie
-import org.openqa.selenium.SearchContext
-import org.openqa.selenium.WebDriver
-import org.openqa.selenium.WebElement
 import java.io.File
-import java.io.InputStream
 import java.net.URI
-import java.nio.file.Files
 import java.time.Instant
-import java.util.Date
+import java.util.*
 import org.http4k.core.cookie.Cookie as HCookie
 
 class Http4kWebDriverTest {
@@ -54,157 +41,6 @@ class Http4kWebDriverTest {
         assertThat(driver.findElement(By.id("firstId"))!!.text, equalTo("the first text"))
     }
 
-    @Test
-    fun `POSTing a form prefixes with the original host in the URL`() {
-        val driver = Http4kWebDriver(
-            routes(
-                "/submit" bind { Response(OK).body(it.uri.toString()) },
-                "/" bind { req ->
-                    val body = File("src/test/resources/test.html").readText()
-                    Response(OK).body(
-                        body
-                            .replace("FORMMETHOD", POST.name)
-                            .replace("THEMETHOD", req.method.name)
-                            .replace("THEBODY", req.bodyString())
-                            .replace("THEURL", req.uri.toString())
-                            .replace("THETIME", System.currentTimeMillis().toString())
-                            .replace("ACTION", """action="/submit"""")
-                    )
-                })
-        )
-        driver.navigate().to(Uri.of("http://host/"))
-        driver.findElement(By.id("button"))!!.submit()
-        assertThat(
-            driver.pageSource,
-            equalTo("http://host/submit")
-        )
-    }
-
-    @Test
-    fun `POST form`() {
-        driver.get("https://example.com/bob")
-        driver.findElement(By.id("button"))!!.submit()
-        driver.assertOnPage("https://example.com/form")
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
-    }
-
-    @Test
-    fun `POST form via button click`() {
-        driver.get("/bob")
-        driver.findElement(By.id("resetbutton"))!!.click()
-        driver.assertOnPage("/bob")
-        driver.findElement(By.id("button"))!!.click()
-        driver.assertOnPage("/form")
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
-    }
-
-    @Test
-    fun `POST form with empty action`() {
-        var loadCount = 0
-        val driver = Http4kWebDriver({ req ->
-            loadCount++
-            val body = File("src/test/resources/test.html").readText()
-            Response(OK).body(
-                body
-                    .replace("FORMMETHOD", POST.name)
-                    .replace("THEMETHOD", req.method.name)
-                    .replace("THEBODY", req.bodyString())
-                    .replace("THEURL", req.uri.toString())
-                    .replace("THETIME", System.currentTimeMillis().toString())
-                    .replace("ACTION", "action")
-            )
-        })
-
-        val n0 = loadCount
-        driver.get("http://example.com/bob")
-        driver.findElement(By.id("button"))!!.submit()
-        driver.assertOnPage("http://example.com/bob")
-        assertThat(loadCount, equalTo(n0 + 2))
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
-    }
-
-    @Test
-    fun `POST form with action set to empty string`() {
-        var loadCount = 0
-        val driver = Http4kWebDriver({ req ->
-            loadCount++
-            val body = File("src/test/resources/test.html").readText()
-            Response(OK).body(
-                body
-                    .replace("FORMMETHOD", POST.name)
-                    .replace("THEMETHOD", req.method.name)
-                    .replace("THEBODY", req.bodyString())
-                    .replace("THEURL", req.uri.toString())
-                    .replace("THETIME", System.currentTimeMillis().toString())
-                    .replace("ACTION", "action=\"\"")
-            )
-        })
-        val n0 = loadCount
-        driver.get("http://127.0.0.1/bob")
-        driver.findElement(By.id("button"))!!.submit()
-        driver.assertOnPage("http://127.0.0.1/bob")
-        assertThat(loadCount, equalTo(n0 + 2))
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
-    }
-
-    @Test
-    fun `POST form with action set to fragment with no leading slash replaces last part of current base path`() {
-        val driver = Http4kWebDriver({ req ->
-            val body = File("src/test/resources/test.html").readText()
-            Response(OK).body(
-                body
-                    .replace("FORMMETHOD", POST.name)
-                    .replace("THEMETHOD", req.method.name)
-                    .replace("THEBODY", req.bodyString())
-                    .replace("THEURL", req.uri.toString())
-                    .replace("THETIME", System.currentTimeMillis().toString())
-                    .replace("ACTION", "action=\"fragmentWithNoLeadingSlash\"")
-            )
-        })
-
-        driver.get("http://example.com/bob/was/here/today")
-        driver.findElement(By.id("button"))!!.submit()
-        driver.assertCurrentUrl("http://example.com/bob/was/here/fragmentWithNoLeadingSlash")
-    }
-
-
-    @Test
-    fun `GET form`() {
-        val driver = Http4kWebDriver({ req ->
-            val body = File("src/test/resources/test.html").readText()
-            Response(OK).body(
-                body
-                    .replace("FORMMETHOD", Method.GET.name)
-                    .replace("THEMETHOD", req.method.name)
-                    .replace("THEBODY", req.bodyString())
-                    .replace("THEURL", req.uri.toString())
-                    .replace("THETIME", System.currentTimeMillis().toString())
-                    .replace("ACTION", "action=\"/form\"")
-            )
-        })
-
-        driver.get("/bob")
-        driver.findElement(By.id("button"))!!.submit()
-        driver.assertOnPage("/form?text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2&button=yes")
-        assertThat(driver.findElement(By.tagName("thebody"))!!.text, equalTo(""))
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("GET"))
-    }
 
     @Test
     fun navigation() {
@@ -343,19 +179,6 @@ class Http4kWebDriverTest {
     }
 
     @Test
-    fun `POST form with an empty text box`() {
-        driver.get("https://example.com/bob")
-        driver.findElement(By.tagName("textarea"))!!.sendKeys("")
-        driver.findElement(By.id("button"))!!.submit()
-        driver.assertOnPage("https://example.com/form")
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=&select1=option1&select1=option2&button=yes")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
-    }
-
-    @Test
     fun `Set the host header when navigating to a URL`() {
         val driver = Http4kWebDriver({ req ->
             Response(OK).body(req.header("host") ?: "none")
@@ -381,96 +204,5 @@ class Http4kWebDriverTest {
 
         driver.navigate().to("http://redirect.com")
         assertThat(driver.pageSource, equalTo("destination.com"))
-    }
-
-    // https://www.w3.org/TR/html401/interact/forms.html#h-17.13
-    @Test
-    fun `POST form via input of type 'submit' click`() {
-        driver.get("https://example.com/bob")
-        driver.findElement(By.id("input-submit"))!!.click()
-        driver.assertOnPage("https://example.com/form")
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&textarea1=textarea&select1=option1&select1=option2")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
-    }
-
-    @Test
-    fun `POST form - activated submit buttons ('input' elements) are submitted with the form`() {
-        driver.get("https://example.com/bob")
-        driver.findElement(By.id("only-send-when-activated"))!!.submit()
-        driver.assertOnPage("https://example.com/form")
-        assertThat(
-            driver.findElement(By.tagName("thebody"))!!.text,
-            equalTo("text1=textValue&checkbox1=checkbox&only-send-when-activated=only-send-when-activated&textarea1=textarea&select1=option1&select1=option2")
-        )
-        assertThat(driver.findElement(By.tagName("themethod"))!!.text, equalTo("POST"))
-    }
-
-    @Test
-    fun `POST form - a form that has an 'enctype' of 'multipart form-data' transmits its data as a multipart form`() {
-        val driver = Http4kWebDriver({ req ->
-            val body = File("src/test/resources/file_upload_test.html").readText()
-            if (req.method == GET) return@Http4kWebDriver Response(OK).body(body)
-
-            val formBody = MultipartFormBody.from(req)
-            val file = formBody.file("file")!!
-
-            Response(OK).body(body
-                .replace("ENCODING", req.header("content-type")!!)
-                .replace("FILENAME", file.filename)
-                .replace("FILECONTENT", file.content.asString()))
-        })
-
-        val fileContent = "hello mum"
-        val filePath = kotlin.io.path.createTempFile("file-upload-test", ".txt")
-        Files.newBufferedWriter(filePath).use { it.write(fileContent) }
-
-        driver.get("https://example.com/bob")
-        driver.findElement(By.tagName("input"))!!.sendKeys(filePath.toString())
-        driver.findElement(By.tagName("button"))!!.submit()
-
-        assertThat(driver, hasElement(By.tagName("theformencoding"), hasText(startsWith("multipart/form-data"))))
-        assertThat(driver, hasElement(By.tagName("thefilename"), hasText(equalTo(filePath.fileName.toString()))))
-        assertThat(driver, hasElement(By.tagName("thefilecontent"), hasText(equalTo(fileContent))))
-    }
-}
-
-private fun InputStream.asString(): String {
-    return reader().use { it.readText() }
-}
-
-private fun WebDriver.assertOnPage(expected: String) {
-    assertThat(findElement(By.tagName("h1"))!!.text, equalTo(expected))
-}
-
-private fun Http4kWebDriver.assertCurrentUrl(expectedUrl: String) {
-    assertThat(currentUrl, equalTo(expectedUrl))
-}
-
-private fun hasElement(by: By, matcher: Matcher<WebElement>): Matcher<SearchContext> = object : Matcher<SearchContext> {
-    override val description: String = "has the element matching ${by} that " + matcher.description
-
-    override fun invoke(actual: SearchContext): MatchResult {
-        val element: WebElement? = actual.findElement(by)
-
-        return when (element) {
-            null -> MatchResult.Mismatch("could not find element")
-            else -> matcher(element)
-        }
-    }
-}
-
-private fun hasText(matcher: Matcher<String>): Matcher<WebElement> = object : Matcher<WebElement> {
-    override val description: String = "has the text content " + matcher.description
-
-    override fun invoke(actual: WebElement): MatchResult {
-        val text : String? = actual.text
-
-        return when (text) {
-            null -> MatchResult.Mismatch("could not find any text content")
-            else -> matcher(text)
-        }
     }
 }

--- a/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Matchers.kt
+++ b/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Matchers.kt
@@ -1,0 +1,53 @@
+package org.http4k.webdriver
+
+import com.natpryce.hamkrest.MatchResult
+import com.natpryce.hamkrest.Matcher
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.throws
+import org.openqa.selenium.By
+import org.openqa.selenium.SearchContext
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.WebElement
+import java.io.InputStream
+
+internal fun isNotImplemented(fn: () -> Unit) = assertThat({ fn() }, throws<FeatureNotImplementedYet>())
+
+internal fun InputStream.asString(): String {
+    return reader().use { it.readText() }
+}
+
+internal fun WebDriver.assertOnPage(expected: String) {
+    assertThat(findElement(By.tagName("h1"))!!.text, equalTo(expected))
+}
+
+internal fun Http4kWebDriver.assertCurrentUrl(expectedUrl: String) {
+    assertThat(currentUrl, equalTo(expectedUrl))
+}
+
+internal fun hasElement(by: By, matcher: Matcher<WebElement>): Matcher<SearchContext> = object :
+    Matcher<SearchContext> {
+    override val description: String = "has the element matching ${by} that " + matcher.description
+
+    override fun invoke(actual: SearchContext): MatchResult {
+        val element: WebElement? = actual.findElement(by)
+
+        return when (element) {
+            null -> MatchResult.Mismatch("could not find element")
+            else -> matcher(element)
+        }
+    }
+}
+
+internal fun hasText(matcher: Matcher<String>): Matcher<WebElement> = object : Matcher<WebElement> {
+    override val description: String = "has the text content " + matcher.description
+
+    override fun invoke(actual: WebElement): MatchResult {
+        val text : String? = actual.text
+
+        return when (text) {
+            null -> MatchResult.Mismatch("could not find any text content")
+            else -> matcher(text)
+        }
+    }
+}

--- a/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Matchers.kt
+++ b/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/Matchers.kt
@@ -22,7 +22,15 @@ internal fun WebDriver.assertOnPage(expected: String) {
 }
 
 internal fun Http4kWebDriver.assertCurrentUrl(expectedUrl: String) {
-    assertThat(currentUrl, equalTo(expectedUrl))
+    assertThat(this, hasCurrentUrl(expectedUrl))
+}
+
+internal fun hasCurrentUrl(url: String): Matcher<WebDriver> = object : Matcher<WebDriver> {
+    override val description: String = "has the current url of \"$url\""
+
+    override fun invoke(actual: WebDriver): MatchResult {
+        return equalTo(url)(actual.currentUrl)
+    }
 }
 
 internal fun hasElement(by: By, matcher: Matcher<WebElement>): Matcher<SearchContext> = object :

--- a/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/assert.kt
+++ b/http4k-testing/webdriver/src/test/kotlin/org/http4k/webdriver/assert.kt
@@ -1,6 +1,0 @@
-package org.http4k.webdriver
-
-import com.natpryce.hamkrest.assertion.assertThat
-import com.natpryce.hamkrest.throws
-
-fun isNotImplemented(fn: () -> Unit) = assertThat({ fn() }, throws<FeatureNotImplementedYet>())

--- a/http4k-testing/webdriver/src/test/resources/file_upload_test.html
+++ b/http4k-testing/webdriver/src/test/resources/file_upload_test.html
@@ -8,9 +8,20 @@
 <theformencoding>ENCODING</theformencoding>
 <thefilename>FILENAME</thefilename>
 <thefilecontent>FILECONTENT</thefilecontent>
+<theotherformfields>OTHERFORMFIELDS</theotherformfields>
 
 <div>
     <form action="" method="post" enctype="multipart/form-data">
+      <input name="text1" type="text" value="textValue"/>
+      <textarea name="textarea1">textarea</textarea>
+      <input name="checkbox1" type="checkbox" value="checkbox" checked/>
+      <input name="checkbox1" type="checkbox" value="checkbox2"/>
+      <input type="radio" value="radio" checked="checked"/>
+      <select name="select1">
+        <option value="option1" selected="selected"></option>
+        <option value="option2" selected="selected"></option>
+      </select>
+
       <input type="file" id="file" name="file" accept=".txt">
       <button id="button" value="yes" name="button"></button>
     </form>

--- a/http4k-testing/webdriver/src/test/resources/file_upload_test.html
+++ b/http4k-testing/webdriver/src/test/resources/file_upload_test.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Page title</title>
+</head>
+<body>
+<theformencoding>ENCODING</theformencoding>
+<thefilename>FILENAME</thefilename>
+<thefilecontent>FILECONTENT</thefilecontent>
+
+<div>
+    <form action="" method="post" enctype="multipart/form-data">
+      <input type="file" id="file" name="file" accept=".txt">
+      <button id="button" value="yes" name="button"></button>
+    </form>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Hi!

Needed this for something at work. The test shows a reasonable example of "sending" a file through a submit in the webdriver, the interface is identical to the way I've seen it done in selenium (make a temp file and send the filepath as keys to the input).

I used the multipart lenses, which was fun. I also checked that the other fields in the form were being sent OK fairly brutally.

Had a small tidy on some of the hamkrest matchers too.

Thanks!