### PR TITLE
Group spans by traces

### DIFF
--- a/http4k-testing/tracerbullet/src/main/kotlin/org/http4k/tracing/TracerBullet.kt
+++ b/http4k-testing/tracerbullet/src/main/kotlin/org/http4k/tracing/TracerBullet.kt
@@ -22,6 +22,12 @@ class TracerBullet(private val tracers: List<Tracer>) {
 }
 
 internal fun List<MetadataEvent>.buildTree(): List<EventNode> {
+    return groupBy { it.traces()?.traceId }
+        .mapValues { it.value.buildTreeForTrace() }
+        .flatMap { it.value }
+}
+
+private fun List<MetadataEvent>.buildTreeForTrace(): List<EventNode> {
     val eventsByParent = groupBy { it.traces()?.parentSpanId }
 
     fun MetadataEvent.childEventNodes(): List<EventNode> =

--- a/http4k-testing/tracerbullet/src/main/kotlin/org/http4k/tracing/TracerBullet.kt
+++ b/http4k-testing/tracerbullet/src/main/kotlin/org/http4k/tracing/TracerBullet.kt
@@ -21,11 +21,9 @@ class TracerBullet(private val tracers: List<Tracer>) {
             .flatMap { event -> tracers.flatMap { it(event, Tracer.TreeWalker(tracers)) } }
 }
 
-internal fun List<MetadataEvent>.buildTree(): List<EventNode> {
-    return groupBy { it.traces()?.traceId }
-        .mapValues { it.value.buildTreeForTrace() }
-        .flatMap { it.value }
-}
+internal fun List<MetadataEvent>.buildTree() = groupBy { it.traces()?.traceId }
+    .mapValues { it.value.buildTreeForTrace() }
+    .flatMap { it.value }
 
 private fun List<MetadataEvent>.buildTreeForTrace(): List<EventNode> {
     val eventsByParent = groupBy { it.traces()?.parentSpanId }

--- a/http4k-testing/tracerbullet/src/test/kotlin/org/http4k/tracing/TracerBulletExtraTest.kt
+++ b/http4k-testing/tracerbullet/src/test/kotlin/org/http4k/tracing/TracerBulletExtraTest.kt
@@ -34,14 +34,16 @@ class TracerBulletExtraTest {
             eventWith("Event 1.7 (B-C)", "1", "span1.C.2", "span1.B.4"),
             eventWith("Event 1.6 (A-B)", "1", "span1.B.4", "span1.A.1"),
             eventWith("Event 1.9 (A-D)", "1", "span1.D.3", "span1.A.1"),
-            eventWith("Event 1.0", "-A", "span1.A.1", null),
+            eventWith("Event 1.0", "1", "span1.A.1", null),
             eventWith("Event 2.1 (A-B)", "2", "span2.B.1", "span2.A.1"),
             eventWith("Event 2.2 (A-B)", "2", "span2.B.2", "span2.A.1"),
             eventWith("Event 2.5 (D-E)", "2", "span2.E.1", "span2.D.1"),
             eventWith("Event 2.4 (B-D)", "2", "span2.D.1", "span2.B.3"),
             eventWith("Event 2.3 (A-B)", "2", "span2.B.3", "span2.A.1"),
             eventWith("Event 2.6 (A-E)", "2", "span2.E.2", "span2.A.1"),
-            eventWith("Event 2.0", "-B", "span2.A.1", "ROOT")
+            eventWith("Event 2.0", "2", "span2.A.1", "ROOT"),
+            eventWith("Event 3.1 (A-B,diff trace)", "3.1", "span3.B.1", "span3.A.1"),
+            eventWith("Event 3.0", "3.0", "span3.A.1", null),
         ).buildTree()
         prettyPrint(input, 0)
         approver.assertApproved(prettify(asFormatString(input)))

--- a/http4k-testing/tracerbullet/src/test/resources/org/http4k/tracing/TracerBulletExtraTest.traces can be grouped.approved
+++ b/http4k-testing/tracerbullet/src/test/resources/org/http4k/tracing/TracerBulletExtraTest.traces can be grouped.approved
@@ -6,7 +6,7 @@
     },
     "metadata" : {
       "traces" : {
-        "traceId" : "-A",
+        "traceId" : "1",
         "spanId" : "span1.A.1",
         "parentSpanId" : null,
         "samplingDecision" : "1"
@@ -176,7 +176,7 @@
     },
     "metadata" : {
       "traces" : {
-        "traceId" : "-B",
+        "traceId" : "2",
         "spanId" : "span2.A.1",
         "parentSpanId" : "ROOT",
         "samplingDecision" : "1"
@@ -287,4 +287,38 @@
     },
     "children" : [ ]
   } ]
+}, {
+  "event" : {
+    "event" : {
+      "value" : "Event 3.1 (A-B,diff trace)",
+      "category" : "Foo"
+    },
+    "metadata" : {
+      "traces" : {
+        "traceId" : "3.1",
+        "spanId" : "span3.B.1",
+        "parentSpanId" : "span3.A.1",
+        "samplingDecision" : "1"
+      },
+      "timestamp" : 17
+    }
+  },
+  "children" : [ ]
+}, {
+  "event" : {
+    "event" : {
+      "value" : "Event 3.0",
+      "category" : "Foo"
+    },
+    "metadata" : {
+      "traces" : {
+        "traceId" : "3.0",
+        "spanId" : "span3.A.1",
+        "parentSpanId" : null,
+        "samplingDecision" : "1"
+      },
+      "timestamp" : 18
+    }
+  },
+  "children" : [ ]
 } ]


### PR DESCRIPTION
This PR fixes TracerBullet cross-trace spans sharing by grouping spans by their traceId before building a tree.
See discussion in slack https://kotlinlang.slack.com/archives/C5AL3AKUY/p1711545523381239?thread_ts=1711364711.659419&cid=C5AL3AKUY