### PR TITLE
Lens metadata enables the augmentation of schemas in OpenApi definition

### DIFF
--- a/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/env/Environment.kt
+++ b/http4k-cloudnative/src/main/kotlin/org/http4k/cloudnative/env/Environment.kt
@@ -2,7 +2,6 @@ package org.http4k.cloudnative.env
 
 import org.http4k.core.Uri
 import org.http4k.lens.BiDiLensSpec
-import org.http4k.lens.Lens
 import org.http4k.lens.LensExtractor
 import org.http4k.lens.LensGet
 import org.http4k.lens.LensSet

--- a/http4k-contract/openapi/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
+++ b/http4k-contract/openapi/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
@@ -44,7 +44,6 @@ import org.http4k.lens.MultipartForm
 import org.http4k.lens.ParamMeta
 import org.http4k.lens.ParamMeta.ArrayParam
 import org.http4k.lens.ParamMeta.EnumParam
-import org.http4k.lens.ParamMeta.FileParam
 import org.http4k.lens.ParamMeta.ObjectParam
 import org.http4k.lens.ParamMeta.StringParam
 import org.http4k.lens.WebForm
@@ -202,9 +201,6 @@ class OpenApi3<NODE : Any>(
     private fun requestParameter(meta: Meta): RequestParameter<NODE> =
         when (val paramMeta: ParamMeta = meta.paramMeta) {
             ObjectParam -> SchemaParameter(meta, "{}".toSchema())
-            FileParam -> PrimitiveParameter(meta, json {
-                obj("type" to string(FileParam.value), "format" to string("binary"))
-            })
 
             is ArrayParam -> PrimitiveParameter(meta, json {
                 val itemType = paramMeta.itemType()

--- a/http4k-contract/openapi/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
+++ b/http4k-contract/openapi/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
@@ -200,7 +200,8 @@ class OpenApi3<NODE : Any>(
 
     private fun requestParameter(meta: Meta): RequestParameter<NODE> =
         when (val paramMeta: ParamMeta = meta.paramMeta) {
-            ObjectParam -> SchemaParameter(meta, "{}".toSchema())
+            ObjectParam -> SchemaParameter(meta, "{}".toSchema()
+                .appendFields(meta.schemaFields()))
 
             is ArrayParam -> PrimitiveParameter(meta, json {
                 val itemType = paramMeta.itemType()

--- a/http4k-contract/openapi/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
+++ b/http4k-contract/openapi/src/main/kotlin/org/http4k/contract/openapi/v3/OpenApi3.kt
@@ -208,7 +208,7 @@ class OpenApi3<NODE : Any>(
 
             is ArrayParam -> PrimitiveParameter(meta, json {
                 val itemType = paramMeta.itemType()
-                obj(
+                obj(listOf(
                     "type" to string("array"),
                     "items" to when (itemType) {
                         is EnumParam<*> -> apiRenderer.toSchema(
@@ -218,7 +218,8 @@ class OpenApi3<NODE : Any>(
                         ).definitions.first().second
 
                         else -> obj("type" to string(itemType.value))
-                    }
+                    })
+                    + meta.schemaFields()
                 )
             })
 
@@ -243,6 +244,7 @@ class OpenApi3<NODE : Any>(
     private fun Meta.schemaFields(): List<Pair<String, NODE>> =
         this.schemaMetadata()?.map { entry -> entry.key to asNode(entry.value) } ?: emptyList()
 
+    @Suppress("UNCHECKED_CAST")
     private fun Meta.schemaMetadata(): Map<String, Any>? = metadata?.let { it["schema"] as Map<String, Any> }
 
     private fun JsonSchema<NODE>.appendFields(fields: List<Pair<String, NODE>>): JsonSchema<NODE> =

--- a/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -122,7 +122,7 @@ abstract class ContractRendererContract<NODE : Any>(
             routes += "/paths" / Path.of("firstName") / "bertrand" / Path.boolean().of("age") / Path.enum<Foo>()
                 .of("foo") bindContract POST to { a, _, _, _ -> { Response(OK).body(a) } }
             routes += "/queries" meta {
-                queries += Query.boolean().multi.required("b", "booleanQuery")
+                queries += Query.boolean().multi.required("b", "booleanQuery", schemaOf(mapOf("default" to listOf(true, false))))
                 queries += Query.string().optional("s", "stringQuery")
                 queries += Query.int().optional("i", "intQuery")
                 queries += Query.enum<Foo>().optional("e", "enumQuery")

--- a/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -144,7 +144,7 @@ abstract class ContractRendererContract<NODE : Any>(
                 headers += Header.map { listOf("a", "b") }.optional("list", "listHeader", schemaOf(mapOf("default" to listOf("a", "b"))))
                 headers += Header.map { mapOf("a" to "b") }.optional("obj", "objHeader", schemaOf(mapOf("default" to mapOf("a" to "b"))))
                 headers += Header.enum<HttpMessage, Foo>().optional("e", "enumHeader", schemaOf(mapOf("default" to Foo.bar)))
-                headers += json.jsonLens(Header).optional("j", "jsonHeader")
+                headers += json.jsonLens(Header).optional("j", "jsonHeader", schemaOf(mapOf("default" to mapOf("a" to "b"))))
             } bindContract POST to { _ -> Response(OK).body("hello") }
             routes += "/body_receiving_string" meta {
                 summary = "body_receiving_string"

--- a/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -143,7 +143,7 @@ abstract class ContractRendererContract<NODE : Any>(
                 headers += Header.long().optional("l", "lHeader", schemaOf(mapOf("default" to 8493575243L)))
                 headers += Header.map { listOf("a", "b") }.optional("list", "listHeader", schemaOf(mapOf("default" to listOf("a", "b"))))
                 headers += Header.map { mapOf("a" to "b") }.optional("obj", "objHeader", schemaOf(mapOf("default" to mapOf("a" to "b"))))
-                headers += Header.enum<HttpMessage, Foo>().optional("e", "enumHeader")
+                headers += Header.enum<HttpMessage, Foo>().optional("e", "enumHeader", schemaOf(mapOf("default" to Foo.bar)))
                 headers += json.jsonLens(Header).optional("j", "jsonHeader")
             } bindContract POST to { _ -> Response(OK).body("hello") }
             routes += "/body_receiving_string" meta {

--- a/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -45,9 +45,13 @@ import org.http4k.lens.Path
 import org.http4k.lens.Query
 import org.http4k.lens.Validator.Strict
 import org.http4k.lens.WebForm
+import org.http4k.lens.bigDecimal
+import org.http4k.lens.bigInteger
 import org.http4k.lens.boolean
+import org.http4k.lens.double
 import org.http4k.lens.enum
 import org.http4k.lens.int
+import org.http4k.lens.long
 import org.http4k.lens.multipartForm
 import org.http4k.lens.string
 import org.http4k.lens.webForm
@@ -59,6 +63,8 @@ import org.http4k.testing.Approver
 import org.http4k.testing.JsonApprovalTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import java.math.BigDecimal
+import java.math.BigInteger
 
 @ExtendWith(JsonApprovalTest::class)
 abstract class ContractRendererContract<NODE : Any>(
@@ -98,6 +104,8 @@ abstract class ContractRendererContract<NODE : Any>(
             Body.string(ContentType("custom/v2")).toLens()
         )
 
+        fun schemaOf(schema: Map<String, Any>) = mapOf("schema" to schema)
+
         val router = "/basepath" bind contract {
             renderer = rendererToUse
             tags += Tag("hello", "world")
@@ -127,8 +135,14 @@ abstract class ContractRendererContract<NODE : Any>(
             } bindContract POST to { _ -> Response(OK).body("hello") }
             routes += "/headers" meta {
                 headers += Header.boolean().required("b", "booleanHeader")
-                headers += Header.string().optional("s", "stringHeader")
-                headers += Header.int().optional("i", "intHeader")
+                headers += Header.string().optional("s", "stringHeader", schemaOf(mapOf("pattern" to ".*", "nullable" to true)))
+                headers += Header.int().optional("i", "intHeader", schemaOf(mapOf("default" to 42)))
+                headers += Header.double().optional("d", "dHeader", schemaOf(mapOf("default" to 0.0)))
+                headers += Header.bigDecimal().optional("bd", "bigDHeader", schemaOf(mapOf("default" to BigDecimal("4.2"))))
+                headers += Header.bigInteger().optional("bi", "bigIHeader", schemaOf(mapOf("default" to BigInteger("6547262478"))))
+                headers += Header.long().optional("l", "lHeader", schemaOf(mapOf("default" to 8493575243L)))
+                headers += Header.map { listOf("a", "b") }.optional("list", "listHeader", schemaOf(mapOf("default" to listOf("a", "b"))))
+                headers += Header.map { mapOf("a" to "b") }.optional("obj", "objHeader", schemaOf(mapOf("default" to mapOf("a" to "b"))))
                 headers += Header.enum<HttpMessage, Foo>().optional("e", "enumHeader")
                 headers += json.jsonLens(Header).optional("j", "jsonHeader")
             } bindContract POST to { _ -> Response(OK).body("hello") }

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.renders as expected.approved
@@ -604,6 +604,48 @@
           },
           {
             "in": "header",
+            "name": "d",
+            "required": false,
+            "type": "number",
+            "description": "dHeader"
+          },
+          {
+            "in": "header",
+            "name": "bd",
+            "required": false,
+            "type": "number",
+            "description": "bigDHeader"
+          },
+          {
+            "in": "header",
+            "name": "bi",
+            "required": false,
+            "type": "integer",
+            "description": "bigIHeader"
+          },
+          {
+            "in": "header",
+            "name": "l",
+            "required": false,
+            "type": "integer",
+            "description": "lHeader"
+          },
+          {
+            "in": "header",
+            "name": "list",
+            "required": false,
+            "type": "string",
+            "description": "listHeader"
+          },
+          {
+            "in": "header",
+            "name": "obj",
+            "required": false,
+            "type": "string",
+            "description": "objHeader"
+          },
+          {
+            "in": "header",
             "name": "e",
             "required": false,
             "type": "string",

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
@@ -893,7 +893,11 @@
               "type": "array",
               "items": {
                 "type": "boolean"
-              }
+              },
+              "default": [
+                true,
+                false
+              ]
             },
             "in": "query",
             "name": "b",

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
@@ -586,7 +586,9 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "pattern": ".*",
+              "nullable": true
             },
             "in": "header",
             "name": "s",
@@ -595,12 +597,78 @@
           },
           {
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 42
             },
             "in": "header",
             "name": "i",
             "required": false,
             "description": "intHeader"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "default": 0
+            },
+            "in": "header",
+            "name": "d",
+            "required": false,
+            "description": "dHeader"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "default": 4.2
+            },
+            "in": "header",
+            "name": "bd",
+            "required": false,
+            "description": "bigDHeader"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 6547262478
+            },
+            "in": "header",
+            "name": "bi",
+            "required": false,
+            "description": "bigIHeader"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 8493575243
+            },
+            "in": "header",
+            "name": "l",
+            "required": false,
+            "description": "lHeader"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "default": [
+                "a",
+                "b"
+              ]
+            },
+            "in": "header",
+            "name": "list",
+            "required": false,
+            "description": "listHeader"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "default": {
+                "a": "b"
+              }
+            },
+            "in": "header",
+            "name": "obj",
+            "required": false,
+            "description": "objHeader"
           },
           {
             "in": "header",

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
@@ -676,7 +676,8 @@
             "required": false,
             "description": "enumHeader",
             "schema": {
-              "$ref": "#/components/schemas/Foo"
+              "$ref": "#/components/schemas/Foo",
+              "default": "bar"
             }
           },
           {

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
@@ -686,7 +686,10 @@
             "required": false,
             "description": "jsonHeader",
             "schema": {
-              "$ref": "#/components/schemas/object1955914966"
+              "$ref": "#/components/schemas/object1955914966",
+              "default": {
+                "a": "b"
+              }
             }
           }
         ],

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
@@ -577,7 +577,8 @@
         "parameters": [
           {
             "schema": {
-              "$ref": "#/components/schemas/e"
+              "$ref": "#/components/schemas/e",
+              "default": "bar"
             },
             "in": "header",
             "name": "e",

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
@@ -604,7 +604,9 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "pattern": ".*",
+              "nullable": true
             },
             "in": "header",
             "name": "s",
@@ -613,12 +615,78 @@
           },
           {
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 42
             },
             "in": "header",
             "name": "i",
             "required": false,
             "description": "intHeader"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "default": 0.0
+            },
+            "in": "header",
+            "name": "d",
+            "required": false,
+            "description": "dHeader"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "default": 4.2
+            },
+            "in": "header",
+            "name": "bd",
+            "required": false,
+            "description": "bigDHeader"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 6547262478
+            },
+            "in": "header",
+            "name": "bi",
+            "required": false,
+            "description": "bigIHeader"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 8493575243
+            },
+            "in": "header",
+            "name": "l",
+            "required": false,
+            "description": "lHeader"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "default": [
+                "a",
+                "b"
+              ]
+            },
+            "in": "header",
+            "name": "list",
+            "required": false,
+            "description": "listHeader"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "default": {
+                "a": "b"
+              }
+            },
+            "in": "header",
+            "name": "obj",
+            "required": false,
+            "description": "objHeader"
           }
         ],
         "responses": {

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
@@ -921,7 +921,11 @@
               "type": "array",
               "items": {
                 "type": "boolean"
-              }
+              },
+              "default": [
+                true,
+                false
+              ]
             },
             "in": "query",
             "name": "b",

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
@@ -587,7 +587,10 @@
           },
           {
             "schema": {
-              "$ref": "#/components/schemas/generatedDefinitionId2"
+              "$ref": "#/components/schemas/generatedDefinitionId2",
+              "default": {
+                "a": "b"
+              }
             },
             "in": "header",
             "name": "j",

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
@@ -604,7 +604,9 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "pattern": ".*",
+              "nullable": true
             },
             "in": "header",
             "name": "s",
@@ -613,12 +615,78 @@
           },
           {
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 42
             },
             "in": "header",
             "name": "i",
             "required": false,
             "description": "intHeader"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "default": 0
+            },
+            "in": "header",
+            "name": "d",
+            "required": false,
+            "description": "dHeader"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "default": 4.2
+            },
+            "in": "header",
+            "name": "bd",
+            "required": false,
+            "description": "bigDHeader"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 6547262478
+            },
+            "in": "header",
+            "name": "bi",
+            "required": false,
+            "description": "bigIHeader"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 8493575243
+            },
+            "in": "header",
+            "name": "l",
+            "required": false,
+            "description": "lHeader"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "default": [
+                "a",
+                "b"
+              ]
+            },
+            "in": "header",
+            "name": "list",
+            "required": false,
+            "description": "listHeader"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "default": {
+                "a": "b"
+              }
+            },
+            "in": "header",
+            "name": "obj",
+            "required": false,
+            "description": "objHeader"
           }
         ],
         "responses": {

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
@@ -577,7 +577,8 @@
         "parameters": [
           {
             "schema": {
-              "$ref": "#/components/schemas/e"
+              "$ref": "#/components/schemas/e",
+              "default": "bar"
             },
             "in": "header",
             "name": "e",

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
@@ -587,7 +587,10 @@
           },
           {
             "schema": {
-              "$ref": "#/components/schemas/object744721296"
+              "$ref": "#/components/schemas/object744721296",
+              "default": {
+                "a": "b"
+              }
             },
             "in": "header",
             "name": "j",

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
@@ -921,7 +921,11 @@
               "type": "array",
               "items": {
                 "type": "boolean"
-              }
+              },
+              "default": [
+                true,
+                false
+              ]
             },
             "in": "query",
             "name": "b",

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
@@ -604,7 +604,9 @@
           },
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "pattern": ".*",
+              "nullable": true
             },
             "in": "header",
             "name": "s",
@@ -613,12 +615,78 @@
           },
           {
             "schema": {
-              "type": "integer"
+              "type": "integer",
+              "default": 42
             },
             "in": "header",
             "name": "i",
             "required": false,
             "description": "intHeader"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "default": 0
+            },
+            "in": "header",
+            "name": "d",
+            "required": false,
+            "description": "dHeader"
+          },
+          {
+            "schema": {
+              "type": "number",
+              "default": 4.2
+            },
+            "in": "header",
+            "name": "bd",
+            "required": false,
+            "description": "bigDHeader"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 6547262478
+            },
+            "in": "header",
+            "name": "bi",
+            "required": false,
+            "description": "bigIHeader"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "default": 8493575243
+            },
+            "in": "header",
+            "name": "l",
+            "required": false,
+            "description": "lHeader"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "default": [
+                "a",
+                "b"
+              ]
+            },
+            "in": "header",
+            "name": "list",
+            "required": false,
+            "description": "listHeader"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "default": {
+                "a": "b"
+              }
+            },
+            "in": "header",
+            "name": "obj",
+            "required": false,
+            "description": "objHeader"
           }
         ],
         "responses": {

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
@@ -577,7 +577,8 @@
         "parameters": [
           {
             "schema": {
-              "$ref": "#/components/schemas/e"
+              "$ref": "#/components/schemas/e",
+              "default": "bar"
             },
             "in": "header",
             "name": "e",

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
@@ -587,7 +587,10 @@
           },
           {
             "schema": {
-              "$ref": "#/components/schemas/object744721296"
+              "$ref": "#/components/schemas/object744721296",
+              "default": {
+                "a": "b"
+              }
             },
             "in": "header",
             "name": "j",

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
@@ -921,7 +921,11 @@
               "type": "array",
               "items": {
                 "type": "boolean"
-              }
+              },
+              "default": [
+                true,
+                false
+              ]
             },
             "in": "query",
             "name": "b",

--- a/http4k-core/src/main/kotlin/org/http4k/lens/Meta.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/Meta.kt
@@ -1,3 +1,10 @@
 package org.http4k.lens
 
-data class Meta(val required: Boolean, val location: String, val paramMeta: ParamMeta, val name: String, val description: String? = null)
+data class Meta(
+    val required: Boolean,
+    val location: String,
+    val paramMeta: ParamMeta,
+    val name: String,
+    val description: String? = null,
+    val metadata: Map<String, Any>? = null
+)

--- a/http4k-core/src/main/kotlin/org/http4k/lens/lensSpec.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/lensSpec.kt
@@ -42,22 +42,22 @@ interface LensBuilder<IN : Any, OUT> {
     /**
      * Make a concrete Lens for this spec that looks for an optional value in the target.
      */
-    fun optional(name: String, description: String? = null): Lens<IN, OUT?>
+    fun optional(name: String, description: String? = null, metadata: Map<String, Any>? = null): Lens<IN, OUT?>
 
     /**
      * Make a concrete Lens for this spec that looks for a required value in the target.
      */
-    fun required(name: String, description: String? = null): Lens<IN, OUT>
+    fun required(name: String, description: String? = null, metadata: Map<String, Any>? = null): Lens<IN, OUT>
 
     /**
      * Make a concrete Lens for this spec that falls back to the default value if no value is found in the target.
      */
-    fun defaulted(name: String, default: OUT, description: String? = null): Lens<IN, OUT>
+    fun defaulted(name: String, default: OUT, description: String? = null, metadata: Map<String, Any>? = null): Lens<IN, OUT>
 
     /**
      * Make a concrete Lens for this spec that falls back to another lens if no value is found in the target.
      */
-    fun defaulted(name: String, default: LensExtractor<IN, OUT>, description: String? = null): Lens<IN, OUT>
+    fun defaulted(name: String, default: LensExtractor<IN, OUT>, description: String? = null, metadata: Map<String, Any>? = null): Lens<IN, OUT>
 }
 
 /**
@@ -74,10 +74,10 @@ open class LensSpec<IN : Any, OUT>(
      */
     fun <NEXT> map(nextIn: (OUT) -> NEXT) = LensSpec(location, paramMeta, get.map(nextIn))
 
-    override fun defaulted(name: String, default: OUT, description: String?): Lens<IN, OUT> =
-        defaulted(name, Lens(Meta(false, location, paramMeta, name, description)) { default }, description)
+    override fun defaulted(name: String, default: OUT, description: String?, metadata: Map<String, Any>?): Lens<IN, OUT> =
+        defaulted(name, Lens(Meta(false, location, paramMeta, name, description, metadata)) { default }, description)
 
-    override fun defaulted(name: String, default: LensExtractor<IN, OUT>, description: String?): Lens<IN, OUT> {
+    override fun defaulted(name: String, default: LensExtractor<IN, OUT>, description: String?, metadata: Map<String, Any>?): Lens<IN, OUT> {
         val getLens = get(name)
         return Lens(
             Meta(
@@ -85,12 +85,13 @@ open class LensSpec<IN : Any, OUT>(
                 location,
                 paramMeta,
                 name,
-                description
+                description,
+                metadata
             )
         ) { getLens(it).run { if (isEmpty()) default(it) else first() } }
     }
 
-    override fun optional(name: String, description: String?): Lens<IN, OUT?> {
+    override fun optional(name: String, description: String?, metadata: Map<String, Any>?): Lens<IN, OUT?> {
         val getLens = get(name)
         return Lens(
             Meta(
@@ -98,26 +99,27 @@ open class LensSpec<IN : Any, OUT>(
                 location,
                 paramMeta,
                 name,
-                description
+                description,
+                metadata
             )
         ) { getLens(it).run { if (isEmpty()) null else first() } }
     }
 
-    override fun required(name: String, description: String?): Lens<IN, OUT> {
-        val meta = Meta(true, location, paramMeta, name, description)
+    override fun required(name: String, description: String?, metadata: Map<String, Any>?): Lens<IN, OUT> {
+        val meta = Meta(true, location, paramMeta, name, description, metadata)
         val getLens = get(name)
         return Lens(meta) { getLens(it).firstOrNull() ?: throw LensFailure(listOf(Missing(meta)), target = it) }
     }
 
     open val multi = object : LensBuilder<IN, List<OUT>> {
-        override fun defaulted(name: String, default: List<OUT>, description: String?): Lens<IN, List<OUT>> =
+        override fun defaulted(name: String, default: List<OUT>, description: String?, metadata: Map<String, Any>?): Lens<IN, List<OUT>> =
             defaulted(
                 name,
-                Lens(Meta(false, location, ArrayParam(paramMeta), name, description)) { default },
+                Lens(Meta(false, location, ArrayParam(paramMeta), name, description, metadata)) { default },
                 description
             )
 
-        override fun defaulted(name: String, default: LensExtractor<IN, List<OUT>>, description: String?): Lens<IN, List<OUT>> {
+        override fun defaulted(name: String, default: LensExtractor<IN, List<OUT>>, description: String?, metadata: Map<String, Any>?): Lens<IN, List<OUT>> {
             val getLens = get(name)
             return Lens(
                 Meta(
@@ -125,12 +127,13 @@ open class LensSpec<IN : Any, OUT>(
                     location,
                     ArrayParam(paramMeta),
                     name,
-                    description
+                    description,
+                    metadata
                 )
             ) { getLens(it).run { ifEmpty { default(it) } } }
         }
 
-        override fun optional(name: String, description: String?): Lens<IN, List<OUT>?> {
+        override fun optional(name: String, description: String?, metadata: Map<String, Any>?): Lens<IN, List<OUT>?> {
             val getLens = get(name)
             return Lens(
                 Meta(
@@ -138,18 +141,19 @@ open class LensSpec<IN : Any, OUT>(
                     location,
                     ArrayParam(paramMeta),
                     name,
-                    description
+                    description,
+                    metadata
                 )
             ) { getLens(it).run { ifEmpty { null } } }
         }
 
-        override fun required(name: String, description: String?): Lens<IN, List<OUT>> {
+        override fun required(name: String, description: String?, metadata: Map<String, Any>?): Lens<IN, List<OUT>> {
             val getLens = get(name)
-            return Lens(Meta(true, location, ArrayParam(paramMeta), name, description)) {
+            return Lens(Meta(true, location, ArrayParam(paramMeta), name, description, metadata)) {
                 getLens(it).run {
                     ifEmpty {
                         throw LensFailure(
-                            Missing(Meta(true, location, paramMeta, name, description)),
+                            Missing(Meta(true, location, paramMeta, name, description, metadata)),
                             target = it
                         )
                     }
@@ -166,10 +170,10 @@ open class LensSpec<IN : Any, OUT>(
 interface BiDiMultiLensSpec<IN : Any, OUT> : BiDiLensBuilder<IN, List<OUT>>
 
 interface BiDiLensBuilder<IN : Any, OUT> : LensBuilder<IN, OUT> {
-    override fun optional(name: String, description: String?): BiDiLens<IN, OUT?>
-    override fun required(name: String, description: String?): BiDiLens<IN, OUT>
-    override fun defaulted(name: String, default: OUT, description: String?): BiDiLens<IN, OUT>
-    override fun defaulted(name: String, default: LensExtractor<IN, OUT>, description: String?): BiDiLens<IN, OUT>
+    override fun optional(name: String, description: String?, metadata: Map<String, Any>?): BiDiLens<IN, OUT?>
+    override fun required(name: String, description: String?, metadata: Map<String, Any>?): BiDiLens<IN, OUT>
+    override fun defaulted(name: String, default: OUT, description: String?, metadata: Map<String, Any>?): BiDiLens<IN, OUT>
+    override fun defaulted(name: String, default: LensExtractor<IN, OUT>, description: String?, metadata: Map<String, Any>?): BiDiLens<IN, OUT>
 }
 
 /**
@@ -191,72 +195,73 @@ open class BiDiLensSpec<IN : Any, OUT>(
     fun <NEXT> mapWithNewMeta(nextIn: (OUT) -> NEXT, nextOut: (NEXT) -> OUT, paramMeta: ParamMeta) =
         BiDiLensSpec(location, paramMeta, get.map(nextIn), set.map(nextOut))
 
-    override fun defaulted(name: String, default: OUT, description: String?) =
-        defaulted(name, Lens(Meta(false, location, paramMeta, name, description)) { default }, description)
+    override fun defaulted(name: String, default: OUT, description: String?, metadata: Map<String, Any>?) =
+        defaulted(name, Lens(Meta(false, location, paramMeta, name, description, metadata)) { default }, description)
 
-    override fun defaulted(name: String, default: LensExtractor<IN, OUT>, description: String?): BiDiLens<IN, OUT> {
+    override fun defaulted(name: String, default: LensExtractor<IN, OUT>, description: String?, metadata: Map<String, Any>?): BiDiLens<IN, OUT> {
         val getLens = get(name)
         val setLens = set(name)
-        return BiDiLens(Meta(false, location, paramMeta, name, description),
+        return BiDiLens(Meta(false, location, paramMeta, name, description, metadata),
             { getLens(it).run { if (isEmpty()) default(it) else first() } },
             { out: OUT, target: IN -> setLens(out?.let { listOf(it) } ?: emptyList(), target) }
         )
     }
 
-    override fun optional(name: String, description: String?): BiDiLens<IN, OUT?> {
+    override fun optional(name: String, description: String?, metadata: Map<String, Any>?): BiDiLens<IN, OUT?> {
         val getLens = get(name)
         val setLens = set(name)
-        return BiDiLens(Meta(false, location, paramMeta, name, description),
+        return BiDiLens(Meta(false, location, paramMeta, name, description, metadata),
             { getLens(it).run { if (isEmpty()) null else first() } },
             { out: OUT?, target: IN -> setLens(out?.let { listOf(it) } ?: emptyList(), target) }
         )
     }
 
-    override fun required(name: String, description: String?): BiDiLens<IN, OUT> {
+    override fun required(name: String, description: String?, metadata: Map<String, Any>?): BiDiLens<IN, OUT> {
         val getLens = get(name)
         val setLens = set(name)
-        return BiDiLens(Meta(true, location, paramMeta, name, description),
+        return BiDiLens(Meta(true, location, paramMeta, name, description, metadata),
             {
                 getLens(it).firstOrNull()
-                    ?: throw LensFailure(Missing(Meta(true, location, paramMeta, name, description)), target = it)
+                    ?: throw LensFailure(Missing(Meta(true, location, paramMeta, name, description, metadata)), target = it)
             },
             { out: OUT, target: IN -> setLens(listOf(out), target) })
     }
 
     override val multi = object : BiDiMultiLensSpec<IN, OUT> {
-        override fun defaulted(name: String, default: List<OUT>, description: String?): BiDiLens<IN, List<OUT>> =
+        override fun defaulted(name: String, default: List<OUT>, description: String?, metadata: Map<String, Any>?): BiDiLens<IN, List<OUT>> =
             defaulted(
                 name,
-                Lens(Meta(false, location, ArrayParam(paramMeta), name, description)) { default },
+                Lens(Meta(false, location, ArrayParam(paramMeta), name, description, metadata)) { default },
                 description
             )
 
         override fun defaulted(
             name: String,
             default: LensExtractor<IN, List<OUT>>,
-            description: String?
+            description: String?,
+            metadata: Map<String, Any>?
         ): BiDiLens<IN, List<OUT>> {
             val getLens = get(name)
             val setLens = set(name)
-            return BiDiLens(Meta(false, location, ArrayParam(paramMeta), name, description),
+            return BiDiLens(Meta(false, location, ArrayParam(paramMeta), name, description, metadata),
                 { getLens(it).run { ifEmpty { default(it) } } },
                 { out: List<OUT>, target: IN -> setLens(out, target) }
             )
         }
 
-        override fun optional(name: String, description: String?): BiDiLens<IN, List<OUT>?> {
+        override fun optional(name: String, description: String?, metadata: Map<String, Any>?): BiDiLens<IN, List<OUT>?> {
             val getLens = get(name)
             val setLens = set(name)
-            return BiDiLens(Meta(false, location, ArrayParam(paramMeta), name, description),
+            return BiDiLens(Meta(false, location, ArrayParam(paramMeta), name, description, metadata),
                 { getLens(it).run { ifEmpty { null } } },
                 { out: List<OUT>?, target: IN -> setLens(out ?: emptyList(), target) }
             )
         }
 
-        override fun required(name: String, description: String?): BiDiLens<IN, List<OUT>> {
+        override fun required(name: String, description: String?, metadata: Map<String, Any>?): BiDiLens<IN, List<OUT>> {
             val getLens = get(name)
             val setLens = set(name)
-            return BiDiLens(Meta(true, location, ArrayParam(paramMeta), name, description),
+            return BiDiLens(Meta(true, location, ArrayParam(paramMeta), name, description, metadata),
                 {
                     getLens(it).run {
                         ifEmpty {
@@ -267,7 +272,8 @@ open class BiDiLensSpec<IN : Any, OUT>(
                                         location,
                                         ArrayParam(paramMeta),
                                         name,
-                                        description
+                                        description,
+                                        metadata
                                     )
                                 ), target = it
                             )

--- a/http4k-multipart/src/test/kotlin/org/http4k/format/MultipartExtensionsTest.kt
+++ b/http4k-multipart/src/test/kotlin/org/http4k/format/MultipartExtensionsTest.kt
@@ -33,5 +33,4 @@ class MultipartExtensionsTest {
             equalTo(Moshi.asFormatString(foo))
         )
     }
-
 }

--- a/src/docs/guide/howto/integrate_with_openapi/example.kt
+++ b/src/docs/guide/howto/integrate_with_openapi/example.kt
@@ -45,7 +45,7 @@ fun main() {
         )
     }
 
-    val ageQuery = Query.int().required("age")
+    val ageQuery = Query.int().required("age", "Your age", mapOf("schema" to mapOf("minimum" to 18)))
     fun echo(name: String): HttpHandler = {
         Response(OK).with(
             Body.string(TEXT_PLAIN).toLens() of "hello $name you are ${ageQuery(it)}"

--- a/src/docs/guide/howto/integrate_with_openapi/index.md
+++ b/src/docs/guide/howto/integrate_with_openapi/index.md
@@ -6,6 +6,7 @@ This contract example shows:
 - 2 endpoints with typesafe contracts (marshalling of path parameters and bodies)
 - Custom filters (reporting latency)
 - API key security via a typesafe Query parameter (this can be a header or a body parameter as well)
+- A parameter lens that provides metadata for the output OpenApi schema node
 - OpenApi v3 documentation - Run this example and point a browser [here](https://http4k.org/openapi3?url=http%3A%2F%2Flocalhost%3A8000%2Fcontext%2Fdocs%2Fopenapi.json)
 
 ### Gradle setup


### PR DESCRIPTION
Hi Folks,

We've added an extra field to `Meta` on a lens to enable values to be stuffed under a `schema` key, and then pulled out to add to the OpenAPI spec. This is specific to things that OpenApi considers to be a parameter.

@ivanmoore @jack-bolles and myself paired on these changes, our time was donated by Ford Digital.