### PR TITLE
Change to allow for any information from FieldMetadata to appear on the final SchemaNode

### DIFF
--- a/http4k-contract/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchema.kt
+++ b/http4k-contract/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchema.kt
@@ -318,7 +318,7 @@ private class SchemaNode(
     }
 
     fun put(key: String, value: Any?) {
-        map = map.plus(key to value).toSortedMap(compareBy<String> { sortOrder(it) }.thenBy { it })
+        map = map.plus(key to value)
     }
 
     private fun sortOrder(o1: String) = order.indexOf(o1).let {
@@ -341,7 +341,6 @@ private class SchemaNode(
     val format = map["format"]
 
     companion object {
-
         fun Primitive(
             name: String,
             paramMeta: ParamMeta,
@@ -396,7 +395,6 @@ private class SchemaNode(
                 "required",
                 properties.let { it.filterNot { it.value.isNullable }.takeIf { it.isNotEmpty() }?.keys?.sorted() })
             put("properties", properties)
-
         }
 
         fun Reference(
@@ -431,34 +429,21 @@ private class SchemaNode(
                 put("type", paramMeta().value)
                 put("additionalProperties", additionalProperties)
             }
-
     }
 
-
     override val entries: Set<Map.Entry<String, Any?>>
-        get() = map.entries
+        get() = map.toSortedMap(compareBy<String> { sortOrder(it) }.thenBy { it }).entries
+
     override val keys: Set<String>
         get() = map.keys
     override val size: Int
         get() = map.size
     override val values: Collection<Any?>
         get() = map.values
-
-    override fun isEmpty(): Boolean {
-        return map.isEmpty()
-    }
-
-    override fun get(key: String): Any? {
-        return map.get(key)
-    }
-
-    override fun containsValue(value: Any?): Boolean {
-        return map.containsValue(value)
-    }
-
-    override fun containsKey(key: String): Boolean {
-        return map.containsKey(key)
-    }
+    override fun isEmpty(): Boolean = map.isEmpty()
+    override fun get(key: String): Any? = map.get(key)
+    override fun containsValue(value: Any?): Boolean = map.containsValue(value)
+    override fun containsKey(key: String): Boolean = map.containsKey(key)
 }
 
 private fun items(obj: Any) = when (obj) {

--- a/http4k-contract/jsonschema/src/test/kotlin/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.kt
+++ b/http4k-contract/jsonschema/src/test/kotlin/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.kt
@@ -183,7 +183,8 @@ class AutoJsonToJsonSchemaTest {
                             mapOf(
                                 "key" to "string",
                                 "description" to "string description",
-                                "format" to "string format"
+                                "format" to "string format",
+                                "a-x-thing" to "some special value"
                             )
                         )
                     )

--- a/http4k-contract/jsonschema/src/test/resources/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.can write extra properties to map.approved
+++ b/http4k-contract/jsonschema/src/test/resources/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.can write extra properties to map.approved
@@ -11,13 +11,16 @@
             "example": "stringValue",
             "description": "string description",
             "format": "string format",
-            "type": "string"
+            "type": "string",
+            "a-x-thing": "some special value",
+            "key": "string"
           },
           "num": {
             "example": 1,
             "description": "int description",
             "format": "another format",
-            "type": "integer"
+            "type": "integer",
+            "key": 123
           }
         },
         "example": {

--- a/http4k-contract/jsonschema/src/test/resources/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.renders schema for custom json mapping.approved
+++ b/http4k-contract/jsonschema/src/test/resources/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.renders schema for custom json mapping.approved
@@ -2,23 +2,7 @@
   "node": {
     "$ref": "#/components/schemas/ArbObjectHolder",
     "example": null,
-    "description": null,
-    "format": null,
-    "default": null,
-    "title": null,
-    "multipleOf": null,
-    "maximum": null,
-    "exclusiveMaximum": null,
-    "minimum": null,
-    "exclusiveMinimum": null,
-    "maxLength": null,
-    "minLength": null,
-    "pattern": null,
-    "maxItems": null,
-    "minItems": null,
-    "uniqueItems": null,
-    "maxProperties": null,
-    "minProperties": null
+    "format": null
   },
   "definitions": [
     {
@@ -33,23 +17,7 @@
             "example": [
               "foobar"
             ],
-            "description": null,
             "format": null,
-            "default": null,
-            "title": null,
-            "multipleOf": null,
-            "maximum": null,
-            "exclusiveMaximum": null,
-            "minimum": null,
-            "exclusiveMinimum": null,
-            "maxLength": null,
-            "minLength": null,
-            "pattern": null,
-            "maxItems": null,
-            "minItems": null,
-            "uniqueItems": null,
-            "maxProperties": null,
-            "minProperties": null,
             "type": "array"
           }
         },
@@ -58,23 +26,7 @@
             "foobar"
           ]
         },
-        "description": null,
         "format": null,
-        "default": null,
-        "title": null,
-        "multipleOf": null,
-        "maximum": null,
-        "exclusiveMaximum": null,
-        "minimum": null,
-        "exclusiveMinimum": null,
-        "maxLength": null,
-        "minLength": null,
-        "pattern": null,
-        "maxItems": null,
-        "minItems": null,
-        "uniqueItems": null,
-        "maxProperties": null,
-        "minProperties": null,
         "type": "object",
         "required": [
           "inner"

--- a/http4k-contract/jsonschema/src/test/resources/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.renders schema for custom json mapping.approved
+++ b/http4k-contract/jsonschema/src/test/resources/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.renders schema for custom json mapping.approved
@@ -11,8 +11,8 @@
         "properties": {
           "inner": {
             "items": {
-              "type": "string",
-              "format": null
+              "format": null,
+              "type": "string"
             },
             "example": [
               "foobar"

--- a/http4k-contract/jsonschema/src/test/resources/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.renders schema for raw map field.approved
+++ b/http4k-contract/jsonschema/src/test/resources/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.renders schema for raw map field.approved
@@ -93,8 +93,8 @@
         },
         "key6": {
           "items": {
-            "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "type": "integer"
           },
           "example": [
             1,

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.auto rendering renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.auto rendering renders as expected.approved
@@ -582,8 +582,8 @@
           },
           "numbers": {
             "items": {
-              "type": "integer",
-              "format": "int32"
+              "format": "int32",
+              "type": "integer"
             },
             "example": [
               1


### PR DESCRIPTION
We have a requirement where we wish to append non-standard fields, and override the fields http4k attempts to derive for a given schema.

Changes to `SchemaNode` so that it is backed by a map; rather than a strict set of properties. Addition of the ability to supply an order for known properties, unknown properties appear at the bottom, sub-sorted alphabetically.

@ivanmoore @jack-bolles and myself paired on these changes, our time was donated by Ford Digital.