### PR TITLE
Allow for FieldMetadata to be collected for root Schemas

### DIFF
--- a/http4k-contract/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/MetadataRetrieval.kt
+++ b/http4k-contract/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/MetadataRetrieval.kt
@@ -1,0 +1,27 @@
+package org.http4k.contract.jsonschema.v3
+
+import java.lang.IllegalArgumentException
+import kotlin.reflect.KType
+import kotlin.reflect.full.createType
+
+fun interface MetadataRetrieval : (Any) -> FieldMetadata {
+    companion object {
+        fun compose(vararg retrieval: MetadataRetrieval) = MetadataRetrieval { target ->
+            retrieval.asSequence().map {
+                it(target)
+            }.firstOrNull() ?: FieldMetadata()
+        }
+    }
+}
+
+class SimpleMetadataLookup(
+    private val typeToMetadata: Map<KType, FieldMetadata>
+) : MetadataRetrieval {
+    override fun invoke(target: Any): FieldMetadata {
+        return try {
+            typeToMetadata[target::class.createType()] ?: FieldMetadata()
+        } catch (e: IllegalArgumentException) {
+            FieldMetadata()
+        }
+    }
+}

--- a/http4k-contract/jsonschema/src/test/kotlin/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.kt
+++ b/http4k-contract/jsonschema/src/test/kotlin/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.kt
@@ -214,6 +214,34 @@ class AutoJsonToJsonSchemaTest {
     }
 
     @Test
+    fun `can add extra properties to a root component`(approver: Approver) {
+        val creator = AutoJsonToJsonSchema(
+            json,
+            metadataRetrieval = { obj ->
+                if (obj is ArbObject3) {
+                    FieldMetadata(
+                        mapOf(
+                            "key" to "arb",
+                            "description" to "arb desc",
+                            "additionalProperties" to false
+                        )
+                    )
+                } else {
+                    FieldMetadata()
+                }
+            },
+            modelNamer = SchemaModelNamer.Full,
+            refLocationPrefix = "locationPrefix"
+        )
+
+        approver.assertApproved(
+            Response(OK)
+                .with(CONTENT_TYPE of APPLICATION_JSON)
+                .body(Jackson.asFormatString(creator.toSchema(ArbObject3(), refModelNamePrefix = null)))
+        )
+    }
+
+    @Test
     fun `can override definition id for a raw map`(approver: Approver) {
         approver.assertApproved(
             mapOf(

--- a/http4k-contract/jsonschema/src/test/kotlin/org/http4k/contract/jsonschema/v3/SimpleLookupTest.kt
+++ b/http4k-contract/jsonschema/src/test/kotlin/org/http4k/contract/jsonschema/v3/SimpleLookupTest.kt
@@ -33,7 +33,7 @@ class SimpleLookupTest {
     }
 
     @Test
-    fun `throws on no field found`() {
+    fun `recovers and responds with empty FieldMetadata when there are generics in the class`() {
         assertThat("non existent", { SimpleLookup()(KotlinBean(), "non existent") }, throws<NoFieldFound>())
     }
 }

--- a/http4k-contract/jsonschema/src/test/kotlin/org/http4k/contract/jsonschema/v3/SimpleMetadataLookupTest.kt
+++ b/http4k-contract/jsonschema/src/test/kotlin/org/http4k/contract/jsonschema/v3/SimpleMetadataLookupTest.kt
@@ -1,0 +1,44 @@
+package org.http4k.contract.jsonschema.v3
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+import kotlin.reflect.KTypeProjection
+import kotlin.reflect.KVariance
+import kotlin.reflect.full.createType
+
+class SimpleMetadataLookupTest {
+
+    class KotlinBean
+    class Blowup<T>(val inside: T)
+
+    val simpleMetadataLookup =
+        SimpleMetadataLookup(
+            mapOf(
+                KotlinBean::class.createType() to FieldMetadata(mapOf("description" to "A field description")),
+                Blowup::class.createType(
+                    listOf(KTypeProjection(KVariance.OUT, String::class.createType()))
+                ) to FieldMetadata(mapOf("description" to "A field description"))
+            )
+        )
+
+    @Test
+    fun `finds value from object`() {
+        assertThat(
+            "exists",
+            simpleMetadataLookup(KotlinBean()),
+            equalTo(FieldMetadata(mapOf("description" to "A field description")))
+        )
+        assertThat(
+            "does not exist",
+            simpleMetadataLookup(object {}),
+            equalTo(FieldMetadata())
+        )
+    }
+
+    @Test
+    fun `does not work with generics`() {
+        assertThat("", simpleMetadataLookup(Blowup("inside")), equalTo(FieldMetadata()))
+    }
+
+}

--- a/http4k-contract/jsonschema/src/test/resources/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.can add extra properties to a root component.approved
+++ b/http4k-contract/jsonschema/src/test/resources/org/http4k/contract/jsonschema/v3/AutoJsonToJsonSchemaTest.can add extra properties to a root component.approved
@@ -1,0 +1,35 @@
+{
+  "node": {
+    "$ref": "#/locationPrefix/org.http4k.contract.jsonschema.v3.ArbObject3"
+  },
+  "definitions": [
+    {
+      "first": "org.http4k.contract.jsonschema.v3.ArbObject3",
+      "second": {
+        "properties": {
+          "str": {
+            "example": "stringValue",
+            "type": "string"
+          },
+          "num": {
+            "example": 1,
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "example": {
+          "str": "stringValue",
+          "num": 1
+        },
+        "additionalProperties": false,
+        "description": "arb desc",
+        "type": "object",
+        "required": [
+          "num",
+          "str"
+        ],
+        "key": "arb"
+      }
+    }
+  ]
+}

--- a/http4k-contract/openapi/src/main/kotlin/org/http4k/contract/openapi/v3/jacksonExt.kt
+++ b/http4k-contract/openapi/src/main/kotlin/org/http4k/contract/openapi/v3/jacksonExt.kt
@@ -1,11 +1,14 @@
 package org.http4k.contract.openapi.v3
 
+import org.http4k.contract.jsonschema.v3.FieldMetadata
 import org.http4k.contract.jsonschema.v3.FieldRetrieval
 import org.http4k.contract.jsonschema.v3.JacksonFieldMetadataRetrievalStrategy
 import org.http4k.contract.jsonschema.v3.JacksonJsonNamingAnnotated
 import org.http4k.contract.jsonschema.v3.JacksonJsonPropertyAnnotated
+import org.http4k.contract.jsonschema.v3.MetadataRetrieval
 import org.http4k.contract.jsonschema.v3.PrimitivesFieldMetadataRetrievalStrategy
 import org.http4k.contract.jsonschema.v3.SimpleLookup
+import org.http4k.contract.jsonschema.v3.SimpleMetadataLookup
 import org.http4k.contract.jsonschema.v3.then
 import org.http4k.contract.openapi.ApiInfo
 import org.http4k.contract.openapi.ApiRenderer
@@ -13,6 +16,7 @@ import org.http4k.contract.openapi.OpenAPIJackson
 import org.http4k.contract.openapi.OpenApiExtension
 import org.http4k.contract.openapi.OpenApiVersion
 import org.http4k.format.ConfigurableJackson
+import kotlin.reflect.KType
 
 /**
  * Defaults for configuring OpenApi3 with Jackson
@@ -22,11 +26,12 @@ fun OpenApi3(
     json: ConfigurableJackson = OpenAPIJackson,
     extensions: List<OpenApiExtension> = emptyList(),
     servers: List<ApiServer> = emptyList(),
-    version: OpenApiVersion = OpenApiVersion._3_0_0
+    version: OpenApiVersion = OpenApiVersion._3_0_0,
+    typeToMetadata: Map<KType, FieldMetadata> = emptyMap()
 ) =
-    OpenApi3(apiInfo, json, extensions, ApiRenderer.Auto(json, AutoJsonToJsonSchema(json)), servers = servers, version = version)
+    OpenApi3(apiInfo, json, extensions, ApiRenderer.Auto(json, AutoJsonToJsonSchema(json, typeToMetadata)), servers = servers, version = version)
 
-fun AutoJsonToJsonSchema(json: ConfigurableJackson) = org.http4k.contract.jsonschema.v3.AutoJsonToJsonSchema(
+fun AutoJsonToJsonSchema(json: ConfigurableJackson, typeToMetadata: Map<KType, FieldMetadata> = emptyMap()) = org.http4k.contract.jsonschema.v3.AutoJsonToJsonSchema(
     json,
     FieldRetrieval.compose(
         SimpleLookup(
@@ -34,5 +39,6 @@ fun AutoJsonToJsonSchema(json: ConfigurableJackson) = org.http4k.contract.jsonsc
             JacksonFieldMetadataRetrievalStrategy.then(PrimitivesFieldMetadataRetrievalStrategy)
         ),
         FieldRetrieval.compose(JacksonJsonPropertyAnnotated, JacksonJsonNamingAnnotated(json))
-    )
+    ),
+    metadataRetrieval = MetadataRetrieval.compose(SimpleMetadataLookup(typeToMetadata = typeToMetadata))
 )

--- a/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3AutoTest.kt
+++ b/http4k-contract/openapi/src/test/kotlin/org/http4k/contract/openapi/v3/OpenApi3AutoTest.kt
@@ -1,11 +1,14 @@
 package org.http4k.contract.openapi.v3
 
 import com.fasterxml.jackson.databind.JsonNode
+import org.http4k.contract.ArbObject2
 import org.http4k.contract.AutoContractRendererContract
+import org.http4k.contract.jsonschema.v3.FieldMetadata
 import org.http4k.contract.openapi.AddSimpleFieldToRootNode
 import org.http4k.contract.openapi.ApiInfo
 import org.http4k.contract.openapi.OpenAPIJackson
 import org.http4k.core.Uri
+import kotlin.reflect.full.createType
 
 class OpenApi3AutoTest : AutoContractRendererContract<JsonNode>(
     OpenAPIJackson,
@@ -13,6 +16,7 @@ class OpenApi3AutoTest : AutoContractRendererContract<JsonNode>(
         ApiInfo("title", "1.2", "module description"),
         OpenAPIJackson,
         listOf(AddSimpleFieldToRootNode),
-        listOf(ApiServer(Uri.of("http://localhost:8000"), "a very simple API"))
+        listOf(ApiServer(Uri.of("http://localhost:8000"), "a very simple API")),
+        typeToMetadata = mapOf(ArbObject2::class.createType() to FieldMetadata("additionalProperties" to false))
     )
 )

--- a/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.auto rendering renders as expected.approved
+++ b/http4k-contract/openapi/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.auto rendering renders as expected.approved
@@ -608,6 +608,7 @@
           ],
           "bool": true
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "bool",


### PR DESCRIPTION
Previously only fields on object could be annotated by metadata, this is a proposal to fix that. It should be 100% backwards compatible.

Our time has been donated by Ford Digital