### PR TITLE
Add support for surrogate-key headers in EtagSupport

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
@@ -195,7 +195,7 @@ object ResponseFilters {
         private fun ByteArray.toHex() = joinToString("") { "%02x".format(it) }
 
         companion object {
-            private val SAFE_HEADERS = listOf("date", "last-modified", "cache-control", "expires", "set-cookie", "vary")
+            private val SAFE_HEADERS = listOf("date", "last-modified", "cache-control", "expires", "set-cookie", "vary", "surrogate-key")
         }
     }
 

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ResponseFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ResponseFiltersTest.kt
@@ -440,6 +440,7 @@ class ResponseFiltersTest {
                     .header("date", "passesThroughDate")
                     .header("vary", "passesThroughVary")
                     .header("X-foo", "doesntPassThrough")
+                    .header("surrogate-key", "passesThroughSurrogateKey")
             }
 
             val response = handler(
@@ -451,6 +452,7 @@ class ResponseFiltersTest {
                 response, !hasHeader("x-foo")
                     and hasHeader("date", equalTo("passesThroughDate"))
                     and hasHeader("vary", equalTo("passesThroughVary"))
+                    and hasHeader("surrogate-key", equalTo("passesThroughSurrogateKey"))
             )
         }
     }


### PR DESCRIPTION
Fixes the current problem where if an http4k server sets surrogate-key headers on responses that are to be cached in Varnish/Fastly/etc, then when the cache revalidates and gets a NOT_MODIFIED from the ETagSupport filter it drops the surrogate-key header, breaking purging by surrogate-key.