### PR TITLE
Allow overriding of `Automarshalling.asInputStream(Any)`

### DIFF
--- a/http4k-format/core/src/main/kotlin/org/http4k/format/AutoMarshalling.kt
+++ b/http4k-format/core/src/main/kotlin/org/http4k/format/AutoMarshalling.kt
@@ -30,7 +30,7 @@ abstract class AutoMarshalling {
 
     abstract fun asFormatString(input: Any): String
 
-    fun asInputStream(input: Any): InputStream = asFormatString(input).byteInputStream()
+    open fun asInputStream(input: Any): InputStream = asFormatString(input).byteInputStream()
 
     /**
      * Conversion happens by converting the base object into JSON and then out again

--- a/http4k-format/jackson-xml/src/main/kotlin/org/http4k/format/ConfgurableJacksonXml.kt
+++ b/http4k-format/jackson-xml/src/main/kotlin/org/http4k/format/ConfgurableJacksonXml.kt
@@ -26,6 +26,8 @@ open class ConfigurableJacksonXml(
     override fun <T : Any> asA(input: String, target: KClass<T>): T = mapper.readValue(input, target.java)
     override fun <T : Any> asA(input: InputStream, target: KClass<T>): T = mapper.readValue(input, target.java)
 
+    override fun asInputStream(input: Any): InputStream = mapper.writeValueAsBytes(input).inputStream()
+
     /**
      * Convenience function to write the object as XM to the message body and set the content type.
      */

--- a/http4k-format/jackson-yaml/src/main/kotlin/org/http4k/format/ConfigurableJacksonYaml.kt
+++ b/http4k-format/jackson-yaml/src/main/kotlin/org/http4k/format/ConfigurableJacksonYaml.kt
@@ -22,6 +22,8 @@ open class ConfigurableJacksonYaml(val mapper: ObjectMapper, override val defaul
 
     override fun asFormatString(input: Any): String = mapper.writeValueAsString(input)
 
+    override fun asInputStream(input: Any): InputStream = mapper.writeValueAsBytes(input).inputStream()
+
     inline fun <reified T : Any> WsMessage.Companion.auto() = WsMessage.string().map(mapper.read<T>(), mapper.write())
 
     inline fun <reified T : Any> Body.Companion.auto(

--- a/http4k-format/jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
+++ b/http4k-format/jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
@@ -91,6 +91,8 @@ open class ConfigurableJackson(
 
     inline fun <reified T : Any> JsonNode.asA(): T = mapper.convertValue(this)
 
+    override fun asInputStream(input: Any): InputStream = mapper.writeValueAsBytes(input).inputStream()
+
     inline fun <reified T : Any> WsMessage.Companion.auto() = WsMessage.string().map(mapper.read<T>(), mapper.write())
 
     inline fun <reified T : Any> Body.Companion.auto(


### PR DESCRIPTION
This allows some implementations to avoid creating an intermediate string when serializing directly to an `InputStream`.