### PR TITLE
Replace usage of `Clock` in `http4k-core` with `() -> Instant` where …

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/events/EventFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/events/EventFilters.kt
@@ -2,6 +2,7 @@ package org.http4k.events
 
 import org.http4k.filter.ZipkinTracesStorage
 import java.time.Clock
+import java.time.Instant
 
 /**
  * Useful EventFilters used in building event processing pipelines to add various types of metadata to the events
@@ -31,9 +32,14 @@ object EventFilters {
     /**
      * Adds timestamp metadata to the event.
      */
-    fun AddTimestamp(clock: Clock = Clock.systemUTC()) = EventFilter { next ->
+    fun AddTimestamp(clock: Clock = Clock.systemUTC()) = AddTimestamp(clock::instant)
+
+    /**
+     * Adds timestamp metadata to the event.
+     */
+    fun AddTimestamp(timeSource: () -> Instant) = EventFilter { next ->
         {
-            next(it + ("timestamp" to clock.instant()))
+            next(it + ("timestamp" to timeSource()))
         }
     }
 

--- a/http4k-core/src/main/kotlin/org/http4k/security/CredentialsProvider.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/security/CredentialsProvider.kt
@@ -18,6 +18,12 @@ fun <T> CredentialsProvider.Companion.Refreshing(
     gracePeriod: Duration = Duration.ofSeconds(10),
     clock: Clock = Clock.systemUTC(),
     refreshFn: RefreshCredentials<T>
+) = Refreshing(gracePeriod, clock::instant, refreshFn)
+
+fun <T> CredentialsProvider.Companion.Refreshing(
+    gracePeriod: Duration = Duration.ofSeconds(10),
+    timeSource: () -> Instant,
+    refreshFn: RefreshCredentials<T>
 ) = object : CredentialsProvider<T> {
     private val stored = AtomicReference<ExpiringCredentials<T>>(null)
 
@@ -53,5 +59,5 @@ fun <T> CredentialsProvider.Companion.Refreshing(
     private fun ExpiringCredentials<T>.expiresWithin(duration: Duration): Boolean =
         expiry
             .minus(duration)
-            .isBefore(clock.instant())
+            .isBefore(timeSource())
 }


### PR DESCRIPTION
…appropriate

Allows the use of [fork-handles](https://github.com/fork-handles/forkhandles/tree/trunk/time4k) `TimeSource` type alias.