### PR TITLE
Write CSV header even for empty list

### DIFF
--- a/http4k-format/jackson-csv/src/main/kotlin/org/http4k/format/ConfigurableJacksonCsv.kt
+++ b/http4k-format/jackson-csv/src/main/kotlin/org/http4k/format/ConfigurableJacksonCsv.kt
@@ -19,15 +19,13 @@ open class ConfigurableJacksonCsv(val mapper: CsvMapper, val defaultContentType:
 
     inline fun <reified T> defaultSchema(): CsvSchema = mapper.schemaFor(T::class.java).withHeader()
 
-    fun <T : Any> writerFor(type: KClass<T>, schema: CsvSchema): (List<T>) -> String {
-        val writer = mapper.writerFor(type.java).with(schema)
-        return { body: List<T> ->
-            StringWriter().use { stringWriter ->
-                writer.writeValues(stringWriter)
-                    .writeAll(body)
-                stringWriter
-            }.toString()
-        }
+    fun <T : Any> writerFor(type: KClass<T>, schema: CsvSchema): (List<T>) -> String = { body: List<T> ->
+        StringWriter().use { stringWriter ->
+            mapper.writerFor(type.java).with(schema).writeValues(stringWriter).use {
+                it.writeAll(body)
+            }
+            stringWriter
+        }.toString()
     }
 
     fun <T : Any> readerFor(type: KClass<T>, schema: CsvSchema): (String) -> List<T> {

--- a/http4k-format/jackson-csv/src/test/kotlin/org/http4k/format/jacksonCsvTests.kt
+++ b/http4k-format/jackson-csv/src/test/kotlin/org/http4k/format/jacksonCsvTests.kt
@@ -1,8 +1,10 @@
 package org.http4k.format
 
 import com.fasterxml.jackson.annotation.JsonPropertyOrder
+import com.fasterxml.jackson.dataformat.csv.CsvSchema
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.has
 import org.http4k.core.Body
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
@@ -40,6 +42,29 @@ class JacksonCsvBodyTest {
         assertThat(
             lens(Response(OK).with(lens of objects)),
             equalTo(objects)
+        )
+    }
+
+    @Test
+    fun `default schema is set to use headers`() {
+        assertThat(
+            JacksonCsv.defaultSchema<CsvArbObject>(),
+            has(CsvSchema::usesHeader, equalTo(true))
+        )
+    }
+
+    @Test
+    fun `empty list of objects with schema headers results in output with only headers`() {
+        val writer = JacksonCsv.writerFor(CsvArbObject::class, JacksonCsv.defaultSchema<CsvArbObject>())
+
+        assertThat(
+            writer(emptyList()),
+            equalTo(
+                """
+                    |string,numbers,bool
+                    |
+                """.trimMargin()
+            )
         )
     }
 


### PR DESCRIPTION
When `CsvSchema.withHeader` is used, as is for the default schema, then the resulting CSV text should include the header row even if the list of objects to write is empty.

The fix for the issue was simply to close the underlying CSV writer, which causes the headers to be written correctly.

Noticed this issue in one of the projects I'm working on. I replicated the issue using the added test, plus I also added another test to prove the defaultSchema function creates a schema with headers enabled.

Potentially breaking fix I guess.