### PR TITLE
Allows to remove all queries for a URI

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
@@ -64,7 +64,7 @@ data class Uri(val scheme: String, val userInfo: String, val host: String, val p
 
 fun Uri.removeQuery(name: String) = copy(query = query.toParameters().filterNot { it.first == name }.toUrlFormEncoded())
 
-fun Uri.removeQueries(prefix: String) =
+fun Uri.removeQueries(prefix: String= "") =
     copy(query = query.toParameters().filterNot { it.first.startsWith(prefix) }.toUrlFormEncoded())
 
 fun Uri.query(name: String, value: String?): Uri =

--- a/http4k-core/src/test/kotlin/org/http4k/core/UriTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/UriTest.kt
@@ -90,6 +90,28 @@ class UriTest {
     }
 
     @Test
+    fun can_remove_all_parameter_with_prefix() {
+        assertThat(
+            Uri.of(value = "http://ignore")
+                .query("aa", "b")
+                .query("c", "d")
+                .query("ab", "c")
+                .removeQueries("a").toString(), equalTo("http://ignore?c=d")
+        )
+    }
+
+    @Test
+    fun can_remove_all_parameter() {
+        assertThat(
+            Uri.of(value = "http://ignore")
+                .query("aa", "b")
+                .query("c", "d")
+                .query("ab", "c")
+                .removeQueries().toString(), equalTo("http://ignore")
+        )
+    }
+
+    @Test
     fun parameters_can_be_defined_in_value() {
         assertThat(Uri.of("http://www.google.com?a=b"), equalTo(Uri.of("http://www.google.com").query("a", "b")))
     }


### PR DESCRIPTION
The `Request` already allows to remove all queries as it has the default parameter value set as "". This adds also the default to `Uri.removeQueries()` so it can remove all queries as well.

---

I'd be happy to provide a test, but I cannot find a direct test for that function to build upon, it seems to be implicitly tested through the test for `Request.removeQueries()`. Where would this new test live?