### PR TITLE
Fix #1103 - Omit CORs headers if no match,

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
@@ -61,25 +61,28 @@ object ServerFilters {
                 val response = if (it.method == OPTIONS) Response(OK) else next(it)
 
                 val origin = it.header("Origin")
+
                 val allowedOrigin = when {
                     policy.originPolicy is AllowAllOriginPolicy -> "*"
                     origin != null && policy.originPolicy(origin) -> origin
-                    else -> "null"
+                    else -> null
                 }
 
-                response.with(
-                    Header.required("access-control-allow-origin") of allowedOrigin,
-                    Header.required("access-control-allow-headers") of policy.headers.joined(),
-                    Header.required("access-control-allow-methods") of policy.methods.map { method -> method.name }
-                        .joined(),
-                    { res -> if (policy.credentials) res.header("access-control-allow-credentials", "true") else res },
-                    { res ->
-                        res.takeIf { policy.exposedHeaders.isNotEmpty() }
-                            ?.header("access-control-expose-headers", policy.exposedHeaders.joined())
-                            ?: res
-                    },
-                    { res -> policy.maxAge?.let { maxAge -> res.header("access-control-max-age", "$maxAge") } ?: res }
-                )
+                allowedOrigin?.let {
+                    response.with(
+                        Header.required("access-control-allow-origin") of allowedOrigin,
+                        Header.required("access-control-allow-headers") of policy.headers.joined(),
+                        Header.required("access-control-allow-methods") of policy.methods.map { method -> method.name }
+                            .joined(),
+                        { res -> if (policy.credentials) res.header("access-control-allow-credentials", "true") else res },
+                        { res ->
+                            res.takeIf { policy.exposedHeaders.isNotEmpty() }
+                                ?.header("access-control-expose-headers", policy.exposedHeaders.joined())
+                                ?: res
+                        },
+                        { res -> policy.maxAge?.let { maxAge -> res.header("access-control-max-age", "$maxAge") } ?: res }
+                    )
+                } ?: response
             }
         }
     }

--- a/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/filter/ServerFiltersTest.kt
@@ -295,9 +295,9 @@ class ServerFiltersTest {
 
             assertThat(
                 response, hasStatus(OK)
-                    .and(hasHeader("access-control-allow-origin", "null"))
-                    .and(hasHeader("access-control-allow-headers", "rita, sue, bob"))
-                    .and(hasHeader("access-control-allow-methods", "DELETE, POST"))
+                    .and(!hasHeader("access-control-allow-origin"))
+                    .and(!hasHeader("access-control-allow-headers"))
+                    .and(!hasHeader("access-control-allow-methods"))
                     .and(!hasHeader("access-control-allow-credentials"))
             )
         }
@@ -315,9 +315,9 @@ class ServerFiltersTest {
 
             assertThat(
                 response, hasStatus(OK)
-                    .and(hasHeader("access-control-allow-origin", "null"))
-                    .and(hasHeader("access-control-allow-headers", "rita, sue, bob"))
-                    .and(hasHeader("access-control-allow-methods", "DELETE, POST"))
+                    .and(!hasHeader("access-control-allow-origin"))
+                    .and(!hasHeader("access-control-allow-headers"))
+                    .and(!hasHeader("access-control-allow-methods"))
                     .and(!hasHeader("access-control-allow-credentials"))
             )
         }


### PR DESCRIPTION
We don't emit the CORs headers when no match. See

https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null