### PR TITLE
Add convenience extensions to Response Cache Control methods

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
@@ -21,13 +21,19 @@ fun Response.noStore() = addCacheability("no-store")
 
 fun Response.immutable() = addCacheability("immutable")
 
+fun Response.maxAge() = getCacheControlDirectiveValue("max-age")
+
 fun Response.maxAge(duration: JavaDuration) = replaceHeader("Cache-Control", MaxAgeTtl(duration).replaceIn(header("Cache-Control")))
 
 fun Response.maxAge(duration: KotlinDuration) = maxAge(duration.toJavaDuration())
 
+fun Response.staleWhileRevalidate() = getCacheControlDirectiveValue("stale-while-revalidate")
+
 fun Response.staleWhileRevalidate(duration: JavaDuration) = replaceHeader("Cache-Control", StaleWhenRevalidateTtl(duration).replaceIn(header("Cache-Control")))
 
 fun Response.staleWhileRevalidate(duration: KotlinDuration) = staleWhileRevalidate(duration.toJavaDuration())
+
+fun Response.staleIfError() = getCacheControlDirectiveValue("stale-if-error")
 
 fun Response.staleIfError(duration: JavaDuration) = replaceHeader("Cache-Control", StaleIfErrorTtl(duration).replaceIn(header("Cache-Control")))
 
@@ -54,3 +60,6 @@ private enum class Cacheability {
 
 private fun String.ensureOnlyOnceIn(currentValue: String?): String =
     currentValue?.split(",")?.map(String::trim)?.toSet()?.plus(this)?.joinToString(", ") ?: this
+
+private fun Response.getCacheControlDirectiveValue(directive: String) =
+    header("Cache-Control")?.let { Regex("$directive=(\\d+)").find(it) }?.groupValues?.lastOrNull()?.toLong()

--- a/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
@@ -3,7 +3,9 @@ package org.http4k.core
 import org.http4k.filter.MaxAgeTtl
 import org.http4k.filter.StaleIfErrorTtl
 import org.http4k.filter.StaleWhenRevalidateTtl
-import java.time.Duration
+import kotlin.time.Duration as KotlinDuration
+import kotlin.time.toJavaDuration
+import java.time.Duration as JavaDuration
 
 fun Response.public() = addCacheability(Cacheability.public)
 
@@ -19,11 +21,17 @@ fun Response.noStore() = addCacheability("no-store")
 
 fun Response.immutable() = addCacheability("immutable")
 
-fun Response.maxAge(duration: Duration) = replaceHeader("Cache-Control", MaxAgeTtl(duration).replaceIn(header("Cache-Control")))
+fun Response.maxAge(duration: JavaDuration) = replaceHeader("Cache-Control", MaxAgeTtl(duration).replaceIn(header("Cache-Control")))
 
-fun Response.staleWhileRevalidate(duration: Duration) = replaceHeader("Cache-Control", StaleWhenRevalidateTtl(duration).replaceIn(header("Cache-Control")))
+fun Response.maxAge(duration: KotlinDuration) = maxAge(duration.toJavaDuration())
 
-fun Response.staleIfError(duration: Duration) = replaceHeader("Cache-Control", StaleIfErrorTtl(duration).replaceIn(header("Cache-Control")))
+fun Response.staleWhileRevalidate(duration: JavaDuration) = replaceHeader("Cache-Control", StaleWhenRevalidateTtl(duration).replaceIn(header("Cache-Control")))
+
+fun Response.staleWhileRevalidate(duration: KotlinDuration) = staleWhileRevalidate(duration.toJavaDuration())
+
+fun Response.staleIfError(duration: JavaDuration) = replaceHeader("Cache-Control", StaleIfErrorTtl(duration).replaceIn(header("Cache-Control")))
+
+fun Response.staleIfError(duration: KotlinDuration) = staleIfError(duration.toJavaDuration())
 
 private fun Response.addCacheability(value: String): Response =
     replaceHeader("Cache-Control", value.ensureOnlyOnceIn(header("Cache-Control")))

--- a/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
@@ -62,4 +62,4 @@ private fun String.ensureOnlyOnceIn(currentValue: String?): String =
     currentValue?.split(",")?.map(String::trim)?.toSet()?.plus(this)?.joinToString(", ") ?: this
 
 private fun Response.getCacheControlDirectiveValue(directive: String) =
-    header("Cache-Control")?.let { Regex("$directive=(\\d+)").find(it) }?.groupValues?.lastOrNull()?.toLong()
+    header("Cache-Control")?.let { Regex("$directive=(\\d+)").find(it) }?.groupValues?.lastOrNull()?.toLongOrNull()

--- a/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
@@ -5,6 +5,9 @@ import com.natpryce.hamkrest.equalTo
 import org.http4k.core.Status.Companion.OK
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class ResponseCacheExtTest {
 
@@ -58,24 +61,45 @@ class ResponseCacheExtTest {
     }
 
     @Test
-    fun `adds max-age to response Cache-Control header`() {
+    fun `adds max-age to response Cache-Control header from Java duration`() {
         val maxAgeResponse = Response(OK).maxAge(Duration.ofMinutes(1))
 
         assertThat(maxAgeResponse.header("Cache-Control"), equalTo("max-age=60"))
     }
 
     @Test
-    fun `adds stale-while-revalidate to response Cache-Control header`() {
+    fun `adds max-age to response Cache-Control header from Kotlin duration`() {
+        val maxAgeResponse = Response(OK).maxAge(2.hours)
+
+        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("max-age=7200"))
+    }
+
+    @Test
+    fun `adds stale-while-revalidate to response Cache-Control header from Java duration`() {
         val maxAgeResponse = Response(OK).staleWhileRevalidate(Duration.ofMinutes(1))
 
         assertThat(maxAgeResponse.header("Cache-Control"), equalTo("stale-while-revalidate=60"))
     }
 
     @Test
-    fun `adds stale-if-error to response Cache-Control header`() {
+    fun `adds stale-while-revalidate to response Cache-Control header from Kotlin Duration`() {
+        val maxAgeResponse = Response(OK).staleWhileRevalidate(3.minutes)
+
+        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("stale-while-revalidate=180"))
+    }
+
+    @Test
+    fun `adds stale-if-error to response Cache-Control header from Java duration`() {
         val maxAgeResponse = Response(OK).staleIfError(Duration.ofMinutes(1))
 
         assertThat(maxAgeResponse.header("Cache-Control"), equalTo("stale-if-error=60"))
+    }
+
+    @Test
+    fun `adds stale-if-error to response Cache-Control header from Kotlin Duration`() {
+        val maxAgeResponse = Response(OK).staleIfError(6.seconds)
+
+        assertThat(maxAgeResponse.header("Cache-Control"), equalTo("stale-if-error=6"))
     }
 
     @Test

--- a/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
@@ -61,6 +61,30 @@ class ResponseCacheExtTest {
     }
 
     @Test
+    fun `retrieves null max age if no Cache-Control header`() {
+        val response = Response(OK)
+        assertThat(response.maxAge(), equalTo(null))
+    }
+
+    @Test
+    fun `retrieves null max age if Cache-Control header has no max-age directive`() {
+        val response = Response(OK).header("Cache-Control", "public")
+        assertThat(response.maxAge(), equalTo(null))
+    }
+
+    @Test
+    fun `retrieves null max age if Cache-Control header has invalid max-age directive`() {
+        val response = Response(OK).header("Cache-Control", "max-age=not_a_number")
+        assertThat(response.maxAge(), equalTo(null))
+    }
+
+    @Test
+    fun `retrieves max age from Cache-Control header if valid`() {
+        val response = Response(OK).header("Cache-Control", "public, max-age=60, stale-if-error=1000")
+        assertThat(response.maxAge(), equalTo(60))
+    }
+
+    @Test
     fun `adds max-age to response Cache-Control header from Java duration`() {
         val maxAgeResponse = Response(OK).maxAge(Duration.ofMinutes(1))
 
@@ -75,6 +99,30 @@ class ResponseCacheExtTest {
     }
 
     @Test
+    fun `retrieves null stale-while-revalidate if no Cache-Control header`() {
+        val response = Response(OK)
+        assertThat(response.staleWhileRevalidate(), equalTo(null))
+    }
+
+    @Test
+    fun `retrieves null stale-while-revalidate if Cache-Control header has no directive`() {
+        val response = Response(OK).header("Cache-Control", "public")
+        assertThat(response.staleWhileRevalidate(), equalTo(null))
+    }
+
+    @Test
+    fun `retrieves null stale-while-revalidate if Cache-Control header has invalid directive`() {
+        val response = Response(OK).header("Cache-Control", "stale-while-revalidate=not_a_number")
+        assertThat(response.staleWhileRevalidate(), equalTo(null))
+    }
+
+    @Test
+    fun `retrieves stale-while-revalidate from Cache-Control header if valid`() {
+        val response = Response(OK).header("Cache-Control", "public, max-age=60, stale-while-revalidate=1000")
+        assertThat(response.staleWhileRevalidate(), equalTo(1000))
+    }
+
+    @Test
     fun `adds stale-while-revalidate to response Cache-Control header from Java duration`() {
         val maxAgeResponse = Response(OK).staleWhileRevalidate(Duration.ofMinutes(1))
 
@@ -86,6 +134,30 @@ class ResponseCacheExtTest {
         val maxAgeResponse = Response(OK).staleWhileRevalidate(3.minutes)
 
         assertThat(maxAgeResponse.header("Cache-Control"), equalTo("stale-while-revalidate=180"))
+    }
+
+    @Test
+    fun `retrieves null stale-if-error if no Cache-Control header`() {
+        val response = Response(OK)
+        assertThat(response.staleIfError(), equalTo(null))
+    }
+
+    @Test
+    fun `retrieves null stale-if-error if Cache-Control header has no directive`() {
+        val response = Response(OK).header("Cache-Control", "public")
+        assertThat(response.staleIfError(), equalTo(null))
+    }
+
+    @Test
+    fun `retrieves null stale-if-error if Cache-Control header has invalid directive`() {
+        val response = Response(OK).header("Cache-Control", "stale-if-error=not_a_number")
+        assertThat(response.staleIfError(), equalTo(null))
+    }
+
+    @Test
+    fun `retrieves stale-if-error from Cache-Control header if valid`() {
+        val response = Response(OK).header("Cache-Control", "stale-if-error=10, public, max-age=60")
+        assertThat(response.staleIfError(), equalTo(10))
     }
 
     @Test


### PR DESCRIPTION
Adds the following functions:

- Update the Cache-Control directives from a Kotlin duration as well as a Java duration
- Add convenience methods for parsing the cache control directives as `Long` values

First contribution to this repo so let me know if I've missed anything and I'll update 😃 