### PR TITLE
Add lenses documentation to concepts navigation

### DIFF
--- a/src/mkdocs.yml
+++ b/src/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
   - Concepts:
     - Rationale: guide/concepts/rationale.md
     - HTTP: guide/concepts/http.md
+    - Lenses: guide/concepts/lens.md
     - Serverless: guide/concepts/serverless.md
     - WebSockets: guide/concepts/websockets.md
     - Server-Sent Events: guide/concepts/server-sent-events.md


### PR DESCRIPTION
I thought http4k Lenses were elusive, and then I figured out why. The documentation on Lenses is [published](https://www.http4k.org/guide/concepts/lens/), but it is not actually linked to in the `Concepts` navigation menu:

![image](https://github.com/user-attachments/assets/7d6089c3-ed39-486e-8221-2034e4e8c60d)

This PR addresses this issue.

I'm of course happy to fix this PR if there's anything I missed or if you'd like the navigation items reordered, but I tried to put it in a sensible place.

Similarly, I'm happy to bin the PR altogether if it's intentionally not included!

