### PR TITLE
Add `form(vararg formData: Pair<String, String>)` request helper

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/body/FormBody.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/body/FormBody.kt
@@ -24,3 +24,5 @@ fun Form.toBody(): Body = Body(toUrlFormEncoded())
 fun Request.form(): Form = bodyString().toParameters()
 
 fun Request.form(name: String, value: String): Request = body(form().plus(name to value).toBody())
+
+fun Request.form(vararg formData: Pair<String, String>): Request = body(form().plus(formData).toBody())

--- a/http4k-core/src/test/kotlin/org/http4k/core/FormTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/FormTest.kt
@@ -32,6 +32,16 @@ class FormTest {
     }
 
     @Test
+    fun `can add multiple form parameters`() {
+        val get = Request(GET, "ignored").form("foo" to "1", "bar" to "2")
+
+        val actual = get.form()
+
+        val form: Form = listOf("foo" to "1", "bar" to "2")
+        assertThat(actual, equalTo(form))
+    }
+
+    @Test
     fun `can handle stream body`() {
         val form: Form = listOf("a" to "b")
 

--- a/src/docs/guide/howto/use_html_forms/example_standard.kt
+++ b/src/docs/guide/howto/use_html_forms/example_standard.kt
@@ -9,12 +9,21 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 
 fun main() {
+    // form(name: String, value: String) parses the request body on each invocation
     val request = Request(GET, "/").form("name", "rita").form("age", "55")
 
-    // reparses body every invocation
+    // form(vararg formData: Pair<String, String>) allows you to add multiple form fields to
+    // the request while only parsing the request body once
+    val allInOneRequest = Request(GET, "/").form("name" to "rita", "age" to "55")
+
+    // form(name: String) parses the request body on each invocation
     assertEquals("rita", request.form("name"))
     assertEquals("55", request.form("age"))
     assertNull(request.form("height"))
+
+    assertEquals("rita", allInOneRequest.form("name"))
+    assertEquals("55", allInOneRequest.form("age"))
+    assertNull(allInOneRequest.form("height"))
 
     // toParametersMap() gives form as map
     val parameters: Map<String, List<String?>> = request.form().toParametersMap()


### PR DESCRIPTION
This PR adds a more compact way of adding multiple form fields to a request.

Instead of invoking `form(name: String, value: String)` per form field, a single invocation of `form(vararg formData: Pair<String, String>)` will now suffice. This has the added benefit of only parsing the form body once for all fields, as opposed to once per field.

**Considerations**

1. I've named the parameter `formData`. This aligns with how browsers summarise the collection of inputs, but the [spec](https://url.spec.whatwg.org/#application/x-www-form-urlencoded) is a bit more vague. Should we consider changing this name?

>The application/x-www-form-urlencoded format provides a way to encode a [list](https://infra.spec.whatwg.org/#list) of [tuples](https://infra.spec.whatwg.org/#tuple), each consisting of a name and a value.

2. I've kept the signature consistent with the existing `form(name: String, value: String)` function. This is despite the underlying `Parameter` type being aliased to `Pair<String, String?>`. I think this is the right thing to do, but I thought it worth highlighting here in case it is worthy of debate.

3. I've documented usage of the new helper as part of the current how-to example. This seems consistent with the documentation of @dmcg's' `toParametersMap()` addition, but I'm open to somehow separating it out into its own example if that would be preferred.

Thanks in advance for your review of this PR!

 