### PR TITLE
Fix #1139 - fix haveSetCookie and haveCookie to work when cookie isn't present

### DIFF
--- a/http4k-testing/kotest/src/main/kotlin/org/http4k/kotest/cookie.kt
+++ b/http4k-testing/kotest/src/main/kotlin/org/http4k/kotest/cookie.kt
@@ -22,12 +22,12 @@ fun haveName(expected: String): Matcher<Cookie> = object : Matcher<Cookie> {
 
 infix fun Cookie.shouldHaveValue(expected: String) = this should haveValue(expected)
 infix fun Cookie.shouldNotHaveValue(expected: String) = this shouldNot haveValue(expected)
-fun haveValue(expected: String): Matcher<Cookie> = haveValue(be<String>(expected))
+fun haveValue(expected: String): Matcher<Cookie?> = haveValue(be<String>(expected))
 
 @JvmName("haveCookieValueNullableString")
-fun haveValue(matcher: Matcher<String?>): Matcher<Cookie> = object : Matcher<Cookie> {
-    override fun test(value: Cookie): MatcherResult {
-        val testResult = matcher.test(value.value)
+fun haveValue(matcher: Matcher<String?>): Matcher<Cookie?> = object : Matcher<Cookie?> {
+    override fun test(value: Cookie?): MatcherResult {
+        val testResult = matcher.test(value?.value)
         return MatcherResult(
             testResult.passed(),
             { "Cookie value mismatch: ${testResult.failureMessage()}" },
@@ -36,7 +36,7 @@ fun haveValue(matcher: Matcher<String?>): Matcher<Cookie> = object : Matcher<Coo
     }
 }
 
-fun haveValue(matcher: Matcher<String>): Matcher<Cookie> = haveValue(neverNullMatcher(matcher::test))
+fun haveValue(matcher: Matcher<String>): Matcher<Cookie?> = haveValue(neverNullMatcher(matcher::test))
 
 infix fun Cookie.shouldHaveDomain(expected: String) = this should haveDomain(expected)
 infix fun Cookie.shouldNotHaveDomain(expected: String) = this shouldNot haveDomain(expected)

--- a/http4k-testing/kotest/src/main/kotlin/org/http4k/kotest/request.kt
+++ b/http4k-testing/kotest/src/main/kotlin/org/http4k/kotest/request.kt
@@ -96,6 +96,6 @@ fun Request.shouldHaveCookie(name: String, expected: String) = this should haveC
 fun Request.shouldNotHaveCookie(name: String, expected: String) = this shouldNot haveCookie(name, expected)
 fun haveCookie(name: String, expected: String): Matcher<Request> = haveCookie(name, haveValue(expected))
 
-fun Request.shouldHaveCookie(name: String, match: Matcher<Cookie>) = this should haveCookie(name, match)
-fun Request.shouldNotHaveCookie(name: String, match: Matcher<Cookie>) = this shouldNot haveCookie(name, match)
-fun haveCookie(name: String, match: Matcher<Cookie>): Matcher<Request> = httpMessageHas("Cookie \"$name\"", { r: Request -> r.cookie(name)!! }, match)
+fun Request.shouldHaveCookie(name: String, match: Matcher<Cookie?>) = this should haveCookie(name, match)
+fun Request.shouldNotHaveCookie(name: String, match: Matcher<Cookie?>) = this shouldNot haveCookie(name, match)
+fun haveCookie(name: String, match: Matcher<Cookie?>): Matcher<Request> = httpMessageHas("Cookie \"$name\"", { r: Request -> r.cookie(name) }, match)

--- a/http4k-testing/kotest/src/main/kotlin/org/http4k/kotest/response.kt
+++ b/http4k-testing/kotest/src/main/kotlin/org/http4k/kotest/response.kt
@@ -17,6 +17,6 @@ infix fun Response.shouldHaveSetCookie(expected: Cookie) = this should haveSetCo
 infix fun Response.shouldNotHaveSetCookie(expected: Cookie) = this shouldNot haveSetCookie(expected)
 fun haveSetCookie(expected: Cookie): Matcher<Response> = haveSetCookie(expected.name, be(expected))
 
-fun Response.shouldHaveSetCookie(name: String, match: Matcher<Cookie>) = this should haveSetCookie(name, match)
-fun Response.shouldNotHaveSetCookie(name: String, match: Matcher<Cookie>) = this shouldNot haveSetCookie(name, match)
-fun haveSetCookie(name: String, expected: Matcher<Cookie>): Matcher<Response> = httpMessageHas("Cookie \"$name\"", { r: Response -> r.cookies().find { name == it.name }!! }, expected)
+fun Response.shouldHaveSetCookie(name: String, match: Matcher<Cookie?>) = this should haveSetCookie(name, match)
+fun Response.shouldNotHaveSetCookie(name: String, match: Matcher<Cookie?>) = this shouldNot haveSetCookie(name, match)
+fun haveSetCookie(name: String, expected: Matcher<Cookie?>): Matcher<Response> = httpMessageHas("Cookie \"$name\"", { r: Response -> r.cookies().find { name == it.name } }, expected)

--- a/http4k-testing/kotest/src/test/kotlin/org/http4k/kotest/RequestMatchersTest.kt
+++ b/http4k-testing/kotest/src/test/kotlin/org/http4k/kotest/RequestMatchersTest.kt
@@ -1,6 +1,8 @@
 package org.http4k.kotest
 
 import io.kotest.matchers.be
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.contain
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -12,6 +14,8 @@ import org.http4k.core.cookie.cookie
 import org.http4k.core.with
 import org.http4k.lens.Query
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 
 class RequestMatchersTest {
 
@@ -104,4 +108,32 @@ class RequestMatchersTest {
     @Test
     fun `cookie value`() = assertMatchAndNonMatch(Request(GET, "").cookie(Cookie("name", "bob")),
         { shouldHaveCookie("name", "bob") }, { shouldHaveCookie("name", "bill") })
+
+    @Test
+    fun `should haveCookie(Cookie), cookie does not exist`() {
+        assertThrows<AssertionError> {
+            Request(GET, "").cookie(Cookie("name", "bob")) should haveCookie(Cookie("planet", "Earth"))
+        }
+    }
+
+    @Test
+    fun `shouldNot haveCookie(Cookie), cookie does not exist`() {
+        assertDoesNotThrow {
+            Request(GET, "").cookie(Cookie("name", "bob")) shouldNot haveCookie(Cookie("planet", "Earth"))
+        }
+    }
+
+    @Test
+    fun `should haveCookie(String), cookie does not exist`() {
+        assertThrows<AssertionError> {
+            Request(GET, "").cookie(Cookie("name", "bob")) should haveCookie("planet", "Earth")
+        }
+    }
+
+    @Test
+    fun `shouldNot haveCookie(String), cookie does not exist`() {
+        assertDoesNotThrow {
+            Request(GET, "").cookie(Cookie("name", "bob")) shouldNot haveCookie("planet", "Earth")
+        }
+    }
 }

--- a/http4k-testing/kotest/src/test/kotlin/org/http4k/kotest/ResponseMatchersTest.kt
+++ b/http4k-testing/kotest/src/test/kotlin/org/http4k/kotest/ResponseMatchersTest.kt
@@ -1,11 +1,15 @@
 package org.http4k.kotest
 
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldNot
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.BAD_GATEWAY
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.cookie.Cookie
 import org.http4k.core.cookie.cookie
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
 
 class ResponseMatchersTest {
     @Test
@@ -13,4 +17,18 @@ class ResponseMatchersTest {
 
     @Test
     fun `set cookie`() = assertMatchAndNonMatch(Response(OK).cookie(Cookie("name", "bob")), haveSetCookie(Cookie("name", "bob")), haveSetCookie(Cookie("name", "bill")))
+
+    @Test
+    fun `should haveSetCookie(Cookie), cookie does not exist`() {
+        assertThrows<AssertionError> {
+            Response(OK).cookie(Cookie("name", "bob")) should haveSetCookie(Cookie("planet", "Earth"))
+        }
+    }
+
+    @Test
+    fun `shouldNot haveSetCookie(Cookie), cookie does not exist`() {
+        assertDoesNotThrow {
+            Response(OK).cookie(Cookie("name", "bob")) shouldNot haveSetCookie(Cookie("planet", "Earth"))
+        }
+    }
 }


### PR DESCRIPTION
The functions `haveSetCookie` and `haveCookie` were not handling the situation when the cookie wasn't present in the `Response` or `Request` object, resulting in tests failing when they should be passing. Instead it was throwing a `NullPointerException`.

I have made the Cookie `haveValue` function return a `Matcher` with a nullable Cookie type and removed the non-null assertion in `haveCookie` and `haveSetCookie`.