### PR TITLE
Add additional HTTP error codes

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/Status.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Status.kt
@@ -50,8 +50,13 @@ class Status internal constructor(val code: Int, val description: String, privat
         @JvmField val EXPECTATION_FAILED = Status(417, "Expectation Failed")
         @JvmField val I_M_A_TEAPOT = Status(418, "I'm a teapot") //RFC2324
         @JvmField val UNPROCESSABLE_ENTITY = Status(422, "Unprocessable Entity")
+        @JvmField val LOCKED = Status(423, "Locked")
+        @JvmField val FAILED_DEPENDENCY = Status(424, "Failed Dependency")
+        @JvmField val TOO_EARLY = Status(425, "Too Early")
         @JvmField val UPGRADE_REQUIRED = Status(426, "Upgrade Required")
+        @JvmField val PRECONDITION_REQUIRED = Status(428, "Precondition Required")
         @JvmField val TOO_MANY_REQUESTS = Status(429, "Too many requests")
+        @JvmField val REQUEST_HEADER_FIELDS_TOO_LARGE = Status(431, "Request Header Fields Too Large")
         @JvmField val UNAVAILABLE_FOR_LEGAL_REASONS = Status(451, "Unavailable For Legal Reasons")
 
         private val SERVER_ERROR = 500..599
@@ -105,8 +110,13 @@ class Status internal constructor(val code: Int, val description: String, privat
                 EXPECTATION_FAILED,
                 I_M_A_TEAPOT,
                 UNPROCESSABLE_ENTITY,
+                LOCKED,
+                FAILED_DEPENDENCY,
+                TOO_EARLY,
                 UPGRADE_REQUIRED,
+                PRECONDITION_REQUIRED,
                 TOO_MANY_REQUESTS,
+                REQUEST_HEADER_FIELDS_TOO_LARGE,
                 UNAVAILABLE_FOR_LEGAL_REASONS,
                 INTERNAL_SERVER_ERROR,
                 NOT_IMPLEMENTED,


### PR DESCRIPTION
Adding additional HTTP error codes, as I encountered some of them that were not yet supported by http4k.

* [423 Locked](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/423)
* [424 Failed Dependency](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/424)
* [425 Too Early](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425)
* [428 Precondition Required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/428)
* [431 Request Header Fields Too Large](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/431)
