### PR TITLE
Include Vary header on CORS responses

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ServerFilters.kt
@@ -80,7 +80,15 @@ object ServerFilters {
                                 ?.header("access-control-expose-headers", policy.exposedHeaders.joined())
                                 ?: res
                         },
-                        { res -> policy.maxAge?.let { maxAge -> res.header("access-control-max-age", "$maxAge") } ?: res }
+                        { res -> policy.maxAge?.let { maxAge -> res.header("access-control-max-age", "$maxAge") } ?: res },
+                        { res ->
+                            val existingVaryValues = res.header("Vary")?.split(", ")?.toSet() ?: emptySet()
+                            when {
+                                allowedOrigin == "*" -> res
+                                existingVaryValues == setOf("*") -> res
+                                else -> res.replaceHeader("Vary", (existingVaryValues + "Origin").joinToString(", "))
+                            }
+                        }
                     )
                 } ?: response
             }


### PR DESCRIPTION
As mentioned in [this issue](https://github.com/http4k/http4k/issues/306#issuecomment-1640075947).

`Vary` header should include 'Origin' in its list if a specific value is included in the `Access-Control-Allow-Origin` header, so that caches know to include the origin in the cache key. Docs [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#access-control-allow-origin) and [here](https://httpwg.org/specs/rfc9110.html#field.vary). 