### PR TITLE
Share DiskLocation across all Multipart lens extractions

### DIFF
--- a/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
@@ -82,7 +82,10 @@ data class MultipartFormBody private constructor(
 
     constructor(boundary: String = UUID.randomUUID().toString()) : this(emptyList(), boundary)
 
-    override fun close() = formParts.forEach(MultipartEntity::close)
+    override fun close() {
+        formParts.forEach(MultipartEntity::close)
+        diskLocation.close()
+    }
 
     fun file(name: String) = files(name).firstOrNull()
     fun files(name: String) =

--- a/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
@@ -23,6 +23,26 @@ sealed class MultipartEntity : Closeable {
         MultipartEntity(), Closeable by closeable {
 
         override fun applyTo(builder: MultipartFormBuilder) = builder.field(name, value, headers)
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (javaClass != other?.javaClass) return false
+
+            other as Field
+
+            if (name != other.name) return false
+            if (value != other.value) return false
+            if (headers != other.headers) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = name.hashCode()
+            result = 31 * result + value.hashCode()
+            result = 31 * result + headers.hashCode()
+            return result
+        }
     }
 
     data class File(override val name: String, val file: MultipartFormFile, val headers: Headers = emptyList()) :

--- a/http4k-multipart/src/main/kotlin/org/http4k/lens/multipartForm.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/lens/multipartForm.kt
@@ -73,11 +73,11 @@ fun Body.Companion.multipartForm(
     defaultBoundary: String = MULTIPART_BOUNDARY,
     diskThreshold: Int = DEFAULT_DISK_THRESHOLD,
     contentTypeFn: (String) -> ContentType = ::MultipartFormWithBoundary,
-    diskLocation: DiskLocation = DiskLocation.Temp()
+    getDiskLocation: () -> DiskLocation = { DiskLocation.Temp() }
 ): BiDiBodyLensSpec<MultipartForm> =
     BiDiBodyLensSpec(parts.map { it.meta }, MULTIPART_FORM_DATA,
         LensGet { _, target ->
-            listOf(MultipartFormBody.from(target, diskThreshold, diskLocation).apply {
+            listOf(MultipartFormBody.from(target, diskThreshold, getDiskLocation()).apply {
                 Strict(contentTypeFn(boundary), CONTENT_TYPE(target))
             })
         },

--- a/http4k-multipart/src/main/kotlin/org/http4k/lens/parts.kt
+++ b/http4k-multipart/src/main/kotlin/org/http4k/lens/parts.kt
@@ -10,7 +10,14 @@ import java.io.InputStream
 import kotlin.Int.Companion.MAX_VALUE
 import kotlin.random.Random.Default.nextInt
 
-data class MultipartFormField(val value: String, val headers: Headers = emptyList()) {
+data class MultipartFormField internal constructor(
+    val value: String,
+    val headers: Headers = emptyList(),
+    val closeable: Closeable
+): Closeable by closeable {
+
+    constructor(value: String, headers: Headers = emptyList()): this(value, headers, {})
+
     companion object : BiDiLensSpec<MultipartForm, MultipartFormField>("form",
         StringParam,
         LensGet { name, (fields) -> fields.getOrDefault(name, listOf()) },
@@ -34,8 +41,8 @@ data class MultipartFormFile internal constructor(
         Closeable { })
 
     override fun close() {
-        closeable.close()
         content.close()
+        closeable.close()
     }
 
     private data class Realised(val filename: String, val contentType: ContentType, val content: String)

--- a/http4k-multipart/src/test/kotlin/org/http4k/lens/MultipartFormTest.kt
+++ b/http4k-multipart/src/test/kotlin/org/http4k/lens/MultipartFormTest.kt
@@ -1,6 +1,5 @@
 package org.http4k.lens
 
-import com.natpryce.hamkrest.absent
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.hasSize
@@ -163,11 +162,11 @@ class MultipartFormTest {
     ).toLens()
 
     @Test
-    fun `backing disk location deleted after close`() {
+    fun `backing disk location emptied after close`() {
         val tempDir = Files.createTempDirectory("http4k-override").toFile().apply { deleteOnExit() }
-        assertThat(tempDir.listFiles()!!.toList(), isEmpty)
+        val lens = Body.multipartForm(Strict, diskThreshold = 1, diskLocation = DiskLocation.Temp(tempDir)).toLens()
 
-        val lens = Body.multipartForm(Strict, diskThreshold = 1, getDiskLocation = { DiskLocation.Temp(tempDir) }).toLens()
+        assertThat(tempDir.listFiles()!!.toList(), isEmpty)
 
         val request = emptyRequest.with(
             lens of MultipartForm().with(
@@ -183,6 +182,6 @@ class MultipartFormTest {
             assertThat(tempDir.listFiles()!!.toList(), hasSize(equalTo(3)))
         }
 
-        assertThat(tempDir.listFiles(), absent())
+        assertThat(tempDir.listFiles()!!.toList(), isEmpty)
     }
 }

--- a/http4k-multipart/src/test/kotlin/org/http4k/lens/MultipartFormTest.kt
+++ b/http4k-multipart/src/test/kotlin/org/http4k/lens/MultipartFormTest.kt
@@ -166,8 +166,6 @@ class MultipartFormTest {
         val tempDir = Files.createTempDirectory("http4k-override").toFile().apply { deleteOnExit() }
         val lens = Body.multipartForm(Strict, diskThreshold = 1, diskLocation = DiskLocation.Temp(tempDir)).toLens()
 
-        assertThat(tempDir.listFiles()!!.toList(), isEmpty)
-
         val request = emptyRequest.with(
             lens of MultipartForm().with(
                 stringRequiredField of "world",

--- a/http4k-multipart/src/test/kotlin/org/http4k/lens/MultipartFormTest.kt
+++ b/http4k-multipart/src/test/kotlin/org/http4k/lens/MultipartFormTest.kt
@@ -1,5 +1,6 @@
 package org.http4k.lens
 
+import com.natpryce.hamkrest.absent
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.hasSize
@@ -162,9 +163,9 @@ class MultipartFormTest {
     ).toLens()
 
     @Test
-    fun `backing disk location emptied after close`() {
+    fun `backing disk location deleted after close`() {
         val tempDir = Files.createTempDirectory("http4k-override").toFile().apply { deleteOnExit() }
-        val lens = Body.multipartForm(Strict, diskThreshold = 1, diskLocation = DiskLocation.Temp(tempDir)).toLens()
+        val lens = Body.multipartForm(Strict, diskThreshold = 1, getDiskLocation = { DiskLocation.Temp(tempDir) }).toLens()
 
         val request = emptyRequest.with(
             lens of MultipartForm().with(
@@ -180,6 +181,6 @@ class MultipartFormTest {
             assertThat(tempDir.listFiles()!!.toList(), hasSize(equalTo(3)))
         }
 
-        assertThat(tempDir.listFiles()!!.toList(), isEmpty)
+        assertThat(tempDir.listFiles(), absent())
     }
 }

--- a/http4k-multipart/src/test/kotlin/org/http4k/multipart/LiveServerTest.kt
+++ b/http4k-multipart/src/test/kotlin/org/http4k/multipart/LiveServerTest.kt
@@ -2,7 +2,7 @@ package org.http4k.multipart
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
-import org.http4k.client.ApacheClient
+import com.natpryce.hamkrest.isEmpty
 import org.http4k.client.JavaHttpClient
 import org.http4k.core.Method.POST
 import org.http4k.core.MultipartFormBody
@@ -21,7 +21,7 @@ class LiveServerTest {
     @Test
     fun `can send multipart over wire`() {
 
-        val diskDir = Files.createTempDirectory("http4k-mp").toFile()
+        val diskDir = Files.createTempDirectory("http4k-mp").toFile().apply { deleteOnExit() }
 
         val server = ServerFilters.CatchAll()
             .then { r: Request ->
@@ -41,6 +41,6 @@ class LiveServerTest {
 
         server.stop()
 
-        assertThat(diskDir.exists(), equalTo(false))
+        assertThat(diskDir.listFiles()!!.toList(), isEmpty)
     }
 }

--- a/http4k-multipart/src/test/kotlin/org/http4k/multipart/LiveServerTest.kt
+++ b/http4k-multipart/src/test/kotlin/org/http4k/multipart/LiveServerTest.kt
@@ -1,8 +1,8 @@
 package org.http4k.multipart
 
+import com.natpryce.hamkrest.absent
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
-import com.natpryce.hamkrest.isEmpty
 import org.http4k.client.JavaHttpClient
 import org.http4k.core.Method.POST
 import org.http4k.core.MultipartFormBody
@@ -41,6 +41,6 @@ class LiveServerTest {
 
         server.stop()
 
-        assertThat(diskDir.listFiles()!!.toList(), isEmpty)
+        assertThat(diskDir.listFiles(), absent())
     }
 }


### PR DESCRIPTION
- Multipart Lenses will now share a single `DiskLocation` for all lens extractions
- Fixed an order-of-operations error while deleting multipart files
- Ensure disk-backed form fields are deleted correctly