### PR TITLE
Better diff messages on Approver missing/mismatch

### DIFF
--- a/http4k-testing/approval/src/main/kotlin/org/http4k/testing/ApprovalTest.kt
+++ b/http4k-testing/approval/src/main/kotlin/org/http4k/testing/ApprovalTest.kt
@@ -79,12 +79,7 @@ abstract class ContentTypeAwareApprovalTest(
 
 fun checkingContentType(approver: Approver, contentType: ContentType): Approver = object : Approver {
     override fun <T : HttpMessage> assertApproved(httpMessage: T) {
-        println("checking approved")
         approver.assertApproved(httpMessage)
-        println("checking content type")
-        println(contentType)
-        println(CONTENT_TYPE(httpMessage))
-        println(httpMessage)
         assertEquals(contentType, CONTENT_TYPE(httpMessage))
     }
 

--- a/http4k-testing/approval/src/test/kotlin/org/http4k/testing/NamedSourceApproverTest.kt
+++ b/http4k-testing/approval/src/test/kotlin/org/http4k/testing/NamedSourceApproverTest.kt
@@ -6,6 +6,7 @@ import com.natpryce.hamkrest.throws
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
 import org.junit.jupiter.api.Test
+import org.opentest4j.AssertionFailedError
 import java.io.File
 import java.nio.file.Files
 import kotlin.random.Random
@@ -21,7 +22,7 @@ class NamedSourceApproverTest {
 
     @Test
     fun `when no approval recorded, create actual and throw`() {
-        assertThat({ approver.assertApproved(Response(OK).body(body)) }, throws<ApprovalFailed>())
+        assertThat({ approver.assertApproved(Response(OK).body(body)) }, throws<AssertionFailedError>())
         assertThat(actualFile.exists(), equalTo(true))
         assertThat(actualFile.readText(), equalTo(body))
         assertThat(approvedFile.exists(), equalTo(false))
@@ -53,7 +54,7 @@ class NamedSourceApproverTest {
 
     @Test
     fun `uses file name suffix`() {
-        assertThat({ approver.withNameSuffix("suffix").assertApproved(Response(OK).body(body)) }, throws<ApprovalFailed>())
+        assertThat({ approver.withNameSuffix("suffix").assertApproved(Response(OK).body(body)) }, throws<AssertionFailedError>())
         val actualFile = File(baseFile, "${testName}.suffix.actual")
         assertThat(actualFile.exists(), equalTo(true))
         assertThat(actualFile.readText(), equalTo(body))


### PR DESCRIPTION
Previously, when there was a mismatch in the Approver, the difference could be seen in the console, but because of the message format and exception type, IDEs like IntelliJ would not be able to offer a diff view (by either clicking on the message in the console or typing Cmd+D when selecting the test in the test runner).

With the changes provided in this PR, that is now possible. For example, if the approved file does not exist, it looks like:
<img width="1494" alt="image" src="https://github.com/user-attachments/assets/43698147-0ab0-4ca2-a5a9-4df25d004081">

A mismatch looks like:
<img width="1494" alt="image" src="https://github.com/user-attachments/assets/d6936567-d5db-4daf-8cf9-a34c78931e5c">

The change also removes the need for the ApprovalFailed exception class.

It's just a minor change, but one that really makes a difference when using approval test, as one can simply Cmd+D on the failing test method, instead of having to navigate to the actual/approved files in the navigator and running a diff on the files.