### PR TITLE
Adding ability to create BiDiMapping lens

### DIFF
--- a/http4k-format/gson/src/main/kotlin/org/http4k/format/ConfigurableGson.kt
+++ b/http4k-format/gson/src/main/kotlin/org/http4k/format/ConfigurableGson.kt
@@ -121,6 +121,9 @@ open class ConfigurableGson(
     inline fun <reified T : Any> WsMessage.Companion.auto() =
         WsMessage.json().map({ it.asA<T>() }, { it.asJsonObject() })
 
+    inline fun <reified T: Any> asBiDiMapping() =
+        BiDiMapping<String, T>(mapper.read<T>()) { mapper.toJson(it) }
+
     inline fun <reified T : Any> Body.Companion.auto(
         description: String? = null,
         contentNegotiation: ContentNegotiation = None,

--- a/http4k-format/gson/src/test/kotlin/org/http4k/format/GsonTest.kt
+++ b/http4k-format/gson/src/test/kotlin/org/http4k/format/GsonTest.kt
@@ -84,6 +84,13 @@ class GsonAutoTest : AutoMarshallingJsonContract(Gson) {
     override fun `serialises enum as a key correctly`() {
     }
 
+    @Test
+    fun ` roundtrip arbitrary object to and from with BiDi lens`() {
+        val obj = ArbObject("hello", ArbObject("world", null, listOf(1), true), emptyList(), false)
+        val lens = Gson.asBiDiMapping<ArbObject>()
+        assertThat(lens(lens(obj)), equalTo(obj))
+    }
+
     override fun strictMarshaller() = throw UnsupportedOperationException()
 
     override fun customMarshaller() = object : ConfigurableGson(GsonBuilder().asConfigurable().customise()) {}

--- a/http4k-format/jackson-csv/src/main/kotlin/org/http4k/format/ConfigurableJacksonCsv.kt
+++ b/http4k-format/jackson-csv/src/main/kotlin/org/http4k/format/ConfigurableJacksonCsv.kt
@@ -8,6 +8,7 @@ import org.http4k.core.ContentType
 import org.http4k.core.HttpMessage
 import org.http4k.core.with
 import org.http4k.lens.BiDiBodyLensSpec
+import org.http4k.lens.BiDiMapping
 import org.http4k.lens.ContentNegotiation
 import org.http4k.lens.Meta
 import org.http4k.lens.ParamMeta.ObjectParam
@@ -54,6 +55,9 @@ open class ConfigurableJacksonCsv(val mapper: CsvMapper, val defaultContentType:
      * Convenience function to read an object as CSV from the message body.
      */
     inline fun <reified T: Any> HttpMessage.csv(): List<T> = Body.auto<T>().toLens()(this)
+
+    inline fun <reified T: Any> asBiDiMapping(schema: CsvSchema = defaultSchema<T>()) =
+        BiDiMapping<String, List<T>>(readerFor(T::class, schema), writerFor(T::class, schema))
 
     inline fun <reified T : Any> Body.Companion.auto(
         description: String? = null,

--- a/http4k-format/jackson-csv/src/test/kotlin/org/http4k/format/jacksonCsvTests.kt
+++ b/http4k-format/jackson-csv/src/test/kotlin/org/http4k/format/jacksonCsvTests.kt
@@ -126,7 +126,7 @@ PT1S,1970-01-01T00:00:00Z,2000-01-01,2000-01-01T01:01:01,01:01:01,2000-01-01T01:
         )
 
         assertThat(
-            lens(objects),
+            lens(lens(objects)),
             equalTo(objects)
         )
     }

--- a/http4k-format/jackson-csv/src/test/kotlin/org/http4k/format/jacksonCsvTests.kt
+++ b/http4k-format/jackson-csv/src/test/kotlin/org/http4k/format/jacksonCsvTests.kt
@@ -115,4 +115,19 @@ PT1S,1970-01-01T00:00:00Z,2000-01-01,2000-01-01T01:01:01,01:01:01,2000-01-01T01:
             equalTo(csv)
         )
     }
+
+    @Test
+    fun `roundtrip list of arbitrary objects to and from with BiDi lens`() {
+        val lens = JacksonCsv.asBiDiMapping<CsvArbObject>()
+
+        val objects = listOf(
+            CsvArbObject("hello", emptyList(), false),
+            CsvArbObject("goodbye", listOf(1, 2, 3), true)
+        )
+
+        assertThat(
+            lens(objects),
+            equalTo(objects)
+        )
+    }
 }

--- a/http4k-format/jackson-xml/src/main/kotlin/org/http4k/format/ConfgurableJacksonXml.kt
+++ b/http4k-format/jackson-xml/src/main/kotlin/org/http4k/format/ConfgurableJacksonXml.kt
@@ -10,6 +10,7 @@ import org.http4k.core.ContentType.Companion.APPLICATION_XML
 import org.http4k.core.HttpMessage
 import org.http4k.core.with
 import org.http4k.lens.BiDiBodyLensSpec
+import org.http4k.lens.BiDiMapping
 import org.http4k.lens.ContentNegotiation
 import org.http4k.lens.Meta
 import org.http4k.lens.ParamMeta.ObjectParam
@@ -37,6 +38,14 @@ open class ConfigurableJacksonXml(
      * Convenience function to read an object as XML from the message body.
      */
     inline fun <reified T: Any> HttpMessage.xml(): T = Body.auto<T>().toLens()(this)
+
+    inline fun <reified T: Any> asBiDiMapping() =
+        BiDiMapping<String, T>({ it.asA<T>() }, { it.asXmlString() })
+
+    inline fun <reified T : Any> Body.Companion.auto(
+        description: String? = null,
+        contentNegotiation: ContentNegotiation = ContentNegotiation.None
+    ) = autoBody<T>(description, contentNegotiation)
 
     inline fun <reified T : Any> autoBody(
         description: String? = null,

--- a/http4k-format/jackson-xml/src/test/kotlin/org/http4k/format/JacksonXmlTest.kt
+++ b/http4k-format/jackson-xml/src/test/kotlin/org/http4k/format/JacksonXmlTest.kt
@@ -82,4 +82,11 @@ class JacksonXmlTest : AutoMarshalingXmlContract(JacksonXml) {
         assertThat(r, hasContentType(customContentType).and(hasBody("<UriContainer><field>custom:foo.bar</field></UriContainer>")))
         assertThat(lens(r), equalTo(item))
     }
+
+    @Test
+    fun `can roundtrip an with BiDi lens`() {
+        val lens = JacksonXml.asBiDiMapping<UriContainer>()
+        val item = UriContainer(Uri.of("foo.bar"))
+        assertThat(lens(item), equalTo(item))
+    }
 }

--- a/http4k-format/jackson-xml/src/test/kotlin/org/http4k/format/JacksonXmlTest.kt
+++ b/http4k-format/jackson-xml/src/test/kotlin/org/http4k/format/JacksonXmlTest.kt
@@ -87,6 +87,6 @@ class JacksonXmlTest : AutoMarshalingXmlContract(JacksonXml) {
     fun `can roundtrip an with BiDi lens`() {
         val lens = JacksonXml.asBiDiMapping<UriContainer>()
         val item = UriContainer(Uri.of("foo.bar"))
-        assertThat(lens(item), equalTo(item))
+        assertThat(lens(lens(item)), equalTo(item))
     }
 }

--- a/http4k-format/jackson-yaml/src/main/kotlin/org/http4k/format/ConfigurableJacksonYaml.kt
+++ b/http4k-format/jackson-yaml/src/main/kotlin/org/http4k/format/ConfigurableJacksonYaml.kt
@@ -7,6 +7,7 @@ import org.http4k.core.ContentType.Companion.TEXT_YAML
 import org.http4k.core.HttpMessage
 import org.http4k.core.with
 import org.http4k.lens.BiDiBodyLensSpec
+import org.http4k.lens.BiDiMapping
 import org.http4k.lens.ContentNegotiation
 import org.http4k.lens.ContentNegotiation.Companion.None
 import org.http4k.lens.string
@@ -25,6 +26,8 @@ open class ConfigurableJacksonYaml(val mapper: ObjectMapper, override val defaul
     override fun asInputStream(input: Any): InputStream = mapper.writeValueAsBytes(input).inputStream()
 
     inline fun <reified T : Any> WsMessage.Companion.auto() = WsMessage.string().map(mapper.read<T>(), mapper.write())
+
+    inline fun <reified T: Any> asBiDiMapping() = BiDiMapping<String, List<T>>(mapper.read(), mapper.write())
 
     inline fun <reified T : Any> Body.Companion.auto(
         description: String? = null,

--- a/http4k-format/jackson-yaml/src/test/kotlin/org/http4k/format/jacksonYamlTests.kt
+++ b/http4k-format/jackson-yaml/src/test/kotlin/org/http4k/format/jacksonYamlTests.kt
@@ -206,7 +206,7 @@ bool: true
 
         val obj = ArbObject("hello", ArbObject("world", null, listOf(1), true), emptyList(), false)
 
-        assertThat(lens(listOf(obj)), equalTo(listOf(obj)))
+        assertThat(lens(lens(listOf(obj))), equalTo(listOf(obj)))
     }
 
     override fun strictMarshaller() =

--- a/http4k-format/jackson-yaml/src/test/kotlin/org/http4k/format/jacksonYamlTests.kt
+++ b/http4k-format/jackson-yaml/src/test/kotlin/org/http4k/format/jacksonYamlTests.kt
@@ -200,6 +200,15 @@ bool: true
         assertThat(jackson.asFormatString(value), equalTo("\"stuff\"\n"))
     }
 
+    @Test
+    fun `roundtrip list of arbitrary objects to and from with BiDi lens`() {
+        val lens = JacksonYaml.asBiDiMapping<ArbObject>()
+
+        val obj = ArbObject("hello", ArbObject("world", null, listOf(1), true), emptyList(), false)
+
+        assertThat(lens(listOf(obj)), equalTo(listOf(obj)))
+    }
+
     override fun strictMarshaller() =
         object : ConfigurableJacksonYaml(KotlinModule.Builder().build().asConfigurable().customise()) {}
 

--- a/http4k-format/jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
+++ b/http4k-format/jackson/src/main/kotlin/org/http4k/format/ConfigurableJackson.kt
@@ -27,6 +27,7 @@ import org.http4k.core.with
 import org.http4k.format.JsonType.Integer
 import org.http4k.format.JsonType.Number
 import org.http4k.lens.BiDiBodyLensSpec
+import org.http4k.lens.BiDiMapping
 import org.http4k.lens.ContentNegotiation
 import org.http4k.lens.ContentNegotiation.Companion.None
 import org.http4k.lens.string
@@ -94,6 +95,8 @@ open class ConfigurableJackson(
     override fun asInputStream(input: Any): InputStream = mapper.writeValueAsBytes(input).inputStream()
 
     inline fun <reified T : Any> WsMessage.Companion.auto() = WsMessage.string().map(mapper.read<T>(), mapper.write())
+
+    inline fun <reified T: Any> asBiDiMapping() = BiDiMapping<String, T>(mapper.read<T>(), mapper.write<T>())
 
     inline fun <reified T : Any> Body.Companion.auto(
         description: String? = null,

--- a/http4k-format/jackson/src/test/kotlin/org/http4k/format/jacksonJsonTests.kt
+++ b/http4k-format/jackson/src/test/kotlin/org/http4k/format/jacksonJsonTests.kt
@@ -206,6 +206,14 @@ class JacksonAutoTest : AutoMarshallingJsonContract(Jackson) {
         assertThat(marshaller.asFormatString(MyOtherValue.of("world")), equalTo(""""world""""))
         assertThrows<Exception> { marshaller.asFormatString(UnknownValueType.of("hello")) }
     }
+
+    @Test
+    fun `roundtrip arbitrary object to and from JSON string with BiDi lens`() {
+        val obj = ArbObject("hello", ArbObject("world", null, listOf(1), true), emptyList(), false)
+        val lens = Jackson.asBiDiMapping<ArbObject>()
+        val out = lens(obj)
+        assertThat(lens(out), equalTo(obj))
+    }
 }
 
 class JacksonTest : JsonContract<JsonNode>(Jackson) {

--- a/http4k-format/klaxon/src/main/kotlin/org/http4k/format/ConfigurableKlaxon.kt
+++ b/http4k-format/klaxon/src/main/kotlin/org/http4k/format/ConfigurableKlaxon.kt
@@ -9,6 +9,7 @@ import org.http4k.core.ContentType.Companion.APPLICATION_JSON
 import org.http4k.core.HttpMessage
 import org.http4k.core.with
 import org.http4k.lens.BiDiBodyLensSpec
+import org.http4k.lens.BiDiMapping
 import org.http4k.lens.BiDiWsMessageLensSpec
 import org.http4k.lens.ContentNegotiation
 import org.http4k.lens.string
@@ -31,6 +32,9 @@ open class ConfigurableKlaxon(
         }
 
     override fun asFormatString(input: Any) = klaxon.toJsonString(input)
+
+    inline fun <reified T: Any> asBiDiMapping() =
+        BiDiMapping<String, T>({ asA(it, T::class) }, { asFormatString(it) })
 
     inline fun <reified T : Any> Body.Companion.auto(
         description: String? = null,

--- a/http4k-format/klaxon/src/test/kotlin/org/http4k/format/klaxonJsonTests.kt
+++ b/http4k-format/klaxon/src/test/kotlin/org/http4k/format/klaxonJsonTests.kt
@@ -87,6 +87,14 @@ class KlaxonAutoTest : AutoMarshallingJsonContract(Klaxon) {
             .exceptionOrNull()!!.message!!, startsWith("Unable to instantiate ArbObject"))
     }
 
+
+
+    @Test
+    fun `roundtrip arbitrary object to and from with BiDi lens`() {
+        val lens = Klaxon.asBiDiMapping<ArbObject>()
+        assertThat(lens(lens(obj)), equalTo(obj))
+    }
+
 }
 
 class KlaxonAutoEventsTest : AutoMarshallingEventsContract(Klaxon)

--- a/http4k-format/kondor-json/src/test/kotlin/org/http4k/format/KondorJsonAutoMarshallingJsonTest.kt
+++ b/http4k-format/kondor-json/src/test/kotlin/org/http4k/format/KondorJsonAutoMarshallingJsonTest.kt
@@ -183,6 +183,16 @@ class KondorJsonAutoMarshallingJsonTest : AutoMarshallingJsonContract(
 
         assertThat(body(body(obj)), equalTo(obj))
     }
+
+    @Test
+    fun `roundtrip arbitrary object to and from with BiDi lens`() {
+        val lens = KondorJson() { register(JArbObject) }
+            .asBiDiMapping<ArbObject>()
+
+        val obj = ArbObject("hello", ArbObject("world", null, listOf(1), true), emptyList(), false)
+
+        assertThat(lens(lens(obj)), equalTo(obj))
+    }
 }
 
 private object JInOnly : JStringRepresentable<InOnly>() {

--- a/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/ConfigurableKotlinxSerialization.kt
+++ b/http4k-format/kotlinx-serialization/src/main/kotlin/org/http4k/format/ConfigurableKotlinxSerialization.kt
@@ -160,6 +160,12 @@ open class ConfigurableKotlinxSerialization(
     inline fun <reified T : Any> WsMessage.Companion.auto() =
         WsMessage.json().map({ it.asA<T>() }, { it.asJsonObject() })
 
+    inline fun <reified T: Any> asBiDiMapping() =
+        BiDiMapping<String, T>(
+            { json.decodeFromString<T>(it) },
+            { json.encodeToString(it) }
+        )
+
     inline fun <reified T : Any> Body.Companion.auto(
         description: String? = null,
         contentNegotiation: ContentNegotiation = None,

--- a/http4k-format/kotlinx-serialization/src/test/kotlin/org/http4k/format/KotlinxSerializationAutoTest.kt
+++ b/http4k-format/kotlinx-serialization/src/test/kotlin/org/http4k/format/KotlinxSerializationAutoTest.kt
@@ -325,6 +325,15 @@ class KotlinxSerializationAutoTest : AutoMarshallingJsonContract(KotlinxSerializ
             .exceptionOrNull()!!.message!!, startsWith("Fields [string, child, numbers, bool]"))
     }
 
+    @Test
+    fun `roundtrip list of arbitrary objects to and from with BiDi lens`() {
+        val lens = KotlinxSerialization.asBiDiMapping<ArbObject>()
+
+        val obj = ArbObject("hello", ArbObject("world", null, listOf(1), true), emptyList(), false)
+
+        assertThat(lens(lens(obj)), equalTo(obj))
+    }
+
     override fun strictMarshaller() = KotlinxSerialization
 
     override fun customMarshaller(): AutoMarshalling =

--- a/http4k-format/moshi-yaml/src/main/kotlin/org/http4k/format/ConfigurableMoshiYaml.kt
+++ b/http4k-format/moshi-yaml/src/main/kotlin/org/http4k/format/ConfigurableMoshiYaml.kt
@@ -8,6 +8,7 @@ import org.http4k.core.HttpMessage
 import org.http4k.core.with
 import org.http4k.format.StrictnessMode.Lenient
 import org.http4k.lens.BiDiBodyLensSpec
+import org.http4k.lens.BiDiMapping
 import org.http4k.lens.ContentNegotiation
 import org.http4k.lens.ContentNegotiation.Companion.None
 import org.http4k.lens.string
@@ -59,6 +60,9 @@ open class ConfigurableMoshiYaml(
     )
 
     inline fun <reified T : Any> WsMessage.Companion.auto() = WsMessage.string().map({ }, ::asFormatString)
+
+    inline fun <reified T: Any> asBiDiMapping() =
+        BiDiMapping<String, T>({ asA(it) }, ::asFormatString)
 
     inline fun <reified T : Any> Body.Companion.auto(
         description: String? = null,

--- a/http4k-format/moshi-yaml/src/test/kotlin/org/http4k/format/moshiYamlTests.kt
+++ b/http4k-format/moshi-yaml/src/test/kotlin/org/http4k/format/moshiYamlTests.kt
@@ -157,4 +157,10 @@ bool:true
         assertThat(runCatching { MoshiYaml.autoBody<ArbObject>().toLens()(invalidArbObjectRequest) }
             .exceptionOrNull()!!.message!!, startsWith("Required value 'string' missing at \$"))
     }
+
+    @Test
+    fun `roundtrip list of arbitrary objects to and with BiDi lens`() {
+        val lens = MoshiYaml.asBiDiMapping<ArbObject>()
+        assertThat(lens(lens(obj)), equalTo(obj))
+    }
 }

--- a/http4k-format/moshi/src/main/kotlin/org/http4k/format/ConfigurableMoshi.kt
+++ b/http4k-format/moshi/src/main/kotlin/org/http4k/format/ConfigurableMoshi.kt
@@ -114,6 +114,9 @@ open class ConfigurableMoshi(
     override fun <T : Any> asA(j: MoshiNode, target: KClass<T>): T = adapterFor(target)
         .fromJsonValue(j.unwrap())!!
 
+    inline fun <reified T: Any> asBiDiMapping() =
+        BiDiMapping<String, T>({ asA(it, T::class) }, { asFormatString(it) })
+
     inline fun <reified T : Any> Body.Companion.auto(
         description: String? = null,
         contentNegotiation: ContentNegotiation = None,

--- a/http4k-format/moshi/src/test/kotlin/org/http4k/format/MoshiTest.kt
+++ b/http4k-format/moshi/src/test/kotlin/org/http4k/format/MoshiTest.kt
@@ -197,6 +197,12 @@ class MoshiAutoTest : AutoMarshallingJsonContract(Moshi) {
         assertThrows<Exception> { marshaller.asFormatString(UnknownValueType.of("unknown")).also { println(it) } }
     }
 
+    @Test
+    fun `roundtrip list of arbitrary objects to and with BiDi lens`() {
+        val lens = Moshi.asBiDiMapping<ArbObject>()
+        assertThat(lens(lens(obj)), equalTo(obj))
+    }
+
     override fun strictMarshaller() =
         object : ConfigurableMoshi(Builder().asConfigurable().customise(), strictness = FailOnUnknown) {}
 

--- a/http4k-format/xml/src/main/kotlin/org/http4k/format/Xml.kt
+++ b/http4k-format/xml/src/main/kotlin/org/http4k/format/Xml.kt
@@ -4,12 +4,12 @@ import com.google.gson.JsonElement
 import org.http4k.asByteBuffer
 import org.http4k.asString
 import org.http4k.core.Body
-import org.http4k.core.ContentType
 import org.http4k.core.ContentType.Companion.APPLICATION_XML
 import org.http4k.core.HttpMessage
 import org.http4k.core.with
 import org.http4k.lens.BiDiBodyLensSpec
 import org.http4k.lens.BiDiLensSpec
+import org.http4k.lens.BiDiMapping
 import org.http4k.lens.ContentNegotiation
 import org.http4k.lens.Meta
 import org.http4k.lens.ParamMeta.ObjectParam
@@ -65,6 +65,9 @@ object Xml : AutoMarshallingXml() {
      */
     fun <IN : Any> BiDiLensSpec<IN, String>.xml() = map({ it.asXmlDocument() }, { it.asXmlString() })
 
+    fun asBiDiMapping() =
+        BiDiMapping<String, Document>({ it.asXmlDocument() }, { it.asXmlString() })
+
     fun Body.Companion.xml(
         description: String? = null,
         contentNegotiation: ContentNegotiation = ContentNegotiation.None
@@ -75,5 +78,6 @@ object Xml : AutoMarshallingXml() {
             contentNegotiation
         )
             .map(Body::payload) { Body(it) }
-            .map(ByteBuffer::asString, String::asByteBuffer).map({ it.asXmlDocument() }, { it.asXmlString() })
+            .map(ByteBuffer::asString, String::asByteBuffer)
+            .map({ it.asXmlDocument() }, { it.asXmlString() })
 }

--- a/http4k-format/xml/src/test/kotlin/org/http4k/format/XmlTest.kt
+++ b/http4k-format/xml/src/test/kotlin/org/http4k/format/XmlTest.kt
@@ -65,4 +65,10 @@ class XmlTest {
         assertThat(out.asXmlString(), equalTo(xmlString))
         assertThat(lens(out, Request(GET, "/")), equalTo(original))
     }
+
+    @Test
+    fun `roundtrip xml to and from with BiDi lens`() {
+        val lens = Xml.asBiDiMapping()
+        assertThat(lens(lens(xml)), equalTo(xml))
+    }
 }


### PR DESCRIPTION
Currently the `.auto()` that comes with `format` automarshalling is way more powerful than `asA`/`asFormatString` - but is only useable with `HttpMessage`.

Therefore I've added `asBiDiMapping` that will create an instance of bidirectional lens in exactly same way as it is done in `auto()`.