### PR TITLE
Add `start` time property to HttpTransaction

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/HttpTransaction.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/HttpTransaction.kt
@@ -3,6 +3,7 @@ package org.http4k.core
 import org.http4k.routing.RequestWithRoute
 import org.http4k.routing.ResponseWithRoute
 import java.time.Duration
+import java.time.Instant
 
 data class HttpTransaction(
     val request: Request,
@@ -12,7 +13,8 @@ data class HttpTransaction(
         response is ResponseWithRoute -> mapOf(ROUTING_GROUP_LABEL to response.xUriTemplate.toString())
         request is RequestWithRoute -> mapOf(ROUTING_GROUP_LABEL to request.xUriTemplate.toString())
         else -> emptyMap()
-    }
+    },
+    val start: Instant
 ) {
     fun label(name: String, value: String) = copy(labels = labels + (name to value))
     fun label(name: String) = labels[name]

--- a/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/filter/ResponseFilters.kt
@@ -14,7 +14,6 @@ import org.http4k.filter.GzipCompressionMode.Memory
 import java.security.MessageDigest
 import java.time.Clock
 import java.time.Duration
-import java.time.Duration.between
 import java.time.Instant
 
 object ResponseFilters {
@@ -50,10 +49,15 @@ object ResponseFilters {
             transactionLabeler: HttpTransactionLabeler = { it },
             recordFn: (HttpTransaction) -> Unit
         ): Filter = Filter { next ->
-            {
+            { request ->
                 timeSource().let { start ->
-                    next(it).apply {
-                        recordFn(transactionLabeler(HttpTransaction(it, this, between(start, timeSource()))))
+                    next(request).apply {
+                        recordFn(transactionLabeler(HttpTransaction(
+                            request = request,
+                            response = this,
+                            start = start,
+                            duration = Duration.between(start, timeSource())
+                        )))
                     }
                 }
             }

--- a/http4k-core/src/test/kotlin/org/http4k/client/Java8HttpClientTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/client/Java8HttpClientTest.kt
@@ -13,10 +13,11 @@ import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.TimeUnit.MILLISECONDS
 
-class Java8HttpClientTest : HttpClientContract(::ApacheServer, Java8HttpClient(),
-    ApacheClient(HttpClients.custom()
-        .setDefaultRequestConfig(RequestConfig.custom().setResponseTimeout(100, MILLISECONDS).build()).build()
-        , responseBodyMode = BodyMode.Stream)),
+class Java8HttpClientTest : HttpClientContract(
+    serverConfig = ::ApacheServer,
+    client = Java8HttpClient(),
+    timeoutClient = Java8HttpClient(readTimeout = Duration.ofMillis(100))
+),
     HttpClientWithMemoryModeContract {
 
     @Test

--- a/http4k-core/src/test/kotlin/org/http4k/core/HttpTransactionTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/core/HttpTransactionTest.kt
@@ -10,18 +10,30 @@ import org.http4k.routing.RoutedRequest
 import org.http4k.routing.RoutedResponse
 import org.junit.jupiter.api.Test
 import java.time.Duration.ZERO
+import java.time.Instant
 
 class HttpTransactionTest {
-
+    private val startTime = Instant.ofEpochSecond(93)
+    
     @Test
     fun `cannot get the routing group from a standard Response`() {
-        assertThat(HttpTransaction(Request(GET, Uri.of("/")), Response(OK), ZERO).routingGroup, equalTo("UNMAPPED"))
+        assertThat(HttpTransaction(
+            request = Request(GET, Uri.of("/")),
+            response = Response(OK),
+            start = startTime,
+            duration = ZERO
+        ).routingGroup, equalTo("UNMAPPED"))
     }
 
     @Test
     fun `can get the routing group from a RoutedResponse`() {
         val response = RoutedResponse(Response(OK), UriTemplate.from("hello"))
-        assertThat(HttpTransaction(Request(GET, Uri.of("/")), response, ZERO).routingGroup, equalTo("hello"))
+        assertThat(HttpTransaction(
+            request = Request(GET, Uri.of("/")),
+            response = response,
+            start = startTime,
+            duration = ZERO
+        ).routingGroup, equalTo("hello"))
     }
 
     @Test
@@ -31,9 +43,19 @@ class HttpTransactionTest {
         class ExtendedResponse(val delegate: RoutedResponse) : ResponseWithRoute by delegate
 
         val request = ExtendedRequest(RoutedRequest(Request(GET, "/the-path"), UriTemplate.from("request")))
-        assertThat(HttpTransaction(request, Response(OK), ZERO).labels, equalTo(mapOf("routingGroup" to "request")))
+        assertThat(HttpTransaction(
+            request = request,
+            response = Response(OK),
+            start = startTime,
+            duration = ZERO
+        ).labels, equalTo(mapOf("routingGroup" to "request")))
 
         val response = ExtendedResponse(RoutedResponse(Response(OK, "/the-path"), UriTemplate.from("response")))
-        assertThat(HttpTransaction(request, response, ZERO).labels, equalTo(mapOf("routingGroup" to "response")))
+        assertThat(HttpTransaction(
+            request = request,
+            response = response,
+            start = startTime,
+            duration = ZERO
+        ).labels, equalTo(mapOf("routingGroup" to "response")))
     }
 }

--- a/http4k-core/src/test/kotlin/org/http4k/events/HttpEventTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/events/HttpEventTest.kt
@@ -13,11 +13,18 @@ import org.http4k.routing.RoutedRequest
 import org.http4k.routing.RoutedResponse
 import org.junit.jupiter.api.Test
 import java.time.Duration.ZERO
+import java.time.Instant
 
 class HttpEventTest {
-
-    private val tx = HttpTransaction(Request(GET, ""), Response(OK), ZERO, mapOf())
-
+    private val startTime = Instant.ofEpochSecond(17)
+    private val tx = HttpTransaction(
+        request = Request(GET, ""),
+        response = Response(OK),
+        start = startTime,
+        duration = ZERO,
+        labels = mapOf()
+    )
+    
     @Test
     fun `outgoing equals`() {
         assertThat(Outgoing(tx), equalTo(Outgoing(tx)))
@@ -25,19 +32,33 @@ class HttpEventTest {
 
     @Test
     fun `outgoing uses template if available`() {
-        assertThat(Outgoing(HttpTransaction(Request(GET, "/bob"), Response(OK), ZERO, mapOf())).xUriTemplate, equalTo("bob"))
-        assertThat(Outgoing(HttpTransaction(Request(GET, "/bob"),
-            RoutedResponse(Response(OK), UriTemplate.from("bar")), ZERO, mapOf())).xUriTemplate, equalTo("bar"))
+        assertThat(Outgoing(HttpTransaction(
+            request = Request(GET, "/bob"),
+            response = Response(OK),
+            start = startTime,
+            duration = ZERO,
+            labels = mapOf()
+        )).xUriTemplate, equalTo("bob"))
+        assertThat(Outgoing(HttpTransaction(
+            request = Request(GET, "/bob"),
+            response = RoutedResponse(Response(OK), UriTemplate.from("bar")),
+            start = startTime,
+            duration = ZERO,
+            labels = mapOf()
+        )).xUriTemplate, equalTo("bar"))
     }
 
     @Test
     fun `incoming uses template if available`() {
-        assertThat(HttpEvent.Incoming(HttpTransaction(Request(GET, "/bob"), Response(OK), ZERO, mapOf())).xUriTemplate, equalTo("bob"))
+        assertThat(HttpEvent.Incoming(HttpTransaction(Request(GET, "/bob"), Response(OK), ZERO, mapOf(),startTime)).xUriTemplate, equalTo("bob"))
         assertThat(
             HttpEvent.Incoming(
                 HttpTransaction(
-                    RoutedRequest(Request(GET, "/bob"), UriTemplate.from("bar")),
-                    Response(OK), ZERO, mapOf()
+                    request = RoutedRequest(Request(GET, "/bob"), UriTemplate.from("bar")),
+                    response = Response(OK),
+                    start = startTime,
+                    duration = ZERO,
+                    labels = mapOf()
                 )
             ).xUriTemplate, equalTo("bar"))
     }
@@ -46,5 +67,4 @@ class HttpEventTest {
     fun `incoming equals`() {
         assertThat(HttpEvent.Incoming(tx), equalTo(HttpEvent.Incoming(tx)))
     }
-
 }

--- a/http4k-testing/chaos/src/test/kotlin/org/http4k/chaos/helper.kt
+++ b/http4k-testing/chaos/src/test/kotlin/org/http4k/chaos/helper.kt
@@ -11,10 +11,16 @@ import org.http4k.core.Status.Companion.OK
 import org.http4k.core.then
 import org.http4k.format.Jackson.asJsonObject
 import java.time.Duration
+import java.time.Instant
 
 internal fun assertBehaviour(json: String, description: String, matcher: Matcher<Response>) {
     val behaviour = json.createBehaviourWith(description)
-    val tx = HttpTransaction(Request(GET, ""), Response(OK).body("hello"), Duration.ZERO)
+    val tx = HttpTransaction(
+        request = Request(GET, ""),
+        response = Response(OK).body("hello"),
+        start = Instant.ofEpochSecond(1),
+        duration = Duration.ZERO
+    )
     assertThat(behaviour.then { tx.response }(tx.request), matcher)
 }
 

--- a/http4k-testing/hamkrest/src/test/kotlin/org/http4k/hamkrest/HttpTransactionMatchersTest.kt
+++ b/http4k-testing/hamkrest/src/test/kotlin/org/http4k/hamkrest/HttpTransactionMatchersTest.kt
@@ -9,10 +9,16 @@ import org.http4k.core.Status.Companion.INTERNAL_SERVER_ERROR
 import org.http4k.core.Status.Companion.OK
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.time.Instant
 
 class HttpTransactionMatchersTest {
 
-    private val tx = HttpTransaction(Request(GET, ""), Response(OK), Duration.ofMillis(1))
+    private val tx = HttpTransaction(
+        request = Request(GET, ""),
+        response = Response(OK),
+        start = Instant.ofEpochSecond(10),
+        duration = Duration.ofMillis(1),
+    )
 
     @Test
     fun request() {

--- a/http4k-testing/kotest/src/test/kotlin/org/http4k/kotest/HttpTransactionMatchersTest.kt
+++ b/http4k-testing/kotest/src/test/kotlin/org/http4k/kotest/HttpTransactionMatchersTest.kt
@@ -9,11 +9,17 @@ import org.http4k.core.Status.Companion.INTERNAL_SERVER_ERROR
 import org.http4k.core.Status.Companion.OK
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.time.Instant
 
 class HttpTransactionMatchersTest {
 
-    private val tx = HttpTransaction(Request(GET, ""), Response(OK), Duration.ofMillis(1))
-
+    private val tx = HttpTransaction(
+        request = Request(GET, ""),
+        response = Response(OK),
+        start = Instant.ofEpochSecond(1),
+        duration = Duration.ofMillis(1)
+    )
+    
     @Test
     fun request() {
         assertMatchAndNonMatch(tx, haveRequest(haveMethod(GET)), haveRequest(haveMethod(POST)))

--- a/http4k-testing/strikt/src/test/kotlin/org/http4k/strikt/HttpTransactionAssertionsTest.kt
+++ b/http4k-testing/strikt/src/test/kotlin/org/http4k/strikt/HttpTransactionAssertionsTest.kt
@@ -9,12 +9,18 @@ import org.junit.jupiter.api.Test
 import strikt.api.expectThat
 import strikt.assertions.isEqualTo
 import java.time.Duration
+import java.time.Instant
 
 class HttpTransactionAssertionsTest {
 
     @Test
     fun assertions() {
-        val tx = HttpTransaction(Request(Method.GET, ""), Response(OK), Duration.ZERO)
+        val tx = HttpTransaction(
+            request = Request(Method.GET, ""),
+            response = Response(OK),
+            start = Instant.ofEpochSecond(24),
+            duration = Duration.ZERO
+        )
 
         expectThat(tx) {
             request.isEqualTo(tx.request)


### PR DESCRIPTION
This makes it simpler to report the time of request accurately.

I had to change the Java8HttpClient test to fix a test failure.  Please check that it uses the contract base class as intended.

I added the `start` property as the final constructor parameter to ensure that this change does not break code that deconstructs HttpTransaction values.