### PR TITLE
Add resilience4j timeout filter

### DIFF
--- a/http4k-resilience4j/build.gradle.kts
+++ b/http4k-resilience4j/build.gradle.kts
@@ -6,5 +6,6 @@ dependencies {
     api("io.github.resilience4j:resilience4j-circuitbreaker:_")
     api("io.github.resilience4j:resilience4j-ratelimiter:_")
     api("io.github.resilience4j:resilience4j-retry:_")
+    api("io.github.resilience4j:resilience4j-timelimiter:_")
     testImplementation(testFixtures(project(":http4k-core")))
 }

--- a/http4k-resilience4j/src/test/kotlin/org/http/filter/ResilienceFiltersTest.kt
+++ b/http4k-resilience4j/src/test/kotlin/org/http/filter/ResilienceFiltersTest.kt
@@ -14,15 +14,18 @@ import io.github.resilience4j.ratelimiter.RateLimiter
 import io.github.resilience4j.ratelimiter.RateLimiterConfig
 import io.github.resilience4j.retry.Retry
 import io.github.resilience4j.retry.RetryConfig
+import io.github.resilience4j.timelimiter.TimeLimiter
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.BAD_GATEWAY
+import org.http4k.core.Status.Companion.CLIENT_TIMEOUT
 import org.http4k.core.Status.Companion.INTERNAL_SERVER_ERROR
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.Status.Companion.SERVICE_UNAVAILABLE
 import org.http4k.core.Status.Companion.TOO_MANY_REQUESTS
 import org.http4k.core.then
+import org.http4k.filter.ResilienceFilters
 import org.http4k.filter.ResilienceFilters.Bulkheading
 import org.http4k.filter.ResilienceFilters.CircuitBreak
 import org.http4k.filter.ResilienceFilters.RateLimit
@@ -138,5 +141,27 @@ class ResilienceFiltersTest {
 
         latch.await()
         assertThat(bulkheading(Request(GET, "/second")).status, equalTo(TOO_MANY_REQUESTS))
+    }
+
+    @Test
+    fun `TimeLimit filter returns error response if time limit is exceeded`() {
+        val timeoutService = ResilienceFilters.TimeLimit(TimeLimiter.of(Duration.ofMillis(50)))
+            .then {
+                Thread.sleep(100)
+                Response(OK)
+            }
+
+        assertThat(timeoutService(Request(GET, "/")).status, equalTo(CLIENT_TIMEOUT))
+    }
+
+    @Test
+    fun `TimeLimit filter returns success if time limit is not exceeded`() {
+        val timeoutService = ResilienceFilters.TimeLimit(TimeLimiter.of(Duration.ofMillis(100)))
+            .then {
+                Thread.sleep(50)
+                Response(OK)
+            }
+
+        assertThat(timeoutService(Request(GET, "/")).status, equalTo(OK))
     }
 }

--- a/versions.properties
+++ b/versions.properties
@@ -161,6 +161,14 @@ version.io.github.resilience4j..resilience4j-retry=1.7.1
 ##                                     # available=2.1.0
 ##                                     # available=2.2.0
 
+## [blocked - 2.0.0] gradle variant error v Java 8
+version.io.github.resilience4j..resilience4j-timelimiter=1.7.1
+##                                     # available=2.0.0
+##                                     # available=2.0.1
+##                                     # available=2.0.2
+##                                     # available=2.1.0
+##                                     # available=2.2.0
+
 version.io.helidon.webclient..helidon-webclient=4.1.2
 
 version.io.helidon.webserver..helidon-webserver=4.1.2


### PR DESCRIPTION
Allows using resilience4j timeouts through a simple filter.

Standard usage:

```kotlin
ResilienceFilters.TimeLimit(TimeLimiter.of(Duration.ofMillis(500)))
  .then {
    val upstreamResponse = callSomeSlowApi()
    Response(OK).body(upstreamResponse)
  }
```

I don't know if allowing passing in the executor service is overkill, but it allows users a bit more control over what threads are used if they want it. If you'd rather not use that, just remove the second & third commits.

If there's any other reason this functionality wasn't already included or you just don't want it, feel free to close this PR 🙂 