### PR TITLE
Fix parsing of Accept headers

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/Accept.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Accept.kt
@@ -7,3 +7,13 @@ data class Accept(val contentTypes: List<ContentType>, val directives: Parameter
      */
     fun accepts(contentType: ContentType): Boolean = contentTypes.any { it.equalsIgnoringDirectives(contentType) }
 }
+
+/**
+ * See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+ */
+data class AcceptContent(val types: List<QualifiedContent>) {
+
+    fun accepts(contentType: ContentType): Boolean = types.any { it.content.equalsIgnoringDirectives(contentType) }
+}
+
+data class QualifiedContent(val content: ContentType, val priority: Double = 1.0)

--- a/http4k-core/src/main/kotlin/org/http4k/core/Accept.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Accept.kt
@@ -1,19 +1,20 @@
 package org.http4k.core
 
-data class Accept(val contentTypes: List<ContentType>, val directives: Parameters) {
+/**
+ * See https://www.rfc-editor.org/rfc/rfc9110.html#name-accept
+ */
+data class Accept(val contentTypes: List<QualifiedContent>) {
+
+    @Suppress("UNUSED_PARAMETER")
+    @Deprecated("Directives cannot be used in this context", ReplaceWith("Accept(types)"))
+    constructor(contentTypes: List<ContentType>, directives: Parameters) :
+        this(contentTypes.map { QualifiedContent(it) })
 
     /**
      * Note that the Accept header ignores CharSet because that is in a separate Accept-CharSet header..
      */
-    fun accepts(contentType: ContentType): Boolean = contentTypes.any { it.equalsIgnoringDirectives(contentType) }
-}
-
-/**
- * See https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
- */
-data class AcceptContent(val types: List<QualifiedContent>) {
-
-    fun accepts(contentType: ContentType): Boolean = types.any { it.content.equalsIgnoringDirectives(contentType) }
+    fun accepts(contentType: ContentType): Boolean =
+        contentTypes.any { it.content.equalsIgnoringDirectives(contentType) }
 }
 
 data class QualifiedContent(val content: ContentType, val priority: Double = 1.0)

--- a/http4k-core/src/main/kotlin/org/http4k/core/ContentType.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ContentType.kt
@@ -18,8 +18,6 @@ data class ContentType(val value: String, val directives: Parameters = emptyList
 
     fun equalsIgnoringDirectives(that: ContentType): Boolean = withNoDirectives() == that.withNoDirectives()
 
-    fun equalsIgnoringCharset(that: ContentType): Boolean = withoutCharset() == that.withoutCharset()
-
     companion object {
         fun Text(value: String, charset: Charset? = UTF_8) = ContentType(value, listOfNotNull(charset?.let {
             "charset" to charset.name().lowercase(getDefault())

--- a/http4k-core/src/main/kotlin/org/http4k/core/ContentType.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/ContentType.kt
@@ -8,6 +8,8 @@ data class ContentType(val value: String, val directives: Parameters = emptyList
 
     fun withNoDirectives() = copy(directives = emptyList())
 
+    fun withoutCharset() = copy(directives = directives.filter { it.first.lowercase(getDefault()) != "charset" })
+
     fun toHeaderValue() = (
         listOf(value) +
             directives
@@ -15,6 +17,8 @@ data class ContentType(val value: String, val directives: Parameters = emptyList
         ).joinToString("; ")
 
     fun equalsIgnoringDirectives(that: ContentType): Boolean = withNoDirectives() == that.withNoDirectives()
+
+    fun equalsIgnoringCharset(that: ContentType): Boolean = withoutCharset() == that.withoutCharset()
 
     companion object {
         fun Text(value: String, charset: Charset? = UTF_8) = ContentType(value, listOfNotNull(charset?.let {

--- a/http4k-core/src/main/kotlin/org/http4k/lens/header.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/header.kt
@@ -99,11 +99,7 @@ fun Response.location(uri: Uri) = with(LOCATION of uri)
 
 fun Request.accept(): Accept? = ACCEPT(this)
 
-fun Request.acceptContent(): Accept? = ACCEPT(this)
-
 fun Request.accept(accept: Accept) = with(ACCEPT of accept)
-
-fun Request.acceptContent(accept: Accept) = with(ACCEPT of accept)
 
 fun Request.basicAuthentication() = AUTHORIZATION_BASIC(this)
 

--- a/http4k-core/src/main/kotlin/org/http4k/lens/header.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/header.kt
@@ -65,7 +65,7 @@ object Header : BiDiLensSpec<HttpMessage, String>("header", StringParam,
             .let(::AcceptContent)
 
     private fun injectAcceptContentHeaders(accept: AcceptContent): String = accept.types.joinToString(", ") {
-        it.content.toHeaderValue() + it.priority
+        it.content.withNoDirectives().toHeaderValue() + it.priority
             .takeIf { priority -> priority < 1.0 }
             ?.let { priority -> ";q=$priority" }
             .orEmpty()

--- a/http4k-core/src/main/kotlin/org/http4k/lens/header.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/lens/header.kt
@@ -55,7 +55,7 @@ object Header : BiDiLensSpec<HttpMessage, String>("header", StringParam,
     private fun injectAcceptContentHeaders(accept: Accept): String = accept.contentTypes.joinToString(", ") {
         it.content.withoutCharset().toHeaderValue() + it.priority
             .takeIf { priority -> priority < 1.0 }
-            ?.let { priority -> ";q=$priority" }
+            ?.let { priority -> "; q=$priority" }
             .orEmpty()
     }
 

--- a/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
@@ -161,7 +161,7 @@ class HeaderTest {
         val reqWithHeader = Request(GET, "").accept(accept)
 
         assertThat(reqWithHeader.header("Accept"),
-            equalTo("text/html, application/pdf, application/xml;q=0.9, image/webp, */*;q=0.8"))
+            equalTo("text/html, application/pdf, application/xml; q=0.9, image/webp, */*; q=0.8"))
         assertThat(reqWithHeader.accept(), equalTo(accept))
     }
 
@@ -179,14 +179,14 @@ class HeaderTest {
 
         assertThat(
             Request(GET, "").accept(accept).header("Accept"),
-            equalTo("text/*;q=0.3, text/plain;q=0.7, text/plain; format=flowed, text/plain; format=fixed;q=0.4, */*;q=0.5")
+            equalTo("text/*; q=0.3, text/plain; q=0.7, text/plain; format=flowed, text/plain; format=fixed; q=0.4, */*; q=0.5")
         )
 
         val expected = accept.copy(accept.contentTypes.map { it.copy(content = it.content.withoutCharset()) })
 
         assertThat(
             Request(GET, "")
-                .header("Accept", "text/*;charset=utf-8;q=0.3, text/plain;q=0.7, text/plain;format=flowed;charset=utf-8, text/plain;format=fixed;q=0.4, */*;q=0.5").accept(),
+                .header("Accept", "text/*;charset=utf-8;q=0.3, text/plain; q=0.7, text/plain;format=flowed;charset=utf-8, text/plain;format=fixed;q=0.4, */*;q=0.5").accept(),
             equalTo(expected)
         )
     }

--- a/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
@@ -157,6 +157,24 @@ class HeaderTest {
     }
 
     @Test
+    fun `accept content header serialises correctly from message`() {
+        val accept = AcceptContent(listOf(
+                QualifiedContent(TEXT_HTML.withNoDirectives()),
+                QualifiedContent(APPLICATION_PDF.withNoDirectives()),
+                QualifiedContent(APPLICATION_XML.withNoDirectives(), 0.9),
+                QualifiedContent(ContentType("image/webp")),
+                QualifiedContent(ContentType("*/*"), 0.8)
+            )
+        )
+
+        val reqWithHeader = Request(GET, "").acceptContent(accept)
+
+        assertThat(reqWithHeader.header("Accept"),
+            equalTo("text/html, application/pdf, application/xml;q=0.9, image/webp, */*;q=0.8"))
+        assertThat(reqWithHeader.acceptContent(), equalTo(accept))
+    }
+
+    @Test
     fun `accept header serialises correctly to message`() {
         val reqWithHeader = Request(GET, "").with(Header.ACCEPT of Accept(listOf(TEXT_HTML.withNoDirectives(), APPLICATION_PDF.withNoDirectives(), APPLICATION_XML.withNoDirectives()), listOf("q" to "0.9, image/webp, */*", "q" to "0.8")))
 

--- a/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
@@ -175,6 +175,30 @@ class HeaderTest {
     }
 
     @Test
+    fun `accept content header ignores directives`() {
+        val accept = AcceptContent(
+            listOf(
+                QualifiedContent(ContentType("text/html", listOf("level" to "1")), 0.8),
+                QualifiedContent(ContentType("text/html", listOf("charset" to "utf-8")), 0.2),
+                QualifiedContent(ContentType("text/plain")),
+            )
+        )
+
+        assertThat(
+            Request(GET, "").acceptContent(accept).header("Accept"),
+            equalTo("text/html;q=0.8, text/html;q=0.2, text/plain")
+        )
+
+        val expected = accept.copy(accept.types.map { it.copy(content = it.content.withNoDirectives()) })
+
+        assertThat(
+            Request(GET, "")
+                .header("Accept", "text/html;level=1;q=0.8, text/html;charset=utf-8;q=0.2, text/plain").acceptContent(),
+            equalTo(expected)
+        )
+    }
+
+    @Test
     fun `accept header serialises correctly to message`() {
         val reqWithHeader = Request(GET, "").with(Header.ACCEPT of Accept(listOf(TEXT_HTML.withNoDirectives(), APPLICATION_PDF.withNoDirectives(), APPLICATION_XML.withNoDirectives()), listOf("q" to "0.9, image/webp, */*", "q" to "0.8")))
 

--- a/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
@@ -5,7 +5,6 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.throws
 import org.http4k.core.Accept
-import org.http4k.core.AcceptContent
 import org.http4k.core.ContentType
 import org.http4k.core.ContentType.Companion.APPLICATION_PDF
 import org.http4k.core.ContentType.Companion.APPLICATION_XML
@@ -132,19 +131,10 @@ class HeaderTest {
     }
 
     @Test
-    fun `accept header deserialises correctly from message`() {
+    fun `accept content header deserialises correctly from message`() {
         val accept = Header.ACCEPT(Request(GET, "").header("Accept", "text/html, application/pdf, application/xml;q=0.9, image/webp, */*;q=0.8"))!!
 
-        assertThat(accept, equalTo(Accept(listOf(TEXT_HTML.withNoDirectives(), APPLICATION_PDF.withNoDirectives(), APPLICATION_XML.withNoDirectives()), listOf("q" to "0.9, image/webp, */*", "q" to "0.8"))))
-        assertThat(accept.accepts(TEXT_HTML), equalTo(true))
-        assertThat(accept.accepts(MULTIPART_FORM_DATA), equalTo(false))
-    }
-
-    @Test
-    fun `accept content header deserialises correctly from message`() {
-        val accept = Header.ACCEPT_CONTENT(Request(GET, "").header("Accept", "text/html, application/pdf, application/xml;q=0.9, image/webp, */*;q=0.8"))!!
-
-        assertThat(accept, equalTo(AcceptContent(listOf(
+        assertThat(accept, equalTo(Accept(listOf(
             QualifiedContent(TEXT_HTML.withNoDirectives()),
             QualifiedContent(APPLICATION_PDF.withNoDirectives()),
             QualifiedContent(APPLICATION_XML.withNoDirectives(), 0.9),
@@ -158,7 +148,7 @@ class HeaderTest {
 
     @Test
     fun `accept content header serialises correctly from message`() {
-        val accept = AcceptContent(listOf(
+        val accept = Accept(listOf(
                 QualifiedContent(TEXT_HTML.withNoDirectives()),
                 QualifiedContent(APPLICATION_PDF.withNoDirectives()),
                 QualifiedContent(APPLICATION_XML.withNoDirectives(), 0.9),
@@ -176,7 +166,7 @@ class HeaderTest {
 
     @Test
     fun `accept content header ignores directives`() {
-        val accept = AcceptContent(
+        val accept = Accept(
             listOf(
                 QualifiedContent(ContentType("text/html", listOf("level" to "1")), 0.8),
                 QualifiedContent(ContentType("text/html", listOf("charset" to "utf-8")), 0.2),
@@ -189,21 +179,12 @@ class HeaderTest {
             equalTo("text/html;q=0.8, text/html;q=0.2, text/plain")
         )
 
-        val expected = accept.copy(accept.types.map { it.copy(content = it.content.withNoDirectives()) })
+        val expected = accept.copy(accept.contentTypes.map { it.copy(content = it.content.withNoDirectives()) })
 
         assertThat(
             Request(GET, "")
                 .header("Accept", "text/html;level=1;q=0.8, text/html;charset=utf-8;q=0.2, text/plain").acceptContent(),
             equalTo(expected)
-        )
-    }
-
-    @Test
-    fun `accept header serialises correctly to message`() {
-        val reqWithHeader = Request(GET, "").with(Header.ACCEPT of Accept(listOf(TEXT_HTML.withNoDirectives(), APPLICATION_PDF.withNoDirectives(), APPLICATION_XML.withNoDirectives()), listOf("q" to "0.9, image/webp, */*", "q" to "0.8")))
-
-        assertThat(reqWithHeader.header("Accept"), equalTo("text/html, application/pdf, application/xml;q=0.9, image/webp, */*;q=0.8"))
-        assertThat(reqWithHeader.accept(), equalTo(Accept(listOf(TEXT_HTML.withNoDirectives(), APPLICATION_PDF.withNoDirectives(), APPLICATION_XML.withNoDirectives()), listOf("q" to "0.9, image/webp, */*", "q" to "0.8")))
         )
     }
 

--- a/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
@@ -157,11 +157,11 @@ class HeaderTest {
             )
         )
 
-        val reqWithHeader = Request(GET, "").acceptContent(accept)
+        val reqWithHeader = Request(GET, "").accept(accept)
 
         assertThat(reqWithHeader.header("Accept"),
             equalTo("text/html, application/pdf, application/xml;q=0.9, image/webp, */*;q=0.8"))
-        assertThat(reqWithHeader.acceptContent(), equalTo(accept))
+        assertThat(reqWithHeader.accept(), equalTo(accept))
     }
 
     @Test
@@ -175,7 +175,7 @@ class HeaderTest {
         )
 
         assertThat(
-            Request(GET, "").acceptContent(accept).header("Accept"),
+            Request(GET, "").accept(accept).header("Accept"),
             equalTo("text/html;q=0.8, text/html;q=0.2, text/plain")
         )
 
@@ -183,7 +183,7 @@ class HeaderTest {
 
         assertThat(
             Request(GET, "")
-                .header("Accept", "text/html;level=1;q=0.8, text/html;charset=utf-8;q=0.2, text/plain").acceptContent(),
+                .header("Accept", "text/html;level=1;q=0.8, text/html;charset=utf-8;q=0.2, text/plain").accept(),
             equalTo(expected)
         )
     }

--- a/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
+++ b/http4k-core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
@@ -5,11 +5,13 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.throws
 import org.http4k.core.Accept
+import org.http4k.core.AcceptContent
 import org.http4k.core.ContentType
 import org.http4k.core.ContentType.Companion.APPLICATION_PDF
 import org.http4k.core.ContentType.Companion.APPLICATION_XML
 import org.http4k.core.ContentType.Companion.MULTIPART_FORM_DATA
 import org.http4k.core.ContentType.Companion.TEXT_HTML
+import org.http4k.core.QualifiedContent
 import org.http4k.core.Credentials
 import org.http4k.core.Method
 import org.http4k.core.Method.GET
@@ -134,6 +136,22 @@ class HeaderTest {
         val accept = Header.ACCEPT(Request(GET, "").header("Accept", "text/html, application/pdf, application/xml;q=0.9, image/webp, */*;q=0.8"))!!
 
         assertThat(accept, equalTo(Accept(listOf(TEXT_HTML.withNoDirectives(), APPLICATION_PDF.withNoDirectives(), APPLICATION_XML.withNoDirectives()), listOf("q" to "0.9, image/webp, */*", "q" to "0.8"))))
+        assertThat(accept.accepts(TEXT_HTML), equalTo(true))
+        assertThat(accept.accepts(MULTIPART_FORM_DATA), equalTo(false))
+    }
+
+    @Test
+    fun `accept content header deserialises correctly from message`() {
+        val accept = Header.ACCEPT_CONTENT(Request(GET, "").header("Accept", "text/html, application/pdf, application/xml;q=0.9, image/webp, */*;q=0.8"))!!
+
+        assertThat(accept, equalTo(AcceptContent(listOf(
+            QualifiedContent(TEXT_HTML.withNoDirectives()),
+            QualifiedContent(APPLICATION_PDF.withNoDirectives()),
+            QualifiedContent(APPLICATION_XML.withNoDirectives(), 0.9),
+            QualifiedContent(ContentType("image/webp")),
+            QualifiedContent(ContentType("*/*"), 0.8)
+        ))))
+
         assertThat(accept.accepts(TEXT_HTML), equalTo(true))
         assertThat(accept.accepts(MULTIPART_FORM_DATA), equalTo(false))
     }


### PR DESCRIPTION
Currently, if the `q=` parameter is present, it'll parse the headers incorrectly. 

Moreover, the `directives` property in `Accept` makes no sense as parameters should always be associated with a content type.