### PR TITLE
Add fallback from SSE to HTTP if event stream request cannot be matched in SSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This list is not intended to be all-encompassing - it will document major and br
 changes with their rationale when appropriate:
 
 ### v5.36.0.0 (uncut)
+- **http4k-server-helidon*** : [Possible Break] Throw exception if configured with `Immediate` stop mode as it's not supported.
+- **http4k-realtime-core*** : [Possible Break] SSE responses now contain a "handled" flag, so we can now fallback from SSE to HTTP if the route is unbound in SSE.
+- **http4k-server-undertow*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
+- **http4k-server-jetty*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
+- **http4k-server-jetty11*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
+- **http4k-server-helidon*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
 - **http4k-server-netty*** : [Possible Break] Throw exception if configured with `Immediate` stop mode as it's not supported.
 
 ### v5.35.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ changes with their rationale when appropriate:
 
 ### v5.36.0.0 (uncut)
 - **http4k-server-helidon*** : [Possible Break] Throw exception if configured with `Immediate` stop mode as it's not supported.
-- **http4k-realtime-core*** : [Possible Break] SSE responses now contain a "handled" flag, so we can now fallback from SSE to HTTP if the route is unbound in SSE.
+- **http4k-realtime-core*** : [Possible Break] SSE responses now contain a "handled" flag, so we can now fallback from SSE to HTTP if the route is unbound in SSE. SSE now also returns a 404 if the route is unbound.
 - **http4k-server-undertow*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
 - **http4k-server-jetty*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
 - **http4k-server-jetty11*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,13 @@ This list is not intended to be all-encompassing - it will document major and br
 changes with their rationale when appropriate:
 
 ### v5.36.0.0 (uncut)
-- **http4k-server-helidon*** : [Possible Break] Throw exception if configured with `Immediate` stop mode as it's not supported.
 - **http4k-realtime-core*** : [Possible Break] SSE responses now contain a "handled" flag, so we can now fallback from SSE to HTTP if the route is unbound in SSE. SSE now also returns a 404 if the route is unbound.
-- **http4k-server-undertow*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
+- **http4k-server-helidon*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
+- **http4k-server-helidon*** : [Possible Break] Throw exception if configured with `Immediate` stop mode as it's not supported.
 - **http4k-server-jetty*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
 - **http4k-server-jetty11*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
-- **http4k-server-helidon*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
 - **http4k-server-netty*** : [Possible Break] Throw exception if configured with `Immediate` stop mode as it's not supported.
+- **http4k-server-undertow*** : [Possible Break] Slight refactor of SSE code to support SSE -> HTTP fallback
 
 ### v5.35.5.0
 - **http4k-*** : Upgrade some dependency versions.

--- a/core/realtime-core/src/main/kotlin/org/http4k/routing/internalSse.kt
+++ b/core/realtime-core/src/main/kotlin/org/http4k/routing/internalSse.kt
@@ -1,6 +1,7 @@
 package org.http4k.routing
 
 import org.http4k.core.Request
+import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.core.UriTemplate
 import org.http4k.routing.SseRouterMatch.MatchingHandler
 import org.http4k.routing.SseRouterMatch.Unmatched
@@ -23,7 +24,7 @@ internal class RouterSseHandler(private val list: List<SseRouter>) : RoutingSseH
 
     override operator fun invoke(request: Request): SseResponse = when (val match = match(request)) {
         is MatchingHandler -> match(request)
-        is Unmatched -> SseResponse(handled = false) { it.close() }
+        is Unmatched -> SseResponse(NOT_FOUND, handled = false) { it.close() }
     }
 
     override fun withBasePath(new: String): RoutingSseHandler =
@@ -44,7 +45,7 @@ internal class TemplateRoutingSseHandler(
 
     override operator fun invoke(request: Request): SseResponse = when (val matched = match(request)) {
         is MatchingHandler -> matched(RoutedRequest(request, template))
-        is Unmatched -> SseResponse(handled = false) { it.close() }
+        is Unmatched -> SseResponse(NOT_FOUND, handled = false) { it.close() }
     }
 
     override fun withBasePath(new: String) = TemplateRoutingSseHandler(UriTemplate.from("$new/$template"), handler)

--- a/core/realtime-core/src/main/kotlin/org/http4k/routing/internalSse.kt
+++ b/core/realtime-core/src/main/kotlin/org/http4k/routing/internalSse.kt
@@ -44,7 +44,7 @@ internal class TemplateRoutingSseHandler(
 
     override operator fun invoke(request: Request): SseResponse = when (val matched = match(request)) {
         is MatchingHandler -> matched(RoutedRequest(request, template))
-        is Unmatched -> SseResponse { it.close() }
+        is Unmatched -> SseResponse(handled = false) { it.close() }
     }
 
     override fun withBasePath(new: String) = TemplateRoutingSseHandler(UriTemplate.from("$new/$template"), handler)

--- a/core/realtime-core/src/main/kotlin/org/http4k/routing/internalSse.kt
+++ b/core/realtime-core/src/main/kotlin/org/http4k/routing/internalSse.kt
@@ -23,7 +23,7 @@ internal class RouterSseHandler(private val list: List<SseRouter>) : RoutingSseH
 
     override operator fun invoke(request: Request): SseResponse = when (val match = match(request)) {
         is MatchingHandler -> match(request)
-        is Unmatched -> SseResponse { it.close() }
+        is Unmatched -> SseResponse(handled = false) { it.close() }
     }
 
     override fun withBasePath(new: String): RoutingSseHandler =

--- a/core/realtime-core/src/main/kotlin/org/http4k/sse/sse.kt
+++ b/core/realtime-core/src/main/kotlin/org/http4k/sse/sse.kt
@@ -18,8 +18,8 @@ interface Sse {
 
 typealias SseConsumer = (Sse) -> Unit
 
-data class SseResponse(val status: Status = OK, val headers: Headers = emptyList(), val consumer: SseConsumer) {
-    constructor(consumer: SseConsumer) : this(OK, emptyList(), consumer)
+data class SseResponse(val status: Status = OK, val headers: Headers = emptyList(), val handled: Boolean = true, val consumer: SseConsumer) {
+    constructor(consumer: SseConsumer) : this(OK, emptyList(), true, consumer)
 }
 
 typealias SseHandler = (Request) -> SseResponse

--- a/core/realtime-core/src/test/kotlin/org/http4k/sse/SseClientTest.kt
+++ b/core/realtime-core/src/test/kotlin/org/http4k/sse/SseClientTest.kt
@@ -41,7 +41,7 @@ class SseClientTest {
 
         val client = { req: Request ->
             assertThat(req, equalTo(Request(GET, "/")))
-            SseResponse(OK, listOf("foo" to "bar"), consumer)
+            SseResponse(OK, listOf("foo" to "bar"), consumer = consumer)
         }.testSseClient(Request(GET, "/"))
 
         assertThat(client.status, equalTo(OK))

--- a/core/server/jetty/src/main/kotlin/org/http4k/server/JettyEventStreamHandler.kt
+++ b/core/server/jetty/src/main/kotlin/org/http4k/server/JettyEventStreamHandler.kt
@@ -31,7 +31,7 @@ class JettyEventStreamHandler(
         if (request.isEventStream()) {
             val connectRequest = request.asHttp4kRequest()
             if (connectRequest != null) {
-                val (status, headers, consumer) = sse(connectRequest)
+                val (status, headers, handled, consumer) = sse(connectRequest)
                 response.writeEventStreamResponse(status, headers).handle { _, flushFailure ->
                     if (flushFailure == null) {
                         val output = Content.Sink.asOutputStream(response)

--- a/core/server/jetty11/src/main/kotlin/org/http4k/server/Jetty11EventStreamHandler.kt
+++ b/core/server/jetty11/src/main/kotlin/org/http4k/server/Jetty11EventStreamHandler.kt
@@ -24,7 +24,7 @@ class Jetty11EventStreamHandler(
         if (!baseRequest.isHandled && request.isEventStream()) {
             val connectRequest = request.asHttp4kRequest()
             if (connectRequest != null) {
-                val (status, headers, consumer) = sse(connectRequest)
+                val (status, headers, handled, consumer) = sse(connectRequest)
                 response.writeEventStreamResponse(status, headers)
 
                 val async = request.startAsyncWithNoTimeout()

--- a/core/server/undertow/src/main/kotlin/org/http4k/server/Http4kUndertowSseFallbackHandler.kt
+++ b/core/server/undertow/src/main/kotlin/org/http4k/server/Http4kUndertowSseFallbackHandler.kt
@@ -1,0 +1,49 @@
+package org.http4k.server
+
+import io.undertow.server.HttpHandler
+import io.undertow.server.HttpServerExchange
+import io.undertow.util.HttpString
+import org.http4k.core.ContentType
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.RequestSource
+import org.http4k.core.Uri
+import org.http4k.core.toParametersMap
+import org.http4k.sse.SseHandler
+
+class Http4kUndertowSseFallbackHandler(private val sse: SseHandler, private val fallback: HttpHandler) : HttpHandler {
+
+    override fun handleRequest(exchange: HttpServerExchange) {
+        val request = exchange.asRequest() ?: error("Cannot create request from exchange")
+
+        when {
+            exchange.hasEventStreamContentType() -> {
+                val (status, headers, handled, consumer) = sse(request)
+                println(listOf(status, headers, handled, consumer))
+                if (handled) {
+                    exchange.setStatusCode(status.code)
+                    headers.toParametersMap().forEach { (name, values) ->
+                        exchange.responseHeaders.putAll(HttpString(name), values.toList())
+                    }
+                    Http4kUndertowSseHandler(request, consumer).handleRequest(exchange)
+                } else {
+                    fallback.handleRequest(exchange)
+                }
+            }
+
+            else -> fallback.handleRequest(exchange)
+        }
+    }
+
+    private fun HttpServerExchange.asRequest() =
+        Method.supportedOrNull(requestMethod.toString())?.let {
+            Request(it, Uri.of("$relativePath?$queryString"))
+                .headers(requestHeaders
+                    .flatMap { header -> header.map { header.headerName.toString() to it } })
+                .source(RequestSource(sourceAddress.hostString, sourceAddress.port, requestScheme))
+        }
+}
+
+private fun HttpServerExchange.hasEventStreamContentType() =
+    requestHeaders["Accept"]?.any { it.equals(ContentType.TEXT_EVENT_STREAM.value, true) } ?: false
+

--- a/core/server/undertow/src/main/kotlin/org/http4k/server/Http4kUndertowSseFallbackHandler.kt
+++ b/core/server/undertow/src/main/kotlin/org/http4k/server/Http4kUndertowSseFallbackHandler.kt
@@ -19,7 +19,7 @@ class Http4kUndertowSseFallbackHandler(private val sse: SseHandler, private val 
         when {
             exchange.hasEventStreamContentType() -> {
                 val (status, headers, handled, consumer) = sse(request)
-                println(listOf(status, headers, handled, consumer))
+
                 if (handled) {
                     exchange.setStatusCode(status.code)
                     headers.toParametersMap().forEach { (name, values) ->

--- a/core/server/undertow/src/main/kotlin/org/http4k/server/Http4kUndertowSseHandler.kt
+++ b/core/server/undertow/src/main/kotlin/org/http4k/server/Http4kUndertowSseHandler.kt
@@ -1,64 +1,37 @@
 package org.http4k.server
 
-import io.undertow.server.HttpHandler
-import io.undertow.server.HttpServerExchange
 import io.undertow.server.handlers.sse.ServerSentEventConnection
+import io.undertow.server.handlers.sse.ServerSentEventConnection.EventCallback
 import io.undertow.server.handlers.sse.ServerSentEventHandler
-import io.undertow.util.HttpString
-import org.http4k.core.ContentType
-import org.http4k.core.Method
 import org.http4k.core.Request
-import org.http4k.core.RequestSource
-import org.http4k.core.Uri
-import org.http4k.core.toParametersMap
 import org.http4k.sse.PushAdaptingSse
-import org.http4k.sse.SseHandler
+import org.http4k.sse.SseConsumer
 import org.http4k.sse.SseMessage
+import org.http4k.sse.SseMessage.Data
+import org.http4k.sse.SseMessage.Event
+import org.http4k.sse.SseMessage.Retry
 import java.io.IOException
 
-class Http4kUndertowSseHandler(private val sse: SseHandler) : HttpHandler {
+fun Http4kUndertowSseHandler(request: Request, consumer: SseConsumer) =
+    ServerSentEventHandler { connection, _ ->
+        val socket = object : PushAdaptingSse(request) {
 
-    override fun handleRequest(exchange: HttpServerExchange) {
-        val asRequest = exchange.asRequest()
-        val request = asRequest ?: error("Cannot create request from exchange")
-        val (status, headers, consumer) = sse(request)
-        exchange.setStatusCode(status.code)
+            override fun send(message: SseMessage) =
+                when (message) {
+                    is Retry -> connection.sendRetry(message.backoff.toMillis())
+                    is Data -> connection.send(message.data)
+                    is Event -> connection.send(message.data, message.event, message.id, NoOp)
+                }
 
-        headers.toParametersMap().forEach { (name, values) ->
-            exchange.responseHeaders.putAll(HttpString(name), values.toList())
+            override fun close() = connection.shutdown()
         }
 
-        val next = ServerSentEventHandler { connection, _ ->
-            val socket = object : PushAdaptingSse(request) {
+        consumer(socket)
 
-                override fun send(message: SseMessage) =
-                    when (message) {
-                        is SseMessage.Retry -> connection.sendRetry(message.backoff.toMillis())
-                        is SseMessage.Data -> connection.send(message.data)
-                        is SseMessage.Event -> connection.send(message.data, message.event, message.id, NoOp)
-                    }
-
-                override fun close() = connection.shutdown()
-            }
-
-            consumer(socket)
-
-            connection.addCloseTask { socket.triggerClose() }
-        }
-
-        next.handleRequest(exchange)
+        connection.addCloseTask { socket.triggerClose() }
     }
 
-    private fun HttpServerExchange.asRequest() =
-        Method.supportedOrNull(requestMethod.toString())?.let {
-            Request(it, Uri.of("$relativePath?$queryString"))
-                .headers(requestHeaders
-                    .flatMap { header -> header.map { header.headerName.toString() to it } })
-                .source(RequestSource(sourceAddress.hostString, sourceAddress.port, requestScheme))
-        }
-}
-
-private object NoOp : ServerSentEventConnection.EventCallback {
+private object NoOp : EventCallback {
     override fun done(
         connection: ServerSentEventConnection?,
         data: String?,
@@ -76,8 +49,4 @@ private object NoOp : ServerSentEventConnection.EventCallback {
     ) {
         e?.printStackTrace()
     }
-}
-
-fun hasEventStreamContentType(): (HttpServerExchange) -> Boolean = {
-    it.requestHeaders["Accept"]?.any { it.equals(ContentType.TEXT_EVENT_STREAM.value, true) } ?: false
 }

--- a/core/server/undertow/src/main/kotlin/org/http4k/server/Undertow.kt
+++ b/core/server/undertow/src/main/kotlin/org/http4k/server/Undertow.kt
@@ -8,7 +8,7 @@ import io.undertow.server.handlers.BlockingHandler
 import io.undertow.server.handlers.GracefulShutdownHandler
 import org.http4k.core.HttpHandler
 import org.http4k.core.Response
-import org.http4k.core.Status.Companion.BAD_REQUEST
+import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.server.ServerConfig.StopMode
 import org.http4k.server.ServerConfig.StopMode.Graceful
 import org.http4k.server.ServerConfig.StopMode.Immediate
@@ -26,7 +26,7 @@ class Undertow(
 
     override fun toServer(http: HttpHandler?, ws: WsHandler?, sse: SseHandler?): Http4kServer {
         val httpHandler =
-            (http ?: { Response(BAD_REQUEST) }).let(::Http4kUndertowHttpHandler).let(::BlockingHandler).let { handler ->
+            (http ?: { Response(NOT_FOUND) }).let(::Http4kUndertowHttpHandler).let(::BlockingHandler).let { handler ->
                 when (stopMode) {
                     is Graceful -> GracefulShutdownHandler(handler)
                     else -> handler


### PR DESCRIPTION
We want to be able to fallback in order that the HTTP handler has the chance to match the request even if it's an EventStream request (it's just HTTP after all!).