### PR TITLE
Utility function to get the structure suffix from a content type

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/core/ContentType.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/ContentType.kt
@@ -18,6 +18,8 @@ data class ContentType(val value: String, val directives: Parameters = emptyList
 
     fun equalsIgnoringDirectives(that: ContentType): Boolean = withNoDirectives() == that.withNoDirectives()
 
+    fun structure() = Regex("\\+(\\w*)$").find(value)?.groups?.get(1)?.value
+
     companion object {
         fun Text(value: String, charset: Charset? = UTF_8) = ContentType(value, listOfNotNull(charset?.let {
             "charset" to charset.name().lowercase(getDefault())

--- a/core/core/src/test/kotlin/org/http4k/core/ContentTypeTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/ContentTypeTest.kt
@@ -29,4 +29,20 @@ class ContentTypeTest {
         assertThat(contentType3.toHeaderValue(), equalTo("bar; bob; bob2=jim"))
         assertThat(contentType3.toHeaderValue(), equalTo("bar; bob; bob2=jim"))
     }
+
+    @Test
+    fun `structure returns null when there is no +suffix`() {
+        assertThat(ContentType("foo").structure(), equalTo(null))
+        assertThat(ContentType("foo/bar").structure(), equalTo(null))
+        assertThat(ContentType("foo/bar.baz").structure(), equalTo(null))
+        assertThat(ContentType("foo/bar.baz", listOf("x" to "y")).structure(), equalTo(null))
+    }
+
+    @Test
+    fun `structure returns the structure suffix when there is a +suffix`() {
+        assertThat(ContentType("foo+json").structure(), equalTo("json"))
+        assertThat(ContentType("foo/bar+xml").structure(), equalTo("xml"))
+        assertThat(ContentType("foo/bar.baz+zip").structure(), equalTo("zip"))
+        assertThat(ContentType("foo/bar.baz+json", listOf("x" to "y")).structure(), equalTo("json"))
+    }
 }


### PR DESCRIPTION
Named as per the [media type spec](https://www.rfc-editor.org/rfc/rfc6838#section-4.2.8).

Lets you write stuff like 

```kotlin
if (response.contentType()?.structure() == "json") {
  // do something
}
```