### PR TITLE
Fix #1221 Lack of ability to automatically generate valid Open API schemas for downloading files

### DIFF
--- a/core/contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
+++ b/core/contract/src/main/kotlin/org/http4k/contract/routeMeta.kt
@@ -92,7 +92,8 @@ class RouteMetaDsl internal constructor() {
      */
     @JvmName("returningStatus")
     fun <T> returning(
-        status: Status, body: Pair<BiDiBodyLens<T>, T>,
+        status: Status,
+        body: Pair<BiDiBodyLens<T>, T>,
         description: String? = null,
         definitionId: String? = null,
         schemaPrefix: String? = null

--- a/core/contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
+++ b/core/contract/src/test/kotlin/org/http4k/contract/ContractRendererContract.kt
@@ -12,6 +12,7 @@ import org.http4k.core.Body
 import org.http4k.core.ContentType
 import org.http4k.core.ContentType.Companion.APPLICATION_FORM_URLENCODED
 import org.http4k.core.ContentType.Companion.APPLICATION_JSON
+import org.http4k.core.ContentType.Companion.APPLICATION_PDF
 import org.http4k.core.ContentType.Companion.APPLICATION_XML
 import org.http4k.core.ContentType.Companion.OCTET_STREAM
 import org.http4k.core.ContentType.Companion.TEXT_PLAIN
@@ -47,6 +48,7 @@ import org.http4k.lens.Validator.Strict
 import org.http4k.lens.WebForm
 import org.http4k.lens.bigDecimal
 import org.http4k.lens.bigInteger
+import org.http4k.lens.binary
 import org.http4k.lens.boolean
 import org.http4k.lens.double
 import org.http4k.lens.enum
@@ -244,6 +246,12 @@ abstract class ContractRendererContract<NODE : Any>(
                 val json = MultipartFormField.json(json).required("jsonField")
                 receiving(Body.multipartForm(Strict, field, pic, json).toLens())
             } bindContract PUT to { _ -> Response(OK) }
+            routes += "/pdf-file" meta {
+                returning(OK, Body.binary(APPLICATION_PDF).toLens() to "fake pdf".toByteArray().inputStream())
+            } bindContract GET to { _ -> Response(OK) }
+            routes += "/png-file" meta {
+                returning(OK, Body.binary(ContentType("image/png")).toLens() to "fake png".toByteArray().inputStream())
+            } bindContract GET to { _ -> Response(OK) }
             routes += "/bearer_auth" meta {
                 security = BearerAuthSecurity("foo")
             } bindContract POST to { _ -> Response(OK) }

--- a/core/contract/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.renders as expected.approved
+++ b/core/contract/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.renders as expected.approved
@@ -875,6 +875,7 @@
           "200": {
             "description": "OK",
             "schema": {
+              "type": "file"
             }
           }
         },
@@ -904,6 +905,7 @@
           "200": {
             "description": "OK",
             "schema": {
+              "type": "file"
             }
           }
         },

--- a/core/contract/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.renders as expected.approved
+++ b/core/contract/src/test/resources/org/http4k/contract/openapi/v2/OpenApi2Test.renders as expected.approved
@@ -857,6 +857,64 @@
         ]
       }
     },
+    "/basepath/pdf-file": {
+      "get": {
+        "tags": [
+          "/basepath"
+        ],
+        "summary": "<unknown>",
+        "operationId": "getBasepathPdf_file",
+        "produces": [
+          "application/pdf"
+        ],
+        "consumes": [
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ]
+      }
+    },
+    "/basepath/png-file": {
+      "get": {
+        "tags": [
+          "/basepath"
+        ],
+        "summary": "<unknown>",
+        "operationId": "getBasepathPng_file",
+        "produces": [
+          "image/png"
+        ],
+        "consumes": [
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ]
+      }
+    },
     "/basepath/produces_and_consumes": {
       "get": {
         "tags": [

--- a/core/contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
+++ b/core/contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3AutoTest.renders as expected.approved
@@ -870,6 +870,68 @@
         "deprecated": false
       }
     },
+    "/basepath/pdf-file": {
+      "get": {
+        "summary": "<unknown>",
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "getBasepathPdf_file",
+        "deprecated": false
+      }
+    },
+    "/basepath/png-file": {
+      "get": {
+        "summary": "<unknown>",
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "getBasepathPng_file",
+        "deprecated": false
+      }
+    },
     "/basepath/produces_and_consumes": {
       "get": {
         "summary": "<unknown>",

--- a/core/contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
+++ b/core/contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3KondorTest.renders as expected.approved
@@ -872,6 +872,70 @@
         "deprecated": false
       }
     },
+    "/basepath/pdf-file": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "getBasepathPdf_file",
+        "deprecated": false
+      }
+    },
+    "/basepath/png-file": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "getBasepathPng_file",
+        "deprecated": false
+      }
+    },
     "/basepath/produces_and_consumes": {
       "get": {
         "summary": "<unknown>",

--- a/core/contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
+++ b/core/contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3ServersDefaultTest.renders as expected.approved
@@ -872,6 +872,70 @@
         "deprecated": false
       }
     },
+    "/basepath/pdf-file": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "getBasepathPdf_file",
+        "deprecated": false
+      }
+    },
+    "/basepath/png-file": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "getBasepathPng_file",
+        "deprecated": false
+      }
+    },
     "/basepath/produces_and_consumes": {
       "get": {
         "summary": "<unknown>",

--- a/core/contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
+++ b/core/contract/src/test/resources/org/http4k/contract/openapi/v3/OpenApi3Test.renders as expected.approved
@@ -872,6 +872,70 @@
         "deprecated": false
       }
     },
+    "/basepath/pdf-file": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "getBasepathPdf_file",
+        "deprecated": false
+      }
+    },
+    "/basepath/png-file": {
+      "get": {
+        "summary": "<unknown>",
+        "description": null,
+        "tags": [
+          "/basepath"
+        ],
+        "parameters": [
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": [
+            ]
+          }
+        ],
+        "operationId": "getBasepathPng_file",
+        "deprecated": false
+      }
+    },
     "/basepath/produces_and_consumes": {
       "get": {
         "summary": "<unknown>",

--- a/core/contract/src/test/resources/org/http4k/contract/simple/SimpleJsonTest.renders as expected.approved
+++ b/core/contract/src/test/resources/org/http4k/contract/simple/SimpleJsonTest.renders as expected.approved
@@ -22,6 +22,8 @@
     "GET:/basepath/produces_and_consumes": "<unknown>",
     "POST:/basepath/returning": "<unknown>",
     "PUT:/basepath/multipart-fields": "<unknown>",
+    "GET:/basepath/pdf-file": "<unknown>",
+    "GET:/basepath/png-file": "<unknown>",
     "POST:/basepath/bearer_auth": "<unknown>",
     "POST:/basepath/body_negotiated": "<unknown>"
   }


### PR DESCRIPTION
Issue link: https://github.com/http4k/http4k/issues/1221

This change we will also allow to use [openapi-generator](https://github.com/OpenAPITools/openapi-generator) to generate file types e.g. Blob for Typescript.