### PR TITLE
Updates to formatting of cookies

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/core/cookie/Cookie.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/cookie/Cookie.kt
@@ -41,7 +41,7 @@ data class Cookie(
         appendIfTrue(secure, "secure")
         appendIfTrue(httpOnly, "HttpOnly")
         appendIfPresent(sameSite, "SameSite=$sameSite")
-    }.joinToString("; ")
+    }.joinToString("") { "; $it" }
 
     companion object {
         fun parse(cookieValue: String): Cookie? {
@@ -93,7 +93,7 @@ data class Cookie(
         if (toCheck) add(toInclude)
     }
 
-    fun fullCookieString(unquotedValue: Boolean = false) = "$name=${if (unquotedValue) value else value.quoted()}; ${attributes()}"
+    fun fullCookieString(unquotedValue: Boolean = false) = "$name=${if (unquotedValue) value else value.quoted()}${attributes()}"
     fun keyValueCookieString(unquotedValue: Boolean = false) = "$name=${if (unquotedValue) value else value.quoted()}"
 }
 

--- a/core/core/src/main/kotlin/org/http4k/core/cookie/CookieExtensions.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/cookie/CookieExtensions.kt
@@ -5,7 +5,7 @@ import org.http4k.core.Response
 import org.http4k.unquoted
 import java.time.Instant
 
-fun Response.cookie(cookie: Cookie): Response = header("Set-Cookie", cookie.fullCookieString())
+fun Response.cookie(cookie: Cookie, unquotedValue: Boolean = false) = header("Set-Cookie", cookie.fullCookieString(unquotedValue))
 
 fun Request.removeCookie(name: String) =
     cookies().filterNot { it.name == name }.fold(removeHeader("Cookie")) { acc, c -> acc.cookie(c) }

--- a/core/core/src/main/kotlin/org/http4k/core/cookie/CookieExtensions.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/cookie/CookieExtensions.kt
@@ -39,4 +39,5 @@ fun Response.cookies(): List<Cookie> = headerValues("set-cookie").filterNotNull(
 
 fun Cookie.invalidate(): Cookie = copy(value = "").maxAge(0).expires(Instant.EPOCH)
 
-fun Response.invalidateCookie(name: String, domain: String? = null): Response = replaceCookie(Cookie(name, "", domain = domain).invalidate())
+fun Response.invalidateCookie(name: String, domain: String? = null, path: String? = null) =
+    replaceCookie(Cookie(name, "", domain = domain, path = path).invalidate())

--- a/core/core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
@@ -89,9 +89,9 @@ class CookieTest {
     }
 
     @Test
-    fun `cookie values are quoted`() {
+    fun `cookie values are quoted by default, and do not have a trailing semicolon`() {
         assertThat(Cookie("my-cookie", "my \"quoted\" value").toString(),
-            equalTo("""my-cookie="my \"quoted\" value"; """))
+            equalTo("""my-cookie="my \"quoted\" value""""))
     }
 
     @Test
@@ -102,12 +102,21 @@ class CookieTest {
     }
 
     @Test
-    fun `cookies can be added to the response`() {
+    fun `cookies can be added to the response, quoted by default`() {
         val cookie = Cookie("my-cookie", "my value")
 
         val response = Response(OK).cookie(cookie)
 
-        assertThat(response.headers, equalTo(listOf("Set-Cookie" to cookie.toString()) as Parameters))
+        assertThat(response.headers, equalTo(listOf("Set-Cookie" to "my-cookie=\"my value\"") as Parameters))
+    }
+
+    @Test
+    fun `cookies can be added to the response unquoted`() {
+        val cookie = Cookie("my-cookie", "value")
+
+        val response = Response(OK).cookie(cookie, true)
+
+        assertThat(response.headers, equalTo(listOf("Set-Cookie" to "my-cookie=value") as Parameters))
     }
 
     @Test

--- a/core/core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/cookie/CookieTest.kt
@@ -218,6 +218,12 @@ class CookieTest {
     }
 
     @Test
+    fun `cookie with path can be invalidated at response level`() {
+        assertThat(Response(OK).cookie(Cookie("foo", "bar", domain = "baz.com", path = "/test").maxAge(10)).invalidateCookie("foo", "foo.com", "/other").cookies().first(),
+            equalTo(Cookie("foo", "", domain = "foo.com", path = "/other").invalidate()))
+    }
+
+    @Test
     fun `cookie with various expires date formats parsed`() {
         val expected = Cookie("foo", "bar").expires(LocalDateTime.of(2017, 3, 11, 12, 15, 21).toInstant(ZoneOffset.UTC))
 

--- a/core/core/src/test/kotlin/org/http4k/filter/ClientCookiesTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/filter/ClientCookiesTest.kt
@@ -30,7 +30,7 @@ class ClientCookiesTest {
 
         (0..3).forEach {
             val response = client(Request(GET, "/"))
-            assertThat(response, hasHeader("Set-Cookie", """counter="${it + 1}"; """))
+            assertThat(response, hasHeader("Set-Cookie", """counter="${it + 1}""""))
         }
     }
 


### PR DESCRIPTION
1. When the cookie has no attributes, don't end the string in a trailing `; `. 
	- As per [the spec](https://datatracker.ietf.org/doc/html/rfc6265#section-4.1.1), specifically the line `set-cookie-string = cookie-pair *( ";" SP cookie-av )`
	- I guess there's a chance this may break tests for consumers that are currently asserting the precise cookie string value?
2. Allow the setting of an unquoted cookie on a `Response`
3. Allow the invalidation of a cookie with a path