### PR TITLE
Files containing tokens should only be readable by owner

### DIFF
--- a/connect/amazon/iamidentitycenter/client/src/main/kotlin/org/http4k/connect/amazon/iamidentitycenter/SSOCacheManager.kt
+++ b/connect/amazon/iamidentitycenter/client/src/main/kotlin/org/http4k/connect/amazon/iamidentitycenter/SSOCacheManager.kt
@@ -16,6 +16,7 @@ import se.ansman.kotshi.JsonSerializable
 import java.nio.file.Path
 import java.time.Clock
 import java.time.Instant
+import kotlin.io.path.writeText
 
 class SSOCacheManager(val ssoProfile: SSOProfile, val cachedTokenDirectory: Path, val clientName: ClientName) {
 
@@ -28,7 +29,8 @@ class SSOCacheManager(val ssoProfile: SSOProfile, val cachedTokenDirectory: Path
     }
 
     fun storeSSOCachedToken(cachedToken: SSOCachedToken) {
-        ssoProfile.cachedTokenPath().toFile().writeText(AwsCoreMoshi.asFormatString(cachedToken))
+        ssoProfile.cachedTokenPath().touch(restrictToOwner = true)
+            .writeText(AwsCoreMoshi.asFormatString(cachedToken))
     }
 
     fun retrieveSSOCachedRegistration(): SSOCachedRegistration? {
@@ -37,10 +39,10 @@ class SSOCacheManager(val ssoProfile: SSOProfile, val cachedTokenDirectory: Path
     }
 
     fun storeSSOCachedRegistration(cachedRegistration: SSOCachedRegistration) {
-        ssoProfile.cachedRegistrationPath().toFile().writeText(AwsCoreMoshi.asFormatString(cachedRegistration))
+        ssoProfile.cachedRegistrationPath().touch(restrictToOwner = true)
+            .writeText(AwsCoreMoshi.asFormatString(cachedRegistration))
     }
 }
-
 
 @JsonSerializable
 data class SSOCachedToken(
@@ -115,4 +117,6 @@ fun SSOCachedRegistration.Companion.of(
         scopes = scopes,
         grantTypes = grantTypes
     )
+
+
 

--- a/connect/amazon/iamidentitycenter/client/src/main/kotlin/org/http4k/connect/amazon/iamidentitycenter/pathExtensions.kt
+++ b/connect/amazon/iamidentitycenter/client/src/main/kotlin/org/http4k/connect/amazon/iamidentitycenter/pathExtensions.kt
@@ -1,0 +1,23 @@
+package org.http4k.connect.amazon.iamidentitycenter
+
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
+import kotlin.io.path.createFile
+
+
+val POSIX_OWNER_ONLY_FILE = setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+
+fun Path.hasPosixFilePermissions() = "posix" in this.fileSystem.supportedFileAttributeViews()
+
+fun Path.touch(restrictToOwner: Boolean = false): Path = try {
+    if (!restrictToOwner || !hasPosixFilePermissions()) {
+        createFile()
+    } else {
+        createFile(PosixFilePermissions.asFileAttribute(POSIX_OWNER_ONLY_FILE))
+    }
+} catch (_: FileAlreadyExistsException) {
+    this
+}
+


### PR DESCRIPTION
SSO cache files created by aws cli are owner restricted. This pull request ensures that cache files created by http4 have correct permissions.