### PR TITLE
Fix for #1255. Do not use headers.getCSV in Jetty server implementation to avoid manipulation.

### DIFF
--- a/core/core/src/testFixtures/kotlin/org/http4k/server/ServerContract.kt
+++ b/core/core/src/testFixtures/kotlin/org/http4k/server/ServerContract.kt
@@ -178,6 +178,20 @@ abstract class ServerContract(
     }
 
     @Test
+    fun `should not manipulate request headers`() {
+        val response = client(
+            Request(GET, "$baseUrl/request-headers")
+                .header("foo", """Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36""")
+        )
+        assertThat(response.status, equalTo(OK))
+        assertThat(
+            response.bodyString(), equalTo(
+                """foo: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"""
+            )
+        )
+    }
+
+    @Test
     fun `length is set on body if it is sent`() {
         val response = client(
             Request(POST, "$baseUrl/length")

--- a/core/server/jetty/src/main/kotlin/org/http4k/server/Http4kJettyHttpHandler.kt
+++ b/core/server/jetty/src/main/kotlin/org/http4k/server/Http4kJettyHttpHandler.kt
@@ -34,7 +34,7 @@ internal fun JettyRequest.asHttp4kRequest(): Request? =
 
 private fun JettyRequest.headerParameters() =
     headers.fieldNamesCollection.map { name ->
-        headers.getCSV(name, true).map { name to it }
+        headers.getValuesList(name).map { name to it }
     }.flatten()
 
 private fun Response.transferTo(response: JettyResponse) {


### PR DESCRIPTION
Fixes #1255. Do not use headers.getCSV in Jetty server implementation to avoid rewriting of headers Added a new server contract test to validate that this issue is fixed.