### PR TITLE
Ensure module names are correctly generated on Windows machines

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,7 @@ rootDir.walkTopDown()
     .filterNot { dir -> dir == rootDir || exclusions.any { dir.absolutePath.contains(it) } }
     .forEach {
         val moduleName = it.relativeTo(rootDir).path
+            .replace(File.separatorChar, '/')
             .removePrefix("core/") // remove core ecosystem modules as they have no prefix to add
             .removePrefix("enterprise/") // remove enterprise ecosystem modules as they have no prefix to add
             .replace('/', '-')


### PR DESCRIPTION
Encountering the following error when building the project on Windows.

```
A problem occurred configuring project ':http4k-connect\ai\anthropic\client'.
> The project name 'http4k-connect\ai\anthropic\client' must not contain any of the following characters: [/, \, :, <, >, ", ?, *, |]. Set the 'rootProject.name' or adjust the 'include' statement (see https://docs.gradle.org/8.11.1/dsl/org.gradle.api.initialization.Settings.html#org.gradle.api.initialization.Settings:include(java.lang.String[]) for more details).
```