### PR TITLE
Passthrough calls to `close` and `flush` to ensure output stream is p…

### DIFF
--- a/core/testing/approval/src/main/kotlin/org/http4k/testing/approvalSource.kt
+++ b/core/testing/approval/src/main/kotlin/org/http4k/testing/approvalSource.kt
@@ -40,9 +40,23 @@ internal class FileReadWriteResource(private val target: File) : ReadWriteResour
             if (exists() && !delete()) throw IllegalAccessException("Could not delete $absolutePath")
 
             object : OutputStream() {
-                private val output by lazy { outputStream() }
+                private val delegate = lazy { outputStream() }
+                private val output by delegate
+
                 override fun write(b: Int) {
                     output.write(b)
+                }
+
+                override fun flush() {
+                    if (delegate.isInitialized()) {
+                        output.flush()
+                    }
+                }
+
+                override fun close() {
+                    if (delegate.isInitialized()) {
+                        output.close()
+                    }
                 }
             }
         }


### PR DESCRIPTION
…roperly closed

This caused the `File.delete()` call in certain `FileReadWriteResourceTest` tests to not remove the temporary file as expected, resulting in test failures during subsequent runs due to the existing file.