### PR TITLE
Make BiDiLens open

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/lens/lens.kt
+++ b/core/core/src/main/kotlin/org/http4k/lens/lens.kt
@@ -24,7 +24,7 @@ open class Lens<in IN : Any, out FINAL>(
  * A BiDiLens provides the bi-directional extraction of an entity from a target, or the insertion of an entity
  * into a target.
  */
-class BiDiLens<in IN : Any, FINAL>(
+open class BiDiLens<in IN : Any, FINAL>(
     meta: Meta,
     get: (IN) -> FINAL,
     private val lensSet: (FINAL, IN) -> IN


### PR DESCRIPTION
Allows library users to extend `BiDiLens` for custom implementations of `invoke`, as is currently possible with `Lens`.

Resolves issue #1268.