### PR TITLE
Fix mismatched request signature error when s3 path contains plus symbol

### DIFF
--- a/core/aws/src/main/kotlin/org/http4k/aws/AwsRequestPreSigner.kt
+++ b/core/aws/src/main/kotlin/org/http4k/aws/AwsRequestPreSigner.kt
@@ -42,7 +42,7 @@ fun AwsRequestPreSigner(
 
     AwsPreSignedRequest(
         method = fullRequest.method,
-        uri = fullRequest.query("X-Amz-Signature", signature).uri,
+        uri = fullRequest.query("X-Amz-Signature", signature).encodePlusCharInPath().uri,
         signedHeaders = fullRequest.headers,
         expires = clock.instant() + expires
     )

--- a/core/aws/src/main/kotlin/org/http4k/aws/requestExtensions.kt
+++ b/core/aws/src/main/kotlin/org/http4k/aws/requestExtensions.kt
@@ -1,0 +1,5 @@
+package org.http4k.aws
+
+import org.http4k.core.Request
+
+internal fun Request.encodePlusCharInPath() = uri(uri.path(uri.path.replace("+", "%2B")))

--- a/core/aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
+++ b/core/aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
@@ -5,6 +5,7 @@ import org.http4k.aws.AwsCredentialScope
 import org.http4k.aws.AwsCredentials
 import org.http4k.aws.AwsRequestDate
 import org.http4k.aws.AwsSignatureV4Signer
+import org.http4k.aws.encodePlusCharInPath
 import org.http4k.core.Body
 import org.http4k.core.Filter
 import org.http4k.core.Method
@@ -65,7 +66,7 @@ fun ClientFilters.AwsAuth(
             val signedRequest = fullRequest
                 .replaceHeader("Authorization", buildAuthHeader(scope, credentials, canonicalRequest, date))
 
-            next(signedRequest.body(Body(it.body.payload)))
+            next(signedRequest.encodePlusCharInPath().body(Body(it.body.payload)))
         }
     }
 


### PR DESCRIPTION
At the moment amazon s3 client cannot handle files that contain '+' character in the file name. Request fails with SignatureDoesNotMatch error. There seem to be a known issue with AWS not handling + sign in request path in a standard way (https://jamesd3142.wordpress.com/2018/02/28/amazon-s3-and-the-plus-symbol/). This issue is also discussed here:  https://github.com/akka/alpakka/issues/838 . The solution is to replace '+' with '%2B' after request has been signed.

