### PR TITLE
fix classpath template loading on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@ changes with their rationale when appropriate:
 
 ### v5.46.0.1 (uncut)
 - **http4-aws** : Fix AWS signature when path contains plus symbol. H/T @aharin
+- **http4k-template-core** : [Unlikely break] Fix classpath template resolution on Windows.  H/T @oharaandrew314
 
 ### v5.46.0.0
 - **http4k-*** : Upgrade some dependency versions.
-- **http4-connect-amazon-s3** : [Unlikely break] Make name and region parameters of S3Bucket
+- **http4-connect-amazon-s3** : [Unlikely break] Make name and region parameters of S3Bucket.  H/T @oharaandrew314
 - **http4-contract** : Add ClientCredentialsOAuthSecurity. H/T @ashcor
 
 ### v5.45.2.0

--- a/core/template/core/src/main/kotlin/org/http4k/template/ViewModel.kt
+++ b/core/template/core/src/main/kotlin/org/http4k/template/ViewModel.kt
@@ -11,7 +11,7 @@ interface ViewModel {
      * This is the path of the template file - which matches the fully qualified classname. The templating suffix
      * is added by the template implementation (eg. java.lang.String -> java/lang/String.hbs)
      */
-    fun template(): String = javaClass.name.replace('.', File.separatorChar)
+    fun template(): String = javaClass.name.replace('.', '/')
 }
 
 fun Body.Companion.viewModel(renderer: TemplateRenderer, contentType: ContentType) =


### PR DESCRIPTION
Fixes #1279

Previously, template paths were calculated using the system file seperator, which is `\` on Windows.  This seperator is not valid on the classpath, so I have hardcoded it to `/`.

I'm concerned about this affecting file-based template loading, but the `TemplatesContract`, which tests file loading, seems to still pass.