### PR TITLE
Open Telemetry integration, http status is not recognised. Use correct type Long for http.status_code attribute. 

### DIFF
--- a/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
+++ b/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
@@ -37,8 +37,7 @@ fun ClientFilters.OpenTelemetryTracing(
 
     return Filter { next ->
         { req ->
-            with(
-                tracer.spanBuilder(spanNamer(req))
+            with(tracer.spanBuilder(spanNamer(req))
                 .setSpanKind(CLIENT)
                 .let { spanCreationMutator(it) }
                 .startSpan()) {
@@ -83,8 +82,7 @@ fun ServerFilters.OpenTelemetryTracing(
 
     return Filter { next ->
         { req ->
-            with(
-                tracer.spanBuilder(spanNamer(req))
+            with(tracer.spanBuilder(spanNamer(req))
                 .setParent(textMapPropagator.extract(Context.current(), req, getter))
                 .setSpanKind(SERVER)
                 .let { spanCreationMutator(it, req) }

--- a/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
+++ b/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
@@ -37,7 +37,8 @@ fun ClientFilters.OpenTelemetryTracing(
 
     return Filter { next ->
         { req ->
-            with(tracer.spanBuilder(spanNamer(req))
+            with(
+                tracer.spanBuilder(spanNamer(req))
                 .setSpanKind(CLIENT)
                 .let { spanCreationMutator(it) }
                 .startSpan()) {
@@ -82,7 +83,8 @@ fun ServerFilters.OpenTelemetryTracing(
 
     return Filter { next ->
         { req ->
-            with(tracer.spanBuilder(spanNamer(req))
+            with(
+                tracer.spanBuilder(spanNamer(req))
                 .setParent(textMapPropagator.extract(Context.current(), req, getter))
                 .setSpanKind(SERVER)
                 .let { spanCreationMutator(it, req) }
@@ -134,6 +136,6 @@ val defaultSpanNamer: (Request) -> String = {
 private fun Span.addStandardDataFrom(resp: Response, req: Request) {
     resp.body.length?.also { setAttribute(HTTP_RESPONSE_BODY_SIZE, it) }
     req.body.length?.also { setAttribute(HTTP_REQUEST_BODY_SIZE, it) }
-    setAttribute("http.status_code", resp.status.code.toString())
+    setAttribute("http.status_code", resp.status.code.toLong())
 }
 


### PR DESCRIPTION
When using otel collector with awsxray exporter, http status code is exported as 0, even though OpenTelemetryTracing filter sets "http.status_code" attribute that should be recognised by the collector. The issue seems to be with the type of the attribute. OpenTelemetryTracing sets this attribute as String, but collector expects it to be Long. 

The "http.status_code" attribute has been deprecated in favour of io.opentelemetry.semconv.HttpAttributes.HTTP_RESPONSE_STATUS_CODE = [http.response.status_code](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/) , which is also of type Long. However both Attributes are recognised as long as the value is of type Long. I have not changed to the new attribute name to make this pull request less likely to break existing implementations. 

I have tried to set http.response.status_code outside of the filter using spanCompletionMutator, however I was not to able to make it work without modifications to http4k code, as OpenTelemetry code seem to be randomly picking up either String or Long value.