### PR TITLE
Make xUriTemplate nullable in RoutedMessage... 

### DIFF
--- a/connect/google/analytics-core/src/main/kotlin/org/http4k/connect/google/analytics/filter/CollectPageView.kt
+++ b/connect/google/analytics-core/src/main/kotlin/org/http4k/connect/google/analytics/filter/CollectPageView.kt
@@ -6,7 +6,7 @@ import org.http4k.connect.google.analytics.model.PageView
 import org.http4k.connect.google.analytics.model.UserAgent
 import org.http4k.core.Filter
 import org.http4k.core.Request
-import org.http4k.routing.RequestWithContext
+import org.http4k.routing.RoutedMessage
 import java.util.UUID
 
 fun CollectPageView(
@@ -17,10 +17,9 @@ fun CollectPageView(
         handler(request).also {
             if (it.status.successful || it.status.informational || it.status.redirection) {
                 val host = request.header("host") ?: request.uri.host
-                val path = when (request) {
-                    is RequestWithContext -> request.xUriTemplate.toString()
-                    else -> request.uri.path
-                }
+                val path =  if (request is RoutedMessage && request.xUriTemplate != null)
+                    request.xUriTemplate.toString() else request.uri.path.trimStart('/')
+
                 val userAgent = it.header("User-Agent")?.let(UserAgent::of) ?: UserAgent.Default
                 collector(PageView(path, path, host, clientId(request), userAgent))
             }

--- a/connect/google/analytics-core/src/main/kotlin/org/http4k/connect/google/analytics/filter/CollectPageView.kt
+++ b/connect/google/analytics-core/src/main/kotlin/org/http4k/connect/google/analytics/filter/CollectPageView.kt
@@ -18,7 +18,7 @@ fun CollectPageView(
             if (it.status.successful || it.status.informational || it.status.redirection) {
                 val host = request.header("host") ?: request.uri.host
                 val path =  if (request is RoutedMessage && request.xUriTemplate != null)
-                    request.xUriTemplate.toString() else request.uri.path.trimStart('/')
+                    request.xUriTemplate.toString() else request.uri.path
 
                 val userAgent = it.header("User-Agent")?.let(UserAgent::of) ?: UserAgent.Default
                 collector(PageView(path, path, host, clientId(request), userAgent))

--- a/connect/google/analytics-ga4/client/src/test/kotlin/org/http4k/connect/google/analytics/ga4/CollectPageViewTest.kt
+++ b/connect/google/analytics-ga4/client/src/test/kotlin/org/http4k/connect/google/analytics/ga4/CollectPageViewTest.kt
@@ -101,12 +101,12 @@ class CollectPageViewTest {
         assertNoPageView()
     }
 
-    fun assertPageView(title: String, path: String, host: String) {
+    private fun assertPageView(title: String, path: String, host: String) {
         assertThat(
             testHttpClient.captured, equalTo(
                 Request(Method.POST, "https://www.google-analytics.com/mp/collect")
-                    .header("User-Agent", UserAgent.Default.value)
                     .header("content-type", APPLICATION_JSON.toHeaderValue())
+                    .header("User-Agent", UserAgent.Default.value)
                     .header("Host", "www.google-analytics.com")
                     .query("measurement_id", measurementId)
                     .query("api_secret", apiSecret)

--- a/core/core/src/main/kotlin/org/http4k/core/ProtocolTransaction.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/ProtocolTransaction.kt
@@ -22,7 +22,9 @@ interface ProtocolTransaction<ProtocolResponse> {
 }
 
 fun <ProtocolResponse> defaultLabels(request: Request, response: ProtocolResponse) = when {
-    response is RoutedMessage -> mapOf(ROUTING_GROUP_LABEL to response.xUriTemplate.toString())
-    request is RoutedMessage -> mapOf(ROUTING_GROUP_LABEL to request.xUriTemplate.toString())
+    response is RoutedMessage ->
+        response.xUriTemplate?.let { mapOf(ROUTING_GROUP_LABEL to it.toString()) } ?: emptyMap()
+    request is RoutedMessage ->
+        request.xUriTemplate?.let { mapOf(ROUTING_GROUP_LABEL to it.toString()) } ?: emptyMap()
     else -> emptyMap()
 }

--- a/core/core/src/main/kotlin/org/http4k/events/HttpEvent.kt
+++ b/core/core/src/main/kotlin/org/http4k/events/HttpEvent.kt
@@ -6,7 +6,6 @@ import org.http4k.core.Status
 import org.http4k.core.Uri
 import org.http4k.events.ProtocolEvent.Incoming
 import org.http4k.events.ProtocolEvent.Outgoing
-import org.http4k.routing.RequestWithContext
 import org.http4k.routing.RoutedMessage
 
 object HttpEvent {
@@ -24,7 +23,8 @@ object HttpEvent {
         tx.request.method,
         tx.response.status,
         tx.duration.toMillis(),
-        if (tx.request is RequestWithContext) tx.request.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
+        if (tx.request is RoutedMessage && tx.request.xUriTemplate != null)
+            tx.request.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
     )
 
     fun Outgoing(
@@ -40,6 +40,7 @@ object HttpEvent {
         tx.request.method,
         tx.response.status,
         tx.duration.toMillis(),
-        if (tx.response is RoutedMessage) tx.response.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
+        if (tx.response is RoutedMessage && tx.response.xUriTemplate != null)
+            tx.response.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
     )
 }

--- a/core/core/src/main/kotlin/org/http4k/events/ProtocolEvent.kt
+++ b/core/core/src/main/kotlin/org/http4k/events/ProtocolEvent.kt
@@ -36,7 +36,8 @@ sealed class ProtocolEvent(
         xUriTemplate: String,
         protocol: String
     ) : ProtocolEvent(uri, method, status, latency, xUriTemplate, protocol) {
-        override fun toString() = "Outgoing(uri=$uri, method=$method, status=$status, latency=$latency, xUriTemplate=$xUriTemplate, protocol=$protocol)"
+        override fun toString() =
+            "Outgoing(uri=$uri, method=$method, status=$status, latency=$latency, xUriTemplate=$xUriTemplate, protocol=$protocol)"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/core/core/src/main/kotlin/org/http4k/routing/extensions.kt
+++ b/core/core/src/main/kotlin/org/http4k/routing/extensions.kt
@@ -3,7 +3,7 @@ package org.http4k.routing
 import org.http4k.core.Request
 
 fun Request.path(name: String): String? = when (this) {
-    is RoutedMessage -> xUriTemplate.extract(uri.path)[name]
+    is RoutedMessage -> xUriTemplate?.extract(uri.path)?.get(name) ?: throw IllegalStateException("Request was not routed, so no uri-template present")
     else -> throw IllegalStateException("Request was not routed, so no uri-template present")
 }
 

--- a/core/core/src/main/kotlin/org/http4k/routing/messages.kt
+++ b/core/core/src/main/kotlin/org/http4k/routing/messages.kt
@@ -13,7 +13,7 @@ import org.http4k.routing.RoutedMessage.Companion.X_URI_TEMPLATE
 import java.io.InputStream
 
 interface RoutedMessage {
-    val xUriTemplate: UriTemplate
+    val xUriTemplate: UriTemplate?
 
     companion object {
         const val X_URI_TEMPLATE = "xUriTemplate"
@@ -29,11 +29,7 @@ data class RequestWithContext(val delegate: Request, val context: Map<String, An
         if (delegate is RequestWithContext) delegate.context + (X_URI_TEMPLATE to uriTemplate) else mapOf(X_URI_TEMPLATE to uriTemplate)
     )
 
-    override val xUriTemplate: UriTemplate
-        get() {
-            return context[X_URI_TEMPLATE] as? UriTemplate
-                ?: throw IllegalStateException("Request was not routed, so no uri-template present")
-        }
+    override val xUriTemplate = context[X_URI_TEMPLATE] as? UriTemplate
 
     override fun equals(other: Any?): Boolean = delegate == other
 
@@ -81,14 +77,10 @@ data class ResponseWithContext(val delegate: Response, val context: Map<String, 
 
     constructor(delegate: Response, uriTemplate: UriTemplate) : this(
         if (delegate is ResponseWithContext) delegate.delegate else delegate,
-        if (delegate is ResponseWithContext) delegate.context + (X_URI_TEMPLATE to uriTemplate) else mapOf(
-            X_URI_TEMPLATE to uriTemplate
-        )
+        if (delegate is ResponseWithContext) delegate.context + (X_URI_TEMPLATE to uriTemplate) else mapOf(X_URI_TEMPLATE to uriTemplate)
     )
 
-    override val xUriTemplate: UriTemplate
-        get() = context["xUriTemplate"] as? UriTemplate
-            ?: throw IllegalStateException("Message was not routed, so no uri-template present")
+    override val xUriTemplate = context[X_URI_TEMPLATE] as? UriTemplate
 
     override fun equals(other: Any?): Boolean = delegate == other
 

--- a/core/core/src/test/kotlin/org/http4k/core/ReportHttpTransactionTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/ReportHttpTransactionTest.kt
@@ -1,0 +1,36 @@
+package org.http4k.core
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.core.Method.GET
+import org.http4k.core.Status.Companion.NOT_FOUND
+import org.http4k.core.Status.Companion.OK
+import org.http4k.filter.RequestFilters
+import org.http4k.filter.ResponseFilters
+import org.http4k.lens.RequestKey
+import org.http4k.routing.bind
+import org.http4k.routing.routes
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+class ReportHttpTransactionTest {
+
+    @Test
+    @Disabled
+    fun `unable to set request key before transaction logger`() {
+        val lens = RequestKey.optional<String>("foo")
+
+        val app: HttpHandler = routes("" bind GET to { req: Request -> Response(OK) })
+
+        val stack = RequestFilters.Modify(lens of "bar")
+            .then(ResponseFilters.ReportHttpTransaction(recordFn = { t -> println(t) }))
+            .then(app)
+
+        val routedResponse = stack(Request(GET, ""))
+        assertThat(routedResponse.status, equalTo(OK))
+
+        //this request fails
+        val notFoundResponse = stack(Request(GET, "/notfound"))
+        assertThat(notFoundResponse.bodyString(), equalTo(NOT_FOUND))
+    }
+}

--- a/core/realtime-core/src/main/kotlin/org/http4k/events/SseEvent.kt
+++ b/core/realtime-core/src/main/kotlin/org/http4k/events/SseEvent.kt
@@ -21,7 +21,8 @@ object SseEvent {
         tx.request.method,
         tx.response.status,
         tx.duration.toMillis(),
-        if (tx.request is RequestWithContext) tx.request.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
+        if (tx.request is RoutedMessage && tx.request.xUriTemplate != null)
+            tx.request.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
     )
 
     fun Outgoing(
@@ -37,6 +38,7 @@ object SseEvent {
         tx.request.method,
         tx.response.status,
         tx.duration.toMillis(),
-        if (tx.response is RoutedMessage) tx.response.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
+        if (tx.response is RoutedMessage && tx.response.xUriTemplate != null)
+            tx.response.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
     )
 }

--- a/core/realtime-core/src/main/kotlin/org/http4k/events/WsEvent.kt
+++ b/core/realtime-core/src/main/kotlin/org/http4k/events/WsEvent.kt
@@ -21,7 +21,8 @@ object WsEvent {
         tx.request.method,
         tx.status,
         tx.duration.toMillis(),
-        if (tx.request is RequestWithContext) tx.request.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
+        if (tx.request is RoutedMessage && tx.request.xUriTemplate != null)
+            tx.request.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
     )
 
     fun Outgoing(
@@ -37,6 +38,7 @@ object WsEvent {
         tx.request.method,
         tx.status,
         tx.duration.toMillis(),
-        if (tx.response is RoutedMessage) tx.response.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
+        if (tx.response is RoutedMessage && tx.response.xUriTemplate != null)
+            tx.response.xUriTemplate.toString() else tx.request.uri.path.trimStart('/')
     )
 }


### PR DESCRIPTION
This provides a workaround for #1294 . I'm not crazy about it as it makes the xUriTemplate nullable in the `RoutedMessage` and technically it's a break, but it's a start and may be cleaner than just implementing another RoutedRequest/Response wrapper.