### PR TITLE
Add `lenient()` for adapter for Lenient strictness in ConfigurableMoshi

### DIFF
--- a/core/format/moshi/src/main/kotlin/org/http4k/format/ConfigurableMoshi.kt
+++ b/core/format/moshi/src/main/kotlin/org/http4k/format/ConfigurableMoshi.kt
@@ -97,7 +97,7 @@ open class ConfigurableMoshi(
     override fun <T : Any> asA(input: String, target: KClass<T>): T = adapterFor(target).fromJson(input)!!
 
     private fun <T : Any> adapterFor(target: KClass<T>) = when (strictness) {
-        Lenient -> moshi.adapter(target.java)
+        Lenient -> moshi.adapter(target.java).lenient()
         FailOnUnknown -> moshi.adapter(target.java).failOnUnknown()
     }
 


### PR DESCRIPTION
This change should help in parsing JSON in lenient mode (as stated here in Moshi: [JsonReader.kt](https://github.com/square/moshi/blob/256b13b3bfd6cb5557c857496e674b0b1ab98d10/moshi/src/main/java/com/squareup/moshi/JsonReader.kt#L200-L200)), as per the lenient param in the ConfigurableMoshi constructor.