### PR TITLE
Add call to `withInstanceMetadataServiceMappings()` when constructing…

### DIFF
--- a/connect/amazon/instancemetadata/client/src/main/kotlin/org/http4k/connect/amazon/instancemetadata/InstanceMetadataServiceMoshi.kt
+++ b/connect/amazon/instancemetadata/client/src/main/kotlin/org/http4k/connect/amazon/instancemetadata/InstanceMetadataServiceMoshi.kt
@@ -14,6 +14,7 @@ import se.ansman.kotshi.KotshiJsonAdapterFactory
 
 object InstanceMetadataServiceMoshi : ConfigurableMoshi(
     AwsMoshiBuilder(InstanceMetadataServiceJsonAdapterFactory)
+        .withInstanceMetadataServiceMappings()
         .done()
 )
 


### PR DESCRIPTION
… `InstanceMetadataServiceMoshi`

Without this call the `GetInstanceIdentityDocument` action throws an exception when deserializing `ImageId`.