### PR TITLE
Support for SystemsManager getParameters endpoint

### DIFF
--- a/connect/amazon/systemsmanager/client/src/main/kotlin/org/http4k/connect/amazon/systemsmanager/action/GetParameters.kt
+++ b/connect/amazon/systemsmanager/client/src/main/kotlin/org/http4k/connect/amazon/systemsmanager/action/GetParameters.kt
@@ -1,0 +1,20 @@
+package org.http4k.connect.amazon.systemsmanager.action
+
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.systemsmanager.SystemsManagerAction
+import org.http4k.connect.amazon.systemsmanager.model.Parameter
+import org.http4k.connect.amazon.systemsmanager.model.SSMParameterName
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+@JsonSerializable
+data class GetParameters(
+    val Names: List<SSMParameterName>,
+    val WithDecryption: Boolean? = null,
+) : SystemsManagerAction<GetParametersResult>(GetParametersResult::class)
+
+@JsonSerializable
+data class GetParametersResult(
+    val InvalidParameters: List<String>,
+    val Parameters: List<Parameter>
+)

--- a/connect/amazon/systemsmanager/client/src/testFixtures/kotlin/org/http4k/connect/amazon/systemsmanager/SystemsManagerContract.kt
+++ b/connect/amazon/systemsmanager/client/src/testFixtures/kotlin/org/http4k/connect/amazon/systemsmanager/SystemsManagerContract.kt
@@ -29,7 +29,11 @@ interface SystemsManagerContract : AwsContract {
         )
         assertThat(sm.getParameter(name).successValue().Parameter.Value, equalTo("value2"))
 
+        assertThat(sm.getParameters(listOf(name)).successValue().Parameters.map { it.Value }, equalTo(listOf("value2")))
+
         sm.deleteParameter(name).successValue()
+
+        assertThat(sm.getParameters(listOf(name)).successValue().Parameters.map { it.Value }, equalTo(emptyList()))
 
         assertThat(sm.deleteParameter(name).failureOrNull()!!.status, equalTo(BAD_REQUEST))
     }

--- a/connect/amazon/systemsmanager/fake/src/main/kotlin/org/http4k/connect/amazon/systemsmanager/FakeSystemsManager.kt
+++ b/connect/amazon/systemsmanager/fake/src/main/kotlin/org/http4k/connect/amazon/systemsmanager/FakeSystemsManager.kt
@@ -23,6 +23,7 @@ class FakeSystemsManager(
     override val app = routes(
         api.deleteParameter(parameters),
         api.getParameter(parameters),
+        api.getParameters(parameters),
         api.putParameter(parameters)
     )
 

--- a/connect/amazon/systemsmanager/fake/src/main/kotlin/org/http4k/connect/amazon/systemsmanager/endpoints.kt
+++ b/connect/amazon/systemsmanager/fake/src/main/kotlin/org/http4k/connect/amazon/systemsmanager/endpoints.kt
@@ -6,7 +6,9 @@ import org.http4k.connect.amazon.core.model.AwsAccount
 import org.http4k.connect.amazon.core.model.Region
 import org.http4k.connect.amazon.systemsmanager.action.DeleteParameter
 import org.http4k.connect.amazon.systemsmanager.action.GetParameter
+import org.http4k.connect.amazon.systemsmanager.action.GetParameters
 import org.http4k.connect.amazon.systemsmanager.action.ParameterValue
+import org.http4k.connect.amazon.systemsmanager.action.GetParametersResult
 import org.http4k.connect.amazon.systemsmanager.action.PutParameter
 import org.http4k.connect.amazon.systemsmanager.action.PutParameterResult
 import org.http4k.connect.amazon.systemsmanager.model.Parameter
@@ -23,21 +25,27 @@ fun AwsJsonFake.deleteParameter(parameters: Storage<StoredParameter>) = route<De
 
 
 fun AwsJsonFake.getParameter(parameters: Storage<StoredParameter>) = route<GetParameter> { req ->
-    parameters[req.Name.value]?.let {
-        ParameterValue(
-            Parameter(
-                ARN.of(
-                    SystemsManager.awsService,
-                    Region.of("us-east-1"),
-                    AwsAccount.of("0"),
-                    "parameter",
-                    req.Name
-                ),
-                req.Name, it.value, it.type, null, 1, Timestamp.of(0), null, null
-            )
-        )
-    }
+    parameters[req.Name.value]?.let { ParameterValue(it.parameter()) }
 }
+
+fun AwsJsonFake.getParameters(parameters: Storage<StoredParameter>) = route<GetParameters> { req ->
+    GetParametersResult(
+        req.Names.filter { parameters[it.value] == null }.map { it.value },
+        req.Names.mapNotNull { parameters[it.value]?.parameter() }
+    )
+}
+
+private fun StoredParameter.parameter() = Parameter(
+    ARN.of(
+        SystemsManager.awsService,
+        Region.of("us-east-1"),
+        AwsAccount.of("0"),
+        "parameter",
+        name
+    ),
+    name, value, type, null, 1, Timestamp.of(0), null, null
+)
+
 
 fun AwsJsonFake.putParameter(parameters: Storage<StoredParameter>) = route<PutParameter> { req ->
     val current = parameters[req.Name.value]

--- a/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
+++ b/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
@@ -37,8 +37,7 @@ fun ClientFilters.OpenTelemetryTracing(
 
     return Filter { next ->
         { req ->
-            with(
-                tracer.spanBuilder(spanNamer(req))
+            with(tracer.spanBuilder(spanNamer(req))
                 .setSpanKind(CLIENT)
                 .let { spanCreationMutator(it) }
                 .startSpan()) {
@@ -83,8 +82,7 @@ fun ServerFilters.OpenTelemetryTracing(
 
     return Filter { next ->
         { req ->
-            with(
-                tracer.spanBuilder(spanNamer(req))
+            with(tracer.spanBuilder(spanNamer(req))
                 .setParent(textMapPropagator.extract(Context.current(), req, getter))
                 .setSpanKind(SERVER)
                 .let { spanCreationMutator(it, req) }

--- a/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
+++ b/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
@@ -37,7 +37,8 @@ fun ClientFilters.OpenTelemetryTracing(
 
     return Filter { next ->
         { req ->
-            with(tracer.spanBuilder(spanNamer(req))
+            with(
+                tracer.spanBuilder(spanNamer(req))
                 .setSpanKind(CLIENT)
                 .let { spanCreationMutator(it) }
                 .startSpan()) {
@@ -82,7 +83,8 @@ fun ServerFilters.OpenTelemetryTracing(
 
     return Filter { next ->
         { req ->
-            with(tracer.spanBuilder(spanNamer(req))
+            with(
+                tracer.spanBuilder(spanNamer(req))
                 .setParent(textMapPropagator.extract(Context.current(), req, getter))
                 .setSpanKind(SERVER)
                 .let { spanCreationMutator(it, req) }
@@ -134,6 +136,6 @@ val defaultSpanNamer: (Request) -> String = {
 private fun Span.addStandardDataFrom(resp: Response, req: Request) {
     resp.body.length?.also { setAttribute(HTTP_RESPONSE_BODY_SIZE, it) }
     req.body.length?.also { setAttribute(HTTP_REQUEST_BODY_SIZE, it) }
-    setAttribute("http.status_code", resp.status.code.toString())
+    setAttribute("http.status_code", resp.status.code.toLong())
 }
 


### PR DESCRIPTION
Currently only a getParameter endpoint is supported that retrieves a single ssm parameter. This pull requests add support for getParameters endpoint that allows to retrieve multiple parameters in one call. It is also useful for retrieving optional parameters as it dies not throw exception if requested parameter(s) do not exist.