### PR TITLE
add coverage for websocket server headers

### DIFF
--- a/core/server/helidon/src/test/kotlin/org/http4k/websocket/HelidonWebsocketTest.kt
+++ b/core/server/helidon/src/test/kotlin/org/http4k/websocket/HelidonWebsocketTest.kt
@@ -4,10 +4,19 @@ import org.http4k.client.JavaHttpClient
 import org.http4k.server.Helidon
 import org.http4k.server.ServerConfig.StopMode.Immediate
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 
 class HelidonWebsocketTest : WebsocketServerContract({ Helidon(it, Immediate) }, JavaHttpClient()) {
     @Disabled
     override fun `should propagate close on server stop`() {
         super.`should propagate close on server stop`()
+    }
+
+    /**
+     * Helidon fails to provide the headers
+     */
+    @Disabled
+    override fun `can receive headers from upgrade request`() {
+        super.`can receive headers from upgrade request`()
     }
 }

--- a/core/server/helidon/src/test/kotlin/org/http4k/websocket/HelidonWebsocketTest.kt
+++ b/core/server/helidon/src/test/kotlin/org/http4k/websocket/HelidonWebsocketTest.kt
@@ -4,7 +4,6 @@ import org.http4k.client.JavaHttpClient
 import org.http4k.server.Helidon
 import org.http4k.server.ServerConfig.StopMode.Immediate
 import org.junit.jupiter.api.Disabled
-import org.junit.jupiter.api.Test
 
 class HelidonWebsocketTest : WebsocketServerContract({ Helidon(it, Immediate) }, JavaHttpClient()) {
     @Disabled


### PR DESCRIPTION
Helidon fails to provide the headers from the upgrade request.  This PR will add the missing coverage, with the exception for Helidon.