### PR TITLE
Some additions to http4k-connect-storage

### DIFF
--- a/connect/storage/redis/build.gradle.kts
+++ b/connect/storage/redis/build.gradle.kts
@@ -11,4 +11,6 @@ plugins {
 dependencies {
     api(project(":http4k-format-moshi"))
     api("io.lettuce:lettuce-core:_")
+
+    testFixturesApi("io.mockk:mockk:_")
 }

--- a/connect/storage/redis/src/main/kotlin/org/http4k/connect/storage/RedisStorage.kt
+++ b/connect/storage/redis/src/main/kotlin/org/http4k/connect/storage/RedisStorage.kt
@@ -15,26 +15,31 @@ import java.time.Duration.ofHours
 /**
  * Connect to Redis using Automarshalling
  */
-inline fun <reified T : Any> Storage.Companion.Redis(uri: Uri, autoMarshalling: AutoMarshalling = Moshi) =
-    Redis(uri, AutoRedisCodec<T>(autoMarshalling))
+inline fun <reified T : Any> Storage.Companion.Redis(uri: Uri, autoMarshalling: AutoMarshalling = Moshi, noinline ttl: (T) -> Duration = { ofHours(1) }) =
+    Redis(uri, AutoRedisCodec<T>(autoMarshalling), ttl)
 
 /**
  * Connect to Redis using custom codec
  */
-fun <T : Any> Storage.Companion.Redis(uri: Uri, codec: RedisCodec<String, T>) =
-    Redis(create(uri.asRedis()).connect(codec).sync())
-
+fun <T : Any> Storage.Companion.Redis(uri: Uri, codec: RedisCodec<String, T>, ttl: (T) -> Duration = { ofHours(1) }) =
+    RedisWithDynamicTtl(create(uri.asRedis()).connect(codec).sync(), ttl)
 
 /**
  * Redis-backed storage implementation. You probably want to use one of the builder functions instead of this
  */
 fun <T : Any> Storage.Companion.Redis(redis: RedisCommands<String, T>, ttl: Duration = ofHours(1)) =
+    RedisWithDynamicTtl(redis) { ttl }
+
+/**
+ * Redis-backed storage implementation with custom TTL function.
+ */
+fun <T : Any> Storage.Companion.RedisWithDynamicTtl(redis: RedisCommands<String, T>, ttl: (T) -> Duration = { ofHours(1) }) =
     object : Storage<T> {
 
         override fun get(key: String): T? = redis.get(key)
 
         override fun set(key: String, data: T) {
-            val result = redis.set(key, data, Builder.ex(ttl.toSeconds()))
+            val result = redis.set(key, data, Builder.ex(ttl(data).toSeconds()))
             if (result != "OK") throw RuntimeException(result)
         }
 

--- a/connect/storage/redis/src/test/kotlin/org/http4k/connect/storage/RedisStorageTest.kt
+++ b/connect/storage/redis/src/test/kotlin/org/http4k/connect/storage/RedisStorageTest.kt
@@ -1,11 +1,21 @@
 package org.http4k.connect.storage
 
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import io.lettuce.core.SetArgs
+import io.lettuce.core.api.sync.RedisCommands
+import io.lettuce.core.codec.StringCodec
+import io.lettuce.core.protocol.CommandArgs
+import io.mockk.every
+import io.mockk.mockk
 import org.http4k.connect.assumeDockerDaemonRunning
 import org.http4k.core.Uri
+import org.junit.jupiter.api.Test
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.utility.DockerImageName
+import java.time.Duration
 
 @Testcontainers
 class RedisStorageTest : StorageContract() {
@@ -19,5 +29,34 @@ class RedisStorageTest : StorageContract() {
 
     override val storage: Storage<AnEntity> by lazy {
         Storage.Redis<AnEntity>(Uri.of("redis://${redis.host}:${redis.firstMappedPort}"))
+    }
+
+    @Test
+    fun `when a custom duration function is passed, the returned value is set as the expiry`() {
+        val redisCommands = mockk<RedisCommands<String, AnEntity>>()
+        val capturedArgs = mutableListOf<SetArgs>()
+        every { redisCommands.set(any(), any(), capture(capturedArgs)) } returns "OK"
+
+        val redisStorage = Storage.RedisWithDynamicTtl<AnEntity>(redisCommands) {
+            when (it.name) {
+                "sec" -> Duration.ofSeconds(1)
+                "min" -> Duration.ofMinutes(2)
+                else -> Duration.ofHours(3)
+            }
+        }
+
+        redisStorage["x"] = AnEntity("sec")
+        redisStorage["y"] = AnEntity("hours")
+        redisStorage["z"] = AnEntity("min")
+
+        val durations = capturedArgs.map {
+            val args = CommandArgs(StringCodec())
+            it.build(args)
+            args.toCommandString()
+        }
+
+        assertThat(durations[0], equalTo("EX 1"))
+        assertThat(durations[1], equalTo("EX 10800"))
+        assertThat(durations[2], equalTo("EX 120"))
     }
 }

--- a/core/tools/traffic-capture/build.gradle.kts
+++ b/core/tools/traffic-capture/build.gradle.kts
@@ -10,6 +10,8 @@ plugins {
 
 dependencies {
     api(project(":http4k-core"))
+    compileOnly(project(":http4k-connect-storage-core"))
 
     testImplementation(testFixtures(project(":http4k-core")))
+    testImplementation(project(":http4k-connect-storage-core"))
 }

--- a/core/tools/traffic-capture/src/main/kotlin/org/http4k/traffic/ReadWriteCache.kt
+++ b/core/tools/traffic-capture/src/main/kotlin/org/http4k/traffic/ReadWriteCache.kt
@@ -1,8 +1,12 @@
 package org.http4k.traffic
 
+import org.http4k.base64Encode
+import org.http4k.connect.storage.Storage
 import org.http4k.core.HttpMessage
 import org.http4k.core.Request
 import org.http4k.core.Response
+import org.http4k.core.parse
+import java.security.MessageDigest
 
 /**
  * Combined Read/Write storage models, optimised for retrieval.
@@ -22,5 +26,23 @@ interface ReadWriteCache : Sink, Source {
         fun Memory(cache: MutableMap<Request, Response> = mutableMapOf(), shouldStore: (HttpMessage) -> Boolean = { true }): ReadWriteCache = object : ReadWriteCache,
             Source by Source.MemoryMap(cache),
             Sink by Sink.MemoryMap(cache, shouldStore) {}
+    }
+}
+
+/**
+ * Transform a org.http4k.connect.storage.Storage object into a ReadWriteCache. Requires the http4k-connect-storage module
+ */
+fun Storage<String>.asCache() = asCache({ it.toString() }, { Response.parse(it) })
+
+fun <T : Any> Storage<T>.asCache(
+    marshall: (Response) -> T,
+    unmarshall: (T) -> Response,
+    key: (Request) -> String = { MessageDigest.getInstance("SHA256").digest(it.toString().toByteArray()).base64Encode() },
+): ReadWriteCache = object : ReadWriteCache {
+
+    override fun get(request: Request): Response? = this@asCache[key(request)]?.let(unmarshall)
+
+    override fun set(request: Request, response: Response) {
+        this@asCache[key(request)] = marshall(response)
     }
 }

--- a/core/tools/traffic-capture/src/test/kotlin/org/http4k/traffic/ReadWriteCacheTest.kt
+++ b/core/tools/traffic-capture/src/test/kotlin/org/http4k/traffic/ReadWriteCacheTest.kt
@@ -3,6 +3,7 @@ package org.http4k.traffic
 import com.natpryce.hamkrest.absent
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import org.http4k.connect.storage.Storage
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Response
@@ -23,6 +24,23 @@ class ReadWriteCacheTest {
     @Test
     fun `Memory ReadWriteCache can store and retrieve cached data`() {
         testCache(ReadWriteCache.Memory())
+    }
+
+    @Test
+    fun `asCache can transform a Storage instance into a ReadWriteCache`() {
+        val storage = object : Storage<String> {
+            val values = mutableMapOf<String, String>()
+            override fun get(key: String): String? = values[key]
+            override fun set(key: String, data: String) {
+                values[key] = data
+            }
+
+            override fun remove(key: String) = error("Should not be called")
+            override fun keySet(keyPrefix: String) = error("Should not be called")
+            override fun removeAll(keyPrefix: String) = error("Should not be called")
+        }
+
+        testCache(storage.asCache())
     }
 
     private fun testCache(cache: ReadWriteCache) {


### PR DESCRIPTION
- Allow passing a custom duration function when constructing a Redis instance, so you can cache an object for a different duration depending on its properties.
- In org.http4k.traffic, add an extension to transform a Storage instance into a ReadWriteCache. http4k-connect-storage-core is included as a compileOnly dependency so you don't automatically ship these two modules together, but if you've got them both you can use this function

These two additions between them mean you can do things like easily use REDIS as a cache in front of an HTTP client, caching the responses for different durations depending on their max-age.