### PR TITLE
Added support for s3 bucket keys containing hash (#). 

### DIFF
--- a/connect/amazon/core/src/testFixtures/kotlin/org/http4k/connect/amazon/AwsEnvironment.kt
+++ b/connect/amazon/core/src/testFixtures/kotlin/org/http4k/connect/amazon/AwsEnvironment.kt
@@ -30,7 +30,8 @@ fun configAwsEnvironment(): AwsEnvironment {
             EnvironmentKey.composite {
                 AwsCredentials(
                     EnvironmentKey.required("http4k-development-aws-access-key-id")(it),
-                    EnvironmentKey.required("http4k-development-aws-secret-access-key")(it)
+                    EnvironmentKey.required("http4k-development-aws-secret-access-key")(it),
+                    EnvironmentKey.optional("http4k-development-aws-session-token")(it)
                 )
             }(env),
             Region.of(region)

--- a/connect/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/common.kt
+++ b/connect/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/common.kt
@@ -14,6 +14,7 @@ import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.core.with
 import org.http4k.lens.LastModified
 import org.http4k.routing.Router
+import org.http4k.routing.path
 import org.http4k.template.PebbleTemplates
 import org.http4k.template.viewModel
 import java.time.Clock
@@ -65,3 +66,6 @@ val otherwise = Router("Catch-all") { _: Request -> true }
 internal fun lastModified(headers: Headers, clock: Clock) = headers
     .firstOrNull { it.first == X_HTTP4K_LAST_MODIFIED }?.second?.let { LastModified.parse(it) }?.value?.toInstant()
     ?: Instant.now(clock)
+
+internal fun keyFor(request: Request) =
+    request.uri(request.uri.path(request.uri.path.replace("+", " "))).path("bucketKey")!!

--- a/connect/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/deleteKey.kt
+++ b/connect/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/deleteKey.kt
@@ -4,7 +4,6 @@ import org.http4k.connect.amazon.s3.BucketKeyContent
 import org.http4k.connect.storage.Storage
 import org.http4k.core.Headers
 import org.http4k.core.Method.DELETE
-import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
 import org.http4k.routing.bind
@@ -62,5 +61,3 @@ private fun deleteObjectTagging(
 
     return Response(OK)
 }
-
-private fun keyFor(req: Request) = req.path("bucketKey")!!

--- a/connect/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/getKey.kt
+++ b/connect/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/getKey.kt
@@ -7,7 +7,6 @@ import org.http4k.connect.amazon.s3.restoreReady
 import org.http4k.connect.amazon.s3.storageClass
 import org.http4k.connect.storage.Storage
 import org.http4k.core.Method
-import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
 import org.http4k.routing.bind
@@ -63,5 +62,3 @@ private fun bucketGetTagging(
 
     return Response(OK).body(bodyFor(obj.tags))
 }
-
-private fun keyFor(request: Request) = request.path("bucketKey")!!

--- a/connect/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/putKey.kt
+++ b/connect/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/putKey.kt
@@ -21,7 +21,7 @@ internal fun bucketPutKey(buckets: Storage<Unit>, bucketContent: Storage<BucketK
         queryPresent("tagging") bind {
             putObjectTagging(
                 it.subdomain(buckets),
-                it.path("bucketKey")!!,
+                keyFor(it),
                 buckets,
                 bucketContent,
                 clock,
@@ -32,7 +32,7 @@ internal fun bucketPutKey(buckets: Storage<Unit>, bucketContent: Storage<BucketK
         otherwise bind {
             putObject(
                 it.subdomain(buckets),
-                it.path("bucketKey")!!,
+                keyFor(it),
                 it.body.payload.array(),
                 buckets,
                 bucketContent,
@@ -48,7 +48,7 @@ internal fun pathBasedBucketPutKey(buckets: Storage<Unit>, bucketContent: Storag
         queryPresent("tagging") bind {
             putObjectTagging(
                 it.path("bucketName")!!,
-                it.path("bucketKey")!!,
+                keyFor(it),
                 buckets,
                 bucketContent,
                 clock,
@@ -59,7 +59,7 @@ internal fun pathBasedBucketPutKey(buckets: Storage<Unit>, bucketContent: Storag
         otherwise bind {
             putObject(
                 it.path("bucketName")!!,
-                it.path("bucketKey")!!,
+                keyFor(it),
                 it.body.payload.array(),
                 buckets,
                 bucketContent,

--- a/core/platform/aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
@@ -40,13 +40,16 @@ internal data class AwsCanonicalRequest(val value: String, val signedHeaders: St
                 .sorted()
                 .joinToString("&")
 
-        private fun Uri.normalisedPath() = if (path.isBlank()) "/" else path.split("/")
-            .joinToString("/") {
-                it.urlEncoded().replace("+", "%20").replace("*", "%2A").replace("%7E", "~")
-            }
-            .let { if (it.startsWith("/")) it else "/$it" }
+        private fun Uri.normalisedPath() =
+            if (path.isBlank()) "/" else path.split("/")
+                .joinToString("/") { it.urlEncodedForAws() }
+                .let { if (fragment.isBlank()) it else it + "#${fragment}".urlEncodedForAws() }
+                .let { if (it.startsWith("/")) it else "/$it" }
     }
 }
 
+
 internal fun Request.signedHeaders(): String =
     headers.map { it.first.lowercase(getDefault()) }.toSet().sorted().joinToString(";")
+
+private fun String.urlEncodedForAws() = urlEncoded().replace("+", "%20").replace("*", "%2A").replace("%7E", "~")

--- a/core/platform/aws/src/main/kotlin/org/http4k/aws/AwsRequestPreSigner.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/aws/AwsRequestPreSigner.kt
@@ -42,7 +42,7 @@ fun AwsRequestPreSigner(
 
     AwsPreSignedRequest(
         method = fullRequest.method,
-        uri = fullRequest.query("X-Amz-Signature", signature).encodePlusCharInPath().uri,
+        uri = fullRequest.query("X-Amz-Signature", signature).encodeUriToMatchSignature().uri,
         signedHeaders = fullRequest.headers,
         expires = clock.instant() + expires
     )

--- a/core/platform/aws/src/main/kotlin/org/http4k/aws/requestExtensions.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/aws/requestExtensions.kt
@@ -1,7 +1,15 @@
 package org.http4k.aws
 
 import org.http4k.core.Request
+import org.http4k.core.Uri
+
+
+internal fun Request.encodeUriToMatchSignature() =
+    uri(uri.encodeFragmentInPath().encodePlusCharInPath())
 
 // AWS fail to match the signature if it contains a '+' character in the path
 // See https://jamesd3142.wordpress.com/2018/02/28/amazon-s3-and-the-plus-symbol/
-internal fun Request.encodePlusCharInPath() = uri(uri.path(uri.path.replace("+", "%2B")))
+private fun Uri.encodePlusCharInPath() = path(path.replace("+", "%2B").replace(" ", "+"))
+
+private fun Uri.encodeFragmentInPath() =
+    if (fragment.isBlank()) this else path("$path#${fragment}".replace("#", "%23")).fragment("")

--- a/core/platform/aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
@@ -5,7 +5,7 @@ import org.http4k.aws.AwsCredentialScope
 import org.http4k.aws.AwsCredentials
 import org.http4k.aws.AwsRequestDate
 import org.http4k.aws.AwsSignatureV4Signer
-import org.http4k.aws.encodePlusCharInPath
+import org.http4k.aws.encodeUriToMatchSignature
 import org.http4k.core.Body
 import org.http4k.core.Filter
 import org.http4k.core.Method
@@ -66,7 +66,7 @@ fun ClientFilters.AwsAuth(
             val signedRequest = fullRequest
                 .replaceHeader("Authorization", buildAuthHeader(scope, credentials, canonicalRequest, date))
 
-            next(signedRequest.encodePlusCharInPath().body(Body(it.body.payload)))
+            next(signedRequest.encodeUriToMatchSignature().body(Body(it.body.payload)))
         }
     }
 


### PR DESCRIPTION
Standard AWS s3 client supports s3 bucket keys containing hashes (#). This pull request adds support for bucket keys with hashes in http4k-connect. I have included a contract test for keys with hashes, pluses and spaces. This pull request also fixes an issue, where bucket keys containing spaces were not supported by JavaHttpClient, it only worked with OkHttp.