### PR TITLE
More fixes for special characters in s3 bucket key

### DIFF
--- a/connect/amazon/s3/client/src/testFixtures/kotlin/org/http4k/connect/amazon/s3/S3BucketContract.kt
+++ b/connect/amazon/s3/client/src/testFixtures/kotlin/org/http4k/connect/amazon/s3/S3BucketContract.kt
@@ -52,6 +52,8 @@ interface S3BucketContract : AwsContract {
 
     private val s3 get() = S3.Http({ aws.credentials }, http)
 
+    val preSigner get() = S3BucketPreSigner(bucket, aws.region, aws.credentials, clock)
+
     val key get() = BucketKey.of("originalKey")
 
     fun open() {}
@@ -135,6 +137,7 @@ interface S3BucketContract : AwsContract {
 
     @Test
     fun `bucket key with non ascii characters`() {
+        val http = SetXForwardedHost().then(http)
         waitForBucketCreation()
 
         val newKey = BucketKey.of("key:%7C/+ |ü#with#multiple#hash + %2F+spaces/üo*~é_.png")
@@ -146,6 +149,12 @@ interface S3BucketContract : AwsContract {
             assertThat(String(s3Bucket[newKey].successValue()!!.readBytes()), equalTo("hello"))
             assertThat(s3Bucket.listObjectsV2().successValue().items.map { it.Key }, equalTo(listOf(newKey)))
 
+            preSigner.get(newKey, Duration.ofMinutes(1)).also {
+                val response = Request(GET, it.uri)
+                    .headers(it.signedHeaders)
+                    .let(http)
+                assertThat(response, hasStatus(OK) and hasBody("hello"))
+            }
 
         } finally {
             s3Bucket.deleteObject(newKey)
@@ -155,12 +164,6 @@ interface S3BucketContract : AwsContract {
 
     @Test
     fun `pre signed request`() {
-        val preSigner = S3BucketPreSigner(
-            bucketName = bucket,
-            region = aws.region,
-            credentials = aws.credentials,
-            clock = clock
-        )
         val http = SetXForwardedHost().then(http)
 
         waitForBucketCreation()

--- a/connect/amazon/s3/client/src/testFixtures/kotlin/org/http4k/connect/amazon/s3/S3BucketContract.kt
+++ b/connect/amazon/s3/client/src/testFixtures/kotlin/org/http4k/connect/amazon/s3/S3BucketContract.kt
@@ -134,10 +134,10 @@ interface S3BucketContract : AwsContract {
 
 
     @Test
-    fun `bucket key with unusual characters`() {
+    fun `bucket key with non ascii characters`() {
         waitForBucketCreation()
 
-        val newKey = BucketKey.of("key#with#multiple#hash + spaces")
+        val newKey = BucketKey.of("key:%7C/+ |ü#with#multiple#hash + %2F+spaces/üo*~é_.png")
 
         try {
 

--- a/connect/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/common.kt
+++ b/connect/amazon/s3/fake/src/main/kotlin/org/http4k/connect/amazon/s3/endpoints/common.kt
@@ -68,4 +68,4 @@ internal fun lastModified(headers: Headers, clock: Clock) = headers
     ?: Instant.now(clock)
 
 internal fun keyFor(request: Request) =
-    request.uri(request.uri.path(request.uri.path.replace("+", " "))).path("bucketKey")!!
+    request.path("bucketKey")!!

--- a/core/platform/aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/aws/AwsCanonicalRequest.kt
@@ -41,10 +41,7 @@ internal data class AwsCanonicalRequest(val value: String, val signedHeaders: St
                 .joinToString("&")
 
         private fun Uri.normalisedPath() =
-            if (path.isBlank()) "/" else path.split("/")
-                .joinToString("/") { it.urlEncodedForAws() }
-                .let { if (fragment.isBlank()) it else it + "#${fragment}".urlEncodedForAws() }
-                .let { if (it.startsWith("/")) it else "/$it" }
+            path.let { if (it.startsWith("/")) it else "/$it" }
     }
 }
 
@@ -52,4 +49,3 @@ internal data class AwsCanonicalRequest(val value: String, val signedHeaders: St
 internal fun Request.signedHeaders(): String =
     headers.map { it.first.lowercase(getDefault()) }.toSet().sorted().joinToString(";")
 
-private fun String.urlEncodedForAws() = urlEncoded().replace("+", "%20").replace("*", "%2A").replace("%7E", "~")

--- a/core/platform/aws/src/main/kotlin/org/http4k/aws/AwsRequestPreSigner.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/aws/AwsRequestPreSigner.kt
@@ -23,6 +23,7 @@ fun AwsRequestPreSigner(
     val credentials = credentialsProvider()
 
     val fullRequest = request
+        .encodeUri()
         .replaceHeader("Host", "${request.uri.host}${request.uri.port?.let { port -> ":$port" } ?: ""}")
         .let { it.query("X-Amz-SignedHeaders", it.signedHeaders()) }
         .query("X-Amz-Algorithm", "AWS4-HMAC-SHA256")
@@ -42,7 +43,7 @@ fun AwsRequestPreSigner(
 
     AwsPreSignedRequest(
         method = fullRequest.method,
-        uri = fullRequest.query("X-Amz-Signature", signature).encodeUriToMatchSignature().uri,
+        uri = fullRequest.query("X-Amz-Signature", signature).uri,
         signedHeaders = fullRequest.headers,
         expires = clock.instant() + expires
     )

--- a/core/platform/aws/src/main/kotlin/org/http4k/aws/requestExtensions.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/aws/requestExtensions.kt
@@ -2,14 +2,17 @@ package org.http4k.aws
 
 import org.http4k.core.Request
 import org.http4k.core.Uri
+import org.http4k.urlEncoded
 
 
-internal fun Request.encodeUriToMatchSignature() =
-    uri(uri.encodeFragmentInPath().encodePlusCharInPath())
+internal fun Request.encodeUri() =
+    uri(uri.encodePathAndFragment())
 
-// AWS fail to match the signature if it contains a '+' character in the path
-// See https://jamesd3142.wordpress.com/2018/02/28/amazon-s3-and-the-plus-symbol/
-private fun Uri.encodePlusCharInPath() = path(path.replace("+", "%2B").replace(" ", "+"))
+private fun Uri.encodePathAndFragment() = if (fragment.isBlank())
+    path(path.urlEncodedPath())
+else
+    path("${path}#${fragment}".urlEncodedPath()).fragment("")
 
-private fun Uri.encodeFragmentInPath() =
-    if (fragment.isBlank()) this else path("$path#${fragment}".replace("#", "%23")).fragment("")
+private fun String.urlEncodedPath() =
+    split("/").joinToString("/") { it.urlEncoded().replace("+", "%20").replace("*", "%2A").replace("%7E", "~") }
+

--- a/core/platform/aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
@@ -5,7 +5,7 @@ import org.http4k.aws.AwsCredentialScope
 import org.http4k.aws.AwsCredentials
 import org.http4k.aws.AwsRequestDate
 import org.http4k.aws.AwsSignatureV4Signer
-import org.http4k.aws.encodeUriToMatchSignature
+import org.http4k.aws.encodeUri
 import org.http4k.core.Body
 import org.http4k.core.Filter
 import org.http4k.core.Method
@@ -47,6 +47,7 @@ fun ClientFilters.AwsAuth(
             val date = AwsRequestDate.of(clock.instant())
 
             val fullRequest = it
+                .encodeUri()
                 .replaceHeader("host", "${it.uri.host}${it.uri.port?.let { port -> ":$port" } ?: ""}")
                 .replaceHeader("x-amz-content-sha256", payload.hash)
                 .replaceHeader("x-amz-date", date.full).let {
@@ -66,7 +67,7 @@ fun ClientFilters.AwsAuth(
             val signedRequest = fullRequest
                 .replaceHeader("Authorization", buildAuthHeader(scope, credentials, canonicalRequest, date))
 
-            next(signedRequest.encodeUriToMatchSignature().body(Body(it.body.payload)))
+            next(signedRequest.body(Body(it.body.payload)))
         }
     }
 

--- a/core/platform/aws/src/test/kotlin/org/http4k/aws/AwsCanonicalRequestTest.kt
+++ b/core/platform/aws/src/test/kotlin/org/http4k/aws/AwsCanonicalRequestTest.kt
@@ -45,7 +45,7 @@ e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"""))
 
     @Test
     fun `normalises path`() {
-        val canonical = AwsCanonicalRequest.of(Request(GET, "http://www.google.com/a:b:c/d e/*f/~g"), canonicalPayload)
+        val canonical = AwsCanonicalRequest.of(Request(GET, "http://www.google.com/a%3Ab%3Ac/d%20e/%2Af/~g"), canonicalPayload)
         assertThat(canonical.value, equalTo("""GET
 /a%3Ab%3Ac/d%20e/%2Af/~g
 

--- a/core/platform/aws/src/test/kotlin/org/http4k/aws/RequestExtensionsTest.kt
+++ b/core/platform/aws/src/test/kotlin/org/http4k/aws/RequestExtensionsTest.kt
@@ -1,0 +1,20 @@
+package org.http4k.aws
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.junit.jupiter.api.Test
+
+
+class RequestExtensionsTest {
+
+    @Test
+    fun `encodes path`() {
+        val encodedRequest = Request(GET, "http://www.google.com/a:b:c/d e/*f/~g").encodeUri()
+        assertThat(
+            encodedRequest.uri.path,
+            equalTo("/a%3Ab%3Ac/d%20e/%2Af/~g")
+        )
+    }
+}


### PR DESCRIPTION
Fixes issues with keys containing '%', allows for '/' after '#',  added more special characters to the test. Changed the order of Url encoding for AWS requests. The path encoding logic moved out of AwsCanonicalRequest. Url is now encoded in the full request before canonical request is created, and the same path encoding logic that is used for signing now also applies to http client. Hopefully this fixes all encoding and AWS signature mismatch issues once and for all.  