### PR TITLE
Allow modification of Helidon requests

### DIFF
--- a/core/client/helidon/src/main/kotlin/org/http4k/client/HelidonClient.kt
+++ b/core/client/helidon/src/main/kotlin/org/http4k/client/HelidonClient.kt
@@ -1,6 +1,8 @@
 package org.http4k.client
 
 import io.helidon.http.Method
+import io.helidon.webclient.api.ClientRequest
+import io.helidon.webclient.api.HttpClientRequest
 import io.helidon.webclient.api.HttpClientResponse
 import io.helidon.webclient.api.WebClient
 import org.http4k.core.BodyMode
@@ -25,9 +27,11 @@ object HelidonClient {
     operator fun invoke(
         client: WebClient = WebClient.builder().followRedirects(false).build(),
         bodyMode: BodyMode = Memory,
+        requestModifier: (ClientRequest<HttpClientRequest>) -> ClientRequest<HttpClientRequest> = { it }
     ): HttpHandler = object : HttpHandler {
         override fun invoke(request: Request) = try {
             client.makeHelidonRequest(request)
+                .let(requestModifier)
                 .submit(request.body.payload.array())
                 .asHttp4k()
         } catch (e: IllegalArgumentException) {

--- a/core/client/helidon/src/test/kotlin/org/http4k/client/HelidonClientTest.kt
+++ b/core/client/helidon/src/test/kotlin/org/http4k/client/HelidonClientTest.kt
@@ -5,6 +5,7 @@ import com.natpryce.hamkrest.equalTo
 import io.helidon.webclient.api.WebClient
 import org.http4k.client.HelidonClient.makeHelidonRequest
 import org.http4k.core.Method.GET
+import org.http4k.core.Method.POST
 import org.http4k.core.Request
 import org.http4k.core.Status.Companion.OK
 import org.http4k.server.ApacheServer
@@ -38,5 +39,12 @@ class HelidonClientTest : HttpClientContract(
         val response = client(Request(GET, "http://localhost:$port/headers").header("Host", "localhost:$port"))
         assertThat(response.status, equalTo(OK))
         assertThat(response.bodyString(), equalTo("Host,User-Agent,Connection,Content-Length,Proxy-Connection"))
+    }
+
+    @Test
+    fun `requestModifier allows modification of all requests used by the client`() {
+        val requestModifyingClient = HelidonClient(requestModifier = { it.queryParam("query", "true") })
+        val response = requestModifyingClient(Request(POST, "http://localhost:$port/someUri"))
+        assertThat(response.header("query"), equalTo("true"))
     }
 }


### PR DESCRIPTION
Similar to the [Jetty implementation](https://github.com/ollieabbey/http4k/blob/249ad0c727f5f1cabae0b4d2c22af999a532722a/core/client/jetty/src/main/kotlin/org/http4k/client/JettyClient.kt#L40).

Possible solution to https://github.com/http4k/http4k/issues/1339