### PR TITLE
redirect on refresh

### DIFF
--- a/core/testing/webdriver/src/main/kotlin/org/http4k/webdriver/Http4kWebDriver.kt
+++ b/core/testing/webdriver/src/main/kotlin/org/http4k/webdriver/Http4kWebDriver.kt
@@ -189,9 +189,7 @@ class Http4kWebDriver(initialHandler: HttpHandler, clock: Clock = Clock.systemDe
         }
 
         override fun refresh() {
-            current?.let {
-                current = it.copy(contents = handler(Request(GET, it.url)).bodyString())
-            }
+            current?.let { get(it.url) }
         }
 
         override fun back() {


### PR DESCRIPTION
refreshing the page should, if the response is a redirect, update the uri and the body of the current page.