### PR TITLE
Add support for root-level GraphQL extensions field in GraphQLResponse

### DIFF
--- a/core/api/graphql/src/main/kotlin/org/http4k/graphql/model.kt
+++ b/core/api/graphql/src/main/kotlin/org/http4k/graphql/model.kt
@@ -21,7 +21,10 @@ data class GraphQLRequest(
     }
 }
 
-data class GraphQLResponse(val data: Any?, val errors: List<Map<String, Any>>?) {
+data class GraphQLResponse(
+    val data: Any?,
+    val errors: List<Map<String, Any>>?,
+    val extensions: Map<String, Any>? = null) {
     companion object {
         fun from(executionResult: ExecutionResult) = with(executionResult) {
             val errorList: List<Map<String, Any>>? = executionResult.errors
@@ -35,7 +38,10 @@ data class GraphQLResponse(val data: Any?, val errors: List<Map<String, Any>>?) 
                 } catch (e: Exception) {
                     null
                 },
-                errorList
+                errorList,
+                extensions
+                    ?.takeIf {it.isNotEmpty() }
+                    ?.let { asJsonObject(it).asA() }
             )
         }
 

--- a/core/api/graphql/src/test/kotlin/org/http4k/client/GraphQLClientTest.kt
+++ b/core/api/graphql/src/test/kotlin/org/http4k/client/GraphQLClientTest.kt
@@ -19,7 +19,7 @@ class GraphQLClientTest: InMemoryTest {
         val uri = "/foo"
 
         val graphQLRequest = GraphQLRequest("query", "operation", mapOf("a" to "b"))
-        val graphQLResponse = GraphQLResponse("hello", listOf(mapOf("foo" to "bar")))
+        val graphQLResponse = GraphQLResponse("hello", listOf(mapOf("foo" to "bar"), mapOf("baz" to "qux")))
 
         val client = { req: Request ->
             assertThat(req, equalTo(Request(POST, uri).with(GraphQLRequest.requestLens of graphQLRequest)))

--- a/core/api/graphql/src/test/kotlin/org/http4k/graphql/GraphQLResponseTest.kt
+++ b/core/api/graphql/src/test/kotlin/org/http4k/graphql/GraphQLResponseTest.kt
@@ -15,9 +15,18 @@ class GraphQLResponseTest {
             .message("oh no!")
             .build()
 
-        assertThat(GraphQLResponse.from(
-            ExecutionResultImpl("hello world", listOf(error))
-        ), equalTo(
-            GraphQLResponse("hello world", listOf(Jackson.asA(Jackson.asFormatString(error))))))
+        val extensions: Map<Any, Any> = mapOf("foo" to mapOf("bar" to "baz"))
+
+        assertThat(
+            GraphQLResponse.from(ExecutionResultImpl("hello world", listOf(error), extensions)
+            ),
+            equalTo(
+                GraphQLResponse(
+                    "hello world",
+                    listOf(Jackson.asA(Jackson.asFormatString(error))),
+                    Jackson.asA(Jackson.asFormatString(extensions))
+                )
+            ),
+        )
     }
 }

--- a/core/api/graphql/src/test/kotlin/org/http4k/routing/GraphQLRoutingTest.kt
+++ b/core/api/graphql/src/test/kotlin/org/http4k/routing/GraphQLRoutingTest.kt
@@ -21,7 +21,7 @@ class GraphQLRoutingTest {
         val uri = Uri.of("/bob")
 
         val graphQLRequest = GraphQLRequest("query", "operation", mapOf("a" to "b"))
-        val graphQLResponse = GraphQLResponse("hello", listOf(mapOf("foo" to "bar")))
+        val graphQLResponse = GraphQLResponse("hello", listOf(mapOf("foo" to "bar"), mapOf("baz" to "qux")))
 
         val app = routes("/bob" bind graphQL({
             assertThat(it, equalTo(graphQLRequest))
@@ -39,7 +39,7 @@ class GraphQLRoutingTest {
         val path = "/bob"
 
         val graphQLRequest = GraphQLRequest("query", "operation", mapOf("a" to "b"))
-        val graphQLResponse = GraphQLResponse("hello", listOf(mapOf("foo" to "bar")))
+        val graphQLResponse = GraphQLResponse("hello", listOf(mapOf("foo" to "bar")), mapOf("baz" to "qux"))
 
         val contextValue = "context"
         val app = routes(path bind graphQL({ req, context ->


### PR DESCRIPTION
The [spec](https://spec.graphql.org/October2021/#sec-Response-Format) says: The response map may also contain an entry with key extensions. This entry, if set, must have a map as its value.

This PR will copy the extensions from the ExecutionResult into the GraphQLResponse.

For instance the [Apollo-tracing](https://github.com/apollographql/apollo-tracing?tab=readme-ov-file) compatible [TracingInstrumentation class from graphql-java](https://github.com/graphql-java/graphql-java/blob/master/src/main/java/graphql/execution/instrumentation/tracing/TracingInstrumentation.java) uses this field, which can then be displayed by the already included graphql-playground UI.