### PR TITLE
Add new CloudWatch module to changelog once more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ changes with their rationale when appropriate:
 ### v6.15.0.0
 - **http4k-***: Upgrade versions
 - **http4k-ai-mcp-sdk**: [Breaking] Support for `2025-06-18` spec. Changes to require OAuth resource indicators now require the MCP server URL to be used (to prevent token attack) so if you are using OAuth then you will need to specify it at creation time
+- **http4k-connect-amazon-cloudwatch***: [New module!] with a server fake. H/T @PaulWMR for the contribution.
 - **http4k-connect-amazon-instancemetadata**: [Unlikely Break] Support IMDSv2. H/T @oharaandrew314
 
 ### v6.14.0.0


### PR DESCRIPTION
Not sure why it was removed in the first place.