### PR TITLE
Add webmanifest to content types

### DIFF
--- a/core/core/src/main/resources/META-INF/org/http4k/core/mime.types
+++ b/core/core/src/main/resources/META-INF/org/http4k/core/mime.types
@@ -35,6 +35,7 @@ application/lost+xml				lostxml
 application/mac-binhex40			hqx
 application/mac-compactpro			cpt
 application/mads+xml				mads
+application/manifest+json				webmanifest
 application/marc				mrc
 application/marcxml+xml				mrcx
 application/mathematica				ma nb mb


### PR DESCRIPTION
`.webmanifest` files are used in conjunction with progressive web apps. Adding the content type to http4k's list seems reasonable and complimentary to other features (i.e. the `singlePageApp` helper).

reference: https://www.w3.org/TR/appmanifest/#using-a-link-element-to-link-to-a-manifest