### PR TITLE
Fix SPA routing when it's mounted to a non-root path

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/routing/spa.kt
+++ b/core/core/src/main/kotlin/org/http4k/routing/spa.kt
@@ -2,7 +2,6 @@ package org.http4k.routing
 
 import org.http4k.core.ContentType
 import org.http4k.core.Filter
-import org.http4k.core.Method.GET
 import org.http4k.core.NoOp
 import org.http4k.core.Request
 import org.http4k.core.Response
@@ -38,12 +37,7 @@ internal data class SinglePageAppRouteMatcher(
             handler(request).let {
                 when {
                     it.status != NOT_FOUND -> RoutingMatch(0, m.description, filter.then { _: Request -> it })
-                    else -> handler(Request(GET, pathSegments)).let {
-                        when {
-                            it.status != NOT_FOUND -> RoutingMatch(0, m.description, filter.then { _: Request -> it })
-                            else -> RoutingMatch(2, m.description,  filter.then { _: Request -> Response(NOT_FOUND) })
-                        }
-                    }
+                    else -> RoutingMatch(2, m.description, filter.then { _: Request -> Response(NOT_FOUND) })
                 }
             }
         }
@@ -51,7 +45,9 @@ internal data class SinglePageAppRouteMatcher(
         is NotMatched -> RoutingMatch(2, m.description, filter.then { _: Request -> Response(NOT_FOUND) })
     }
 
-    override fun withBasePath(prefix: String): RouteMatcher<Response, Filter> = copy(pathSegments = prefix + pathSegments)
+    override fun withBasePath(prefix: String): RouteMatcher<Response, Filter> =
+        copy(pathSegments = prefix + pathSegments)
+
     override fun withFilter(new: Filter): RouteMatcher<Response, Filter> = copy(filter = new.then(filter))
     override fun withRouter(other: Router): RouteMatcher<Response, Filter> = copy(router = router.and(other))
 

--- a/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
@@ -54,9 +54,7 @@ class SinglePageAppRoutingHttpHandlerTest  : RoutingHttpHandlerContract() {
     @Test
     override fun `does not match a particular route`() {
         val request = Request(GET, "/not-found")
-        val criteria = isHomePage()
-
-        assertThat(handler(request), criteria)
+        assertThat(handler(request), hasStatus(NOT_FOUND))
     }
 
     @Test
@@ -87,7 +85,7 @@ class SinglePageAppRoutingHttpHandlerTest  : RoutingHttpHandlerContract() {
         val optionsResponse = hasStatus(OK).and(hasBody(""))
 
         assertThat(
-            app(Request(GET, "/index").header("Origin", "foo")),
+            app(Request(GET, "/").header("Origin", "foo")),
             isHomePage("public")
         )
 

--- a/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
@@ -60,10 +60,11 @@ class SinglePageAppRoutingHttpHandlerTest  : RoutingHttpHandlerContract() {
     @Test
     override fun `with base path - no longer matches original`() {
         val criteria = isHomePage()
-        val request = Request(GET, validPath)
         val withBasePath = handler.withBasePath(prefix)
 
-        assertThat(withBasePath(request), criteria)
+        assertThat(withBasePath(Request(GET, validPath)), hasStatus(NOT_FOUND))
+        assertThat(withBasePath(Request(GET, prefix + validPath)), criteria)
+
     }
 
     @Test

--- a/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
@@ -111,7 +111,6 @@ class SinglePageAppRoutingHttpHandlerTest  : RoutingHttpHandlerContract() {
         val dslDefault = singlePageApp()
         val criteria = isHomePage("public")
 
-        println(dslDefault(Request(GET, validPath)))
         assertThat(dslDefault(Request(GET, validPath)), criteria)
     }
 

--- a/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
@@ -111,7 +111,7 @@ class SinglePageAppRoutingHttpHandlerTest  : RoutingHttpHandlerContract() {
         val dslDefault = singlePageApp()
         val criteria = isHomePage("public")
 
-        assertThat(dslDefault(Request(GET, validPath)), criteria)
+        assertThat(dslDefault(Request(GET, "/")), criteria)
     }
 
     private fun isHomePage(name: String = "root"): Matcher<Response> = hasStatus(OK)

--- a/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
@@ -9,6 +9,7 @@ import org.http4k.core.Method.GET
 import org.http4k.core.Method.OPTIONS
 import org.http4k.core.Request
 import org.http4k.core.Response
+import org.http4k.core.Status.Companion.NOT_FOUND
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.then
 import org.http4k.filter.CorsPolicy.Companion.UnsafeGlobalPermissive
@@ -69,7 +70,7 @@ class SinglePageAppRoutingHttpHandlerTest  : RoutingHttpHandlerContract() {
 
     @Test
     fun `does not match non-GET requests for valid path`() {
-        assertThat(handler(Request(OPTIONS, validPath)), hasStatus(OK))
+        assertThat(handler(Request(OPTIONS, validPath)), hasStatus(NOT_FOUND))
         assertThat(handler(Request(GET, validPath)), hasStatus(OK))
     }
 

--- a/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
@@ -26,7 +26,7 @@ class SinglePageAppRoutingHttpHandlerTest  : RoutingHttpHandlerContract() {
     @Test
     override fun `with filter - applies in correct order`() {
         val filtered = handler.withFilter(filterAppending("foo")).withFilter(filterAppending("bar"))
-        val request = Request(GET, "/not-found")
+        val request = Request(GET, validPath)
         val criteria = isHomePage() and hasHeader("res-header", "foobar")
 
         assertThat(filtered(request), criteria)

--- a/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/routing/SinglePageAppRoutingHttpHandlerTest.kt
@@ -36,7 +36,7 @@ class SinglePageAppRoutingHttpHandlerTest  : RoutingHttpHandlerContract() {
     override fun `stacked filter application - applies when not found`() {
         val filtered = filterAppending("foo").then(routes(handler))
         val request = Request(GET, "/not-found")
-        val criteria = isHomePage() and hasHeader("res-header", "foo")
+        val criteria = hasHeader("res-header", "foo")
 
         assertThat(filtered(request), criteria)
     }
@@ -45,7 +45,7 @@ class SinglePageAppRoutingHttpHandlerTest  : RoutingHttpHandlerContract() {
     override fun `with filter - applies when not found`() {
         val filtered = handler.withFilter(filterAppending("foo"))
         val request = Request(GET, "/not-found")
-        val criteria = isHomePage() and hasHeader("res-header", "foo")
+        val criteria = hasHeader("res-header", "foo")
 
         assertThat(filtered(request), criteria)
     }


### PR DESCRIPTION
Currently, it ignores the mounted path, allowing serving content to incorrect paths.

Fix #1376 