### PR TITLE
bugfix: fix #1340, align RespondToAuthChallenge to the official doc

### DIFF
--- a/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/RespondToAuthChallenge.kt
+++ b/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/RespondToAuthChallenge.kt
@@ -14,7 +14,7 @@ import se.ansman.kotshi.JsonSerializable
 data class RespondToAuthChallenge(
     val ClientId: ClientId,
     val ChallengeName: ChallengeName,
-    val ChallengeResponses: Map<ChallengeName, String>? = null,
+    val ChallengeResponses: Map<String, String>? = null,
     val Session: Session? = null,
     val ClientMetadata: Map<String, String>? = null,
     val UserContextData: UserContextData? = null,

--- a/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/model/cognito.kt
+++ b/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/model/cognito.kt
@@ -91,7 +91,7 @@ enum class VerifyStatus {
 }
 
 enum class ChallengeName {
-    SMS_MFA, SOFTWARE_TOKEN_MFA, SELECT_MFA_TYPE, MFA_SETUP, PASSWORD_VERIFIER, CUSTOM_CHALLENGE, DEVICE_SRP_AUTH, DEVICE_PASSWORD_VERIFIER, ADMIN_NO_SRP_AUTH, NEW_PASSWORD_REQUIRED
+    SMS_MFA , EMAIL_OTP , SOFTWARE_TOKEN_MFA , SELECT_MFA_TYPE , MFA_SETUP , PASSWORD_VERIFIER , CUSTOM_CHALLENGE , SELECT_CHALLENGE , DEVICE_SRP_AUTH , DEVICE_PASSWORD_VERIFIER , ADMIN_NO_SRP_AUTH , NEW_PASSWORD_REQUIRED , SMS_OTP , PASSWORD , WEB_AUTHN , PASSWORD_SRP
 }
 
 enum class AdvancedSecurityMode {
@@ -181,7 +181,8 @@ data class AnalyticsMetadata(
 
 @JsonSerializable
 data class UserContextData(
-    val EncodedData: String? = null
+    val EncodedData: String? = null,
+    val IpAddress: IpAddress? = null
 )
 
 @JsonSerializable

--- a/connect/amazon/cognito/client/src/test/kotlin/org/http4k/connect/amazon/cognito/ActualResponseToAuthChallengeRequestsTest.kt
+++ b/connect/amazon/cognito/client/src/test/kotlin/org/http4k/connect/amazon/cognito/ActualResponseToAuthChallengeRequestsTest.kt
@@ -1,0 +1,46 @@
+package org.http4k.connect.amazon.cognito
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.connect.amazon.cognito.action.RespondToAuthChallenge
+import org.http4k.connect.amazon.cognito.model.ChallengeName
+import org.http4k.connect.amazon.cognito.model.ClientId
+import org.http4k.connect.amazon.cognito.model.Session
+import org.junit.jupiter.api.Test
+
+class ActualResponseToAuthChallengeRequestsTest {
+    val factory = CognitoMoshi
+
+    @Test
+    fun `serialize with EMAIL_OTP`() {
+        val actual = RespondToAuthChallenge(
+            ClientId = ClientId.of("1example23456789"),
+            ChallengeName = ChallengeName.EMAIL_OTP,
+            ChallengeResponses = mapOf(
+                "USERNAME" to "testuser",
+                "EMAIL_OTP_CODE" to "12345678"
+            ),
+            Session = Session.of("AYABeC1-y8qooiuysEv0uM4wAqQAHQABAAdTZXJ2aWNlABBDb2duaXRvVXNlclBvb2xzAAEAB2F3cy1rbXMAS2Fybjphd3M6a21zOnVzLXd...")
+        )
+        val expected = """
+            {
+              "ClientId": "1example23456789",
+              "ChallengeName": "EMAIL_OTP",
+              "ChallengeResponses": {
+                "USERNAME" : "testuser",
+                "EMAIL_OTP_CODE": "12345678"
+              },
+              "Session": "AYABeC1-y8qooiuysEv0uM4wAqQAHQABAAdTZXJ2aWNlABBDb2duaXRvVXNlclBvb2xzAAEAB2F3cy1rbXMAS2Fybjphd3M6a21zOnVzLXd..."
+            }
+        """.trimIndent()
+
+        assertSerializedJson(actual, expected)
+    }
+
+    private fun <T : Any> assertSerializedJson(actual: T, expected: String) {
+        assertThat(
+            factory.prettify(factory.asFormatString(actual)),
+            equalTo(factory.prettify((expected)))
+        )
+    }
+}

--- a/connect/amazon/cognito/client/src/testFixtures/kotlin/org/http4k/connect/amazon/cognito/CognitoContract.kt
+++ b/connect/amazon/cognito/client/src/testFixtures/kotlin/org/http4k/connect/amazon/cognito/CognitoContract.kt
@@ -214,7 +214,8 @@ interface CognitoContract : AwsContract {
 
             respondToAuthChallenge(
                 client.ClientId, NEW_PASSWORD_REQUIRED, mapOf(
-                    NEW_PASSWORD_REQUIRED to "",
+                    "NEW_PASSWORD" to "some-new-password",
+                    "USERNAME" to username.value
                 )
             ).successValue()
 


### PR DESCRIPTION
I tried to turn RespondToAuthChallenge into a polymorphic type using the ChallengeName property to provide a type-safe schema, but it seems it doesn't work very well with the code gen through Http4kConnectAction. So I'm only doing the simple fix by turning `ChallengeResponses` to be a `Map<String, String>`