### PR TITLE
Implement additional AWS Cognito actions

### DIFF
--- a/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/GetTokensFromRefreshToken.kt
+++ b/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/GetTokensFromRefreshToken.kt
@@ -1,0 +1,26 @@
+package org.http4k.connect.amazon.cognito.action
+
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.cognito.CognitoAction
+import org.http4k.connect.amazon.cognito.model.AuthenticationResult
+import org.http4k.connect.amazon.cognito.model.ClientId
+import org.http4k.connect.amazon.cognito.model.ClientSecret
+import org.http4k.connect.amazon.cognito.model.ContextData
+import org.http4k.connect.amazon.cognito.model.RefreshToken
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+@JsonSerializable
+    data class GetTokensFromRefreshToken(
+    val ClientId: ClientId,
+    val ClientMetadata: Map<String, String>? = null,
+    val ClientSecret: ClientSecret? = null,
+    val ContextData: ContextData? = null,
+    val DeviceKey: String? = null,
+    val RefreshToken: RefreshToken
+) : CognitoAction<GetTokensFromRefreshTokenResponse>(GetTokensFromRefreshTokenResponse::class)
+
+@JsonSerializable
+data class GetTokensFromRefreshTokenResponse(
+    val AuthenticationResult: AuthenticationResult
+)

--- a/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/ListUsers.kt
+++ b/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/ListUsers.kt
@@ -15,6 +15,7 @@ import se.ansman.kotshi.JsonSerializable
 data class ListUsers(
     val UserPoolId: UserPoolId,
     val AttributesToGet: List<String>? = null, // all attributes
+    val Filter: String? = null,
     val Limit: Int = 60,
     val PaginationToken: String? = null
 ) : CognitoAction<PageOfListedUsers>(PageOfListedUsers::class)

--- a/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/ResendConfirmationCode.kt
+++ b/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/ResendConfirmationCode.kt
@@ -1,0 +1,27 @@
+package org.http4k.connect.amazon.cognito.action
+
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.cognito.CognitoAction
+import org.http4k.connect.amazon.cognito.model.AnalyticsMetadata
+import org.http4k.connect.amazon.cognito.model.ClientId
+import org.http4k.connect.amazon.cognito.model.CodeDeliveryDetails
+import org.http4k.connect.amazon.cognito.model.SecretHash
+import org.http4k.connect.amazon.cognito.model.UserContextData
+import org.http4k.connect.amazon.core.model.Username
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+@JsonSerializable
+data class ResendConfirmationCode(
+    val AnalyticsMetaData: AnalyticsMetadata? = null,
+    val ClientId: ClientId,
+    val ClientMetadata: Map<String, String>? = null,
+    val SecretHash: SecretHash? = null,
+    val UserContextData: UserContextData? = null,
+    val Username: Username
+) : CognitoAction<ResendConfirmationCodeResponse>(ResendConfirmationCodeResponse::class)
+
+@JsonSerializable
+data class ResendConfirmationCodeResponse(
+    val CodeDeliveryDetails: CodeDeliveryDetails
+)

--- a/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/RevokeToken.kt
+++ b/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/RevokeToken.kt
@@ -1,0 +1,27 @@
+package org.http4k.connect.amazon.cognito.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.cognito.CognitoAction
+import org.http4k.connect.amazon.cognito.model.ClientId
+import org.http4k.connect.amazon.cognito.model.ClientSecret
+import org.http4k.connect.amazon.cognito.model.RefreshToken
+import org.http4k.connect.asRemoteFailure
+import org.http4k.core.Response
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+@JsonSerializable
+data class RevokeToken(
+    val ClientId: ClientId,
+    val ClientSecret: ClientSecret? = null,
+    val Token: RefreshToken
+) : CognitoAction<Unit>(Unit::class) {
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(Unit)
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+}


### PR DESCRIPTION
Implemented additional AWS Cognito actions: GetTokensFromRefreshToken, ResendConfirmationCode, and RevokeToken.

Added Filter parameter to ListUser action. I added this as a String instead of trying to make an elaborate data structure.

Docs:
* https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RevokeToken.html
* https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_GetTokensFromRefreshToken.html
* https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ResendConfirmationCode.html
* https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_RevokeToken.html
* https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_ListUsers.html#API_ListUsers_RequestSyntax
