### PR TITLE
Add support for base64 encoded AWS SESv2 attachments

### DIFF
--- a/connect/amazon/ses/client/src/main/kotlin/org/http4k/connect/amazon/ses/model/EmailContent.kt
+++ b/connect/amazon/ses/client/src/main/kotlin/org/http4k/connect/amazon/ses/model/EmailContent.kt
@@ -39,11 +39,23 @@ data class RawMessage(
 data class Message(
     @Json(name = "Body") val body: Body,
     @Json(name = "Subject") val subject: Content,
-    @Json(name = "Headers") val headers: List<MessageHeader>? = null
+    @Json(name = "Headers") val headers: List<MessageHeader>? = null,
+    @Json(name = "Attachments") val attachments: List<Attachment>? = null
 )
 
 @JsonSerializable
 data class MessageHeader(
     @Json(name = "Name") val name: String,
     @Json(name = "Value") val value: String
+)
+
+@JsonSerializable
+data class Attachment(
+    @Json(name = "FileName") val fileName: String,
+    @Json(name = "RawContent") val rawContent: Base64Blob,
+    @Json(name = "ContentDescription") val contentDescription: String? = null,
+    @Json(name = "ContentDisposition") val contentDisposition: String? = null,
+    @Json(name = "ContentId") val contentId: String? = null,
+    @Json(name = "ContentTransferEncoding") val contentTransferEncoding: String = "BASE64",
+    @Json(name = "ContentType") val contentType: String? = null
 )


### PR DESCRIPTION
Closes #1397