### PR TITLE
Lenses and content negotiation logic for accept-like headers

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/core/ContentEncoding.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/ContentEncoding.kt
@@ -1,0 +1,50 @@
+package org.http4k.core
+
+/**
+ *  See https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding
+ */
+@JvmInline
+value class ContentEncodingName(val value: String) {
+    // Generated from https://www.iana.org/assignments/http-parameters/content-coding.csv
+    @Suppress("unused")
+    companion object {
+        /** AES-GCM encryption with a 128-bit content encryption key */
+        val AES128GCM = ContentEncodingName("aes128gcm")
+        
+        /** Brotli Compressed Data Format */
+        val BR = ContentEncodingName("br")
+        
+        /** UNIX "compress" data format [Welch, T., "A Technique for High Performance Data Compression", IEEE Computer 17(6), June 1984.] */
+        val COMPRESS = ContentEncodingName("compress")
+        
+        /** "Dictionary-Compressed Brotli" data format. */
+        val DCB = ContentEncodingName("dcb")
+        
+        /** "Dictionary-Compressed Zstandard" data format. */
+        val DCZ = ContentEncodingName("dcz")
+        
+        /** "deflate" compressed data (RFC1951) inside the "zlib" data format ([RFC1950]) */
+        val DEFLATE = ContentEncodingName("deflate")
+        
+        /** W3C Efficient XML Interchange */
+        val EXI = ContentEncodingName("exi")
+        
+        /** GZIP file format (RFC1952) */
+        val GZIP = ContentEncodingName("gzip")
+        
+        /** Reserved */
+        val IDENTITY = ContentEncodingName("identity")
+        
+        /** Network Transfer Format for Java Archives */
+        val PACK200_GZIP = ContentEncodingName("pack200-gzip")
+        
+        /** Deprecated (alias for compress) */
+        val X_COMPRESS = ContentEncodingName("x-compress")
+        
+        /** Deprecated (alias for gzip) */
+        val X_GZIP = ContentEncodingName("x-gzip")
+        
+        /** A stream of bytes compressed using the Zstandard protocol with a Window_Size of not more than 8 MB. */
+        val ZSTD = ContentEncodingName("zstd")
+    }
+}

--- a/core/core/src/main/kotlin/org/http4k/core/accepting.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/accepting.kt
@@ -1,0 +1,171 @@
+package org.http4k.core
+
+import org.http4k.lens.Header
+import java.nio.charset.Charset
+import java.util.Locale
+
+/**
+ * A content range (e.g. media type range, language range, etc.) weighted by priority
+ */
+data class Weighted<T>(val range: T, val priority: Double) {
+    val contentType get() = range // backward compatiblity
+}
+
+/**
+ * A convenience operator for creating a Weighted<T> programmatically.
+ */
+infix fun <T> T.q(q: Double): Weighted<T> = Weighted(this, q)
+
+/**
+ * A weighted list of content ranges of type T.
+ */
+data class PriorityList<T>(val ranges: List<Weighted<T>>) {
+    companion object
+}
+
+/**
+ * Constructs a PriorityList from a fixed set of weighted ranges and
+ * ensures it is sorted by descending weight.
+ */
+fun <T> PriorityList(vararg values: Weighted<T>): PriorityList<T> =
+    PriorityList(values.toList().sortedByDescending { it.priority })
+
+/**
+ * Selects the client's preferred option of type O from a set of options offered
+ * by the server.
+ *
+ * Precondition: the Priority list is sorted in descending order of weight.
+ * This is guaranteed by the header parser and the function that creates a
+ * fixed PriorityList.
+ *
+ * @param match a predicate that reports whether a range contains the option.
+ */
+fun <R, O> PriorityList<R>.preferredOf(offered: List<O>, match: (R, O) -> Boolean): O? {
+    ranges.forEach { qr ->
+        offered.forEach { o ->
+            if (match(qr.range, o)) return o
+        }
+    }
+    return null
+}
+
+/**
+ * Selects the client's preferred option of type O from a set of options offered
+ * by the server, when the range is a SimpleRange<O>.
+ */
+fun <R, O> PriorityList<R>.preferredOf(offered: List<O>): O? where R : SimpleRange<O> =
+    preferredOf(offered, SimpleRange<O>::matches)
+
+
+internal typealias HeaderParams = Map<String, String>
+internal val NoParams = emptyMap<String, String>()
+
+/**
+ * Parses a PriorityList from a header value.
+ *
+ * Follows RFC 9110: "Previous specifications allowed additional extension parameters to appear after
+ * the weight parameter. The accept extension grammar (accept-params, accept-ext) has been removed
+ * because it had a complicated definition, was not being used in practice, and is more easily
+ * deployed through new header fields. Senders using weights SHOULD send “q” last (after all
+ * media-range parameters). Recipients SHOULD process any parameter named “q” as weight,
+ * regardless of parameter ordering." https://www.rfc-editor.org/rfc/rfc9110.html#name-accept
+ */
+fun <T> PriorityList.Companion.fromHeader(s: String, parseValue: (String, HeaderParams) -> T) =
+    s.split(',')
+        .map(String::trim)
+        .map { part ->
+            val subparts = part.split(";").map(String::trim)
+            val params = subparts.drop(1)
+                .map { str -> str.split("=", limit = 2).map(String::trim) }
+                .associate { kv -> kv.first() to kv.getOrElse(1, { "" }) }
+            Weighted(
+                range = parseValue(subparts.first(), params - "q"),
+                priority = params["q"]?.toDouble() ?: 1.0 // RFC 9110, section 12.4.2
+            )
+        }
+        .sortedByDescending { it.priority }
+        .let(::PriorityList)
+
+
+fun <T> PriorityList<T>.toHeader(rangeToHeader: (T) -> Pair<String, HeaderParams>) =
+    ranges.joinToString(separator = ",") { (value, q) ->
+        val (token, params) = rangeToHeader(value)
+        token +
+            params.entries.joinToString(";") { (key, value) -> "$key=$value" } +
+            (if (q == 1.0) "" else ";q=$q") // RFC 9110, section 12.4.2
+    }
+
+
+/**
+ * A SimpleRange is either a value of some type, T, or a wildcard,
+ * represented in headers as "*", and matching any value of T.
+ * The value is constrained to being represented in HTTP headers
+ * by a single token, with no parameters.
+ *
+ * This is suitable for headers Accept-Charset, Accept-Encoding, and
+ * Accept-Language, but not Accept.
+ */
+sealed interface SimpleRange<in T> {
+    fun matches(t: T): Boolean
+    
+    companion object
+}
+
+data class Exactly<T>(val value: T) : SimpleRange<T> {
+    override fun matches(t: T) = t == value
+}
+
+data object Wildcard : SimpleRange<Any?> {
+    override fun matches(t: Any?) = true
+}
+
+fun <T> SimpleRange.Companion.fromHeader(
+    s: String,
+    valueFromHeader: (String) -> T
+): SimpleRange<T> {
+    return when (s) {
+        "*" -> Wildcard
+        else -> Exactly(valueFromHeader(s))
+    }
+}
+
+fun <T> SimpleRange<T>.forHeader(valueForHeader: (T) -> String) =
+    Pair(
+        when (this) {
+            Wildcard -> "*"
+            is Exactly<T> -> valueForHeader(value)
+        },
+        NoParams
+    )
+
+
+// RFC 9110 Section 12.5.2
+val Header.ACCEPT_CHARSET by lazyOf(
+    Header
+        .map(
+            { PriorityList.fromHeader(it) { s, _ -> SimpleRange.fromHeader(s, Charset::forName) } },
+            { it.toHeader { range -> range.forHeader { it.name().lowercase() } } }
+        )
+        .optional("accept-charset")
+)
+
+// RFC 9110 Section 12.5.3
+val Header.ACCEPT_ENCODING by lazyOf(
+    Header
+        .map(
+            { PriorityList.fromHeader(it) { s, _ -> SimpleRange.fromHeader(s, ::ContentEncodingName) } },
+            { it.toHeader { range -> range.forHeader { it.value } } }
+        )
+        .optional("accept-encoding")
+)
+
+// RFC 9110, Section 12.5.4
+// Supports language selection by the Basic Filtering scheme only (RFC 4647, Section 3.3.1)
+val Header.ACCEPT_LANGUAGE by lazyOf(
+    Header
+        .map(
+            { PriorityList.fromHeader(it) { s, _ -> SimpleRange.fromHeader(s, Locale::forLanguageTag) } },
+            { it.toHeader { range -> range.forHeader { it.toLanguageTag() } } }
+        )
+        .optional("accept-language")
+)

--- a/core/core/src/test/kotlin/org/http4k/core/AcceptHeadersTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/AcceptHeadersTest.kt
@@ -1,0 +1,69 @@
+package learnhttp4kwithtests
+
+import org.http4k.core.ACCEPT_CHARSET
+import org.http4k.core.ACCEPT_ENCODING
+import org.http4k.core.ACCEPT_LANGUAGE
+import org.http4k.core.PriorityList
+import org.http4k.core.ContentEncodingName
+import org.http4k.core.Exactly
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.Wildcard
+import org.http4k.core.q
+import org.http4k.core.with
+import org.http4k.lens.Header
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.nio.charset.Charset
+import java.util.Locale
+
+class AcceptHeadersTest {
+    @Test
+    fun `can set and get the Accept-Language header`() {
+        val preferredLanguages = PriorityList(
+            Exactly(Locale.forLanguageTag("en-GB")) q 1.0,
+            Exactly(Locale.forLanguageTag("en")) q 0.75,
+            Wildcard q 0.25
+        )
+        
+        val rq = Request(GET, "/something")
+            .with(Header.ACCEPT_LANGUAGE of preferredLanguages)
+        assertEquals("en-GB,en;q=0.75,*;q=0.25", rq.header("Accept-Language"))
+        
+        val parsed = Header.ACCEPT_LANGUAGE(rq)
+        assertEquals(preferredLanguages, parsed)
+    }
+    
+    @Test
+    fun `can set and get the Accept-Charset header`() {
+        val preferredCharsets = PriorityList(
+            Exactly(Charset.forName("UTF-8")) q 1.0,
+            Exactly(Charset.forName("ISO-8859-1")) q 0.75,
+            Exactly(Charset.forName("US-ASCII")) q 0.6,
+            Wildcard q 0.25
+        )
+        
+        val rq = Request(GET, "/something")
+            .with(Header.ACCEPT_CHARSET of preferredCharsets)
+        assertEquals("utf-8,iso-8859-1;q=0.75,us-ascii;q=0.6,*;q=0.25", rq.header("Accept-Charset"))
+        
+        val parsed = Header.ACCEPT_CHARSET(rq)
+        assertEquals(preferredCharsets, parsed)
+    }
+    
+    @Test
+    fun `can set and get the Accept-Encoding header`() {
+        val preferredEncodings = PriorityList(
+            Exactly(ContentEncodingName.GZIP) q 1.0,
+            Exactly(ContentEncodingName.DEFLATE) q 0.75,
+            Wildcard q 0.5
+        )
+        
+        val rq = Request(GET, "/something")
+            .with(Header.ACCEPT_ENCODING of preferredEncodings)
+        assertEquals("gzip,deflate;q=0.75,*;q=0.5", rq.header("Accept-Encoding"))
+        
+        val parsed = Header.ACCEPT_ENCODING(rq)
+        assertEquals(preferredEncodings, parsed)
+    }
+}

--- a/core/core/src/test/kotlin/org/http4k/core/AcceptableOperationsTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/AcceptableOperationsTest.kt
@@ -1,0 +1,45 @@
+package org.http4k.core
+
+import org.http4k.core.AcceptableOperationsTest.PossibleValues.a
+import org.http4k.core.AcceptableOperationsTest.PossibleValues.b
+import org.http4k.core.AcceptableOperationsTest.PossibleValues.c
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+
+class AcceptableOperationsTest {
+    enum class PossibleValues { a, b, c }
+    
+    // The tests shuffle the lists of offered options to show that the selection
+    // is driven by the quality parameter of the client's preferences, not the
+    // order in which options are offered by the server.
+    
+    @Test
+    fun `selects client's preferred value from available list`() {
+        val prefs = PriorityList(a q 1.0, b q 0.75, c q 0.5)
+        
+        assertEquals(a, prefs.preferredOf(listOf(a), match = Any::equals))
+        assertEquals(b, prefs.preferredOf(listOf(b), match = Any::equals))
+        assertEquals(c, prefs.preferredOf(listOf(c), match = Any::equals))
+        assertEquals(a, prefs.preferredOf(listOf(a, b).shuffled(), match = Any::equals))
+        assertEquals(b, prefs.preferredOf(listOf(b, c).shuffled(), match = Any::equals))
+        assertEquals(a, prefs.preferredOf(listOf(a, c).shuffled(), match = Any::equals))
+        assertEquals(a, prefs.preferredOf(listOf(a, b, c).shuffled(), match = Any::equals))
+    }
+    
+    @Test
+    fun `honours wildcards`() {
+        val prefs = PriorityList(
+            Exactly(a) q 1.0,
+            Exactly(b) q 0.75,
+            Wildcard q 0.5)
+        
+        assertEquals(a, prefs.preferredOf(listOf(a)))
+        assertEquals(b, prefs.preferredOf(listOf(b)))
+        assertEquals(c, prefs.preferredOf(listOf(c)))
+        assertEquals(a, prefs.preferredOf(listOf(a, b).shuffled()))
+        assertEquals(b, prefs.preferredOf(listOf(b, c).shuffled()))
+        assertEquals(a, prefs.preferredOf(listOf(a, c).shuffled()))
+        assertEquals(a, prefs.preferredOf(listOf(a, b, c).shuffled()))
+    }
+}

--- a/core/core/src/test/kotlin/org/http4k/core/AcceptableParsingTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/AcceptableParsingTest.kt
@@ -1,0 +1,89 @@
+package learnhttp4kwithtests
+
+import learnhttp4kwithtests.AcceptableParsingTest.ExampleValue.a
+import learnhttp4kwithtests.AcceptableParsingTest.ExampleValue.b
+import learnhttp4kwithtests.AcceptableParsingTest.ExampleValue.c
+import org.http4k.core.PriorityList
+import org.http4k.core.Method.GET
+import org.http4k.core.Weighted
+import org.http4k.core.Request
+import org.http4k.core.fromHeader
+import org.http4k.core.toHeader
+import org.http4k.lens.Header
+import org.http4k.lens.LensFailure
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.fail
+
+class AcceptableParsingTest {
+    enum class ExampleValue {
+        a, b, c
+    }
+    
+    private val valueParser: (String, Map<String, String>) -> ExampleValue =
+        { s, _ -> ExampleValue.valueOf(s) }
+    
+    @Test
+    fun `parse single value`() {
+        val parsed = PriorityList.fromHeader("a", valueParser)
+        assertEquals(PriorityList(listOf(Weighted(a, 1.0))), parsed)
+    }
+    
+    @Test
+    fun `parse multiple values`() {
+        val parsed = PriorityList.fromHeader("a,b,c", valueParser)
+        assertEquals(
+            PriorityList(
+                listOf(
+                    Weighted(a, 1.0),
+                    Weighted(b, 1.0),
+                    Weighted(c, 1.0),
+                )
+            ),
+            parsed
+        )
+    }
+    
+    @Test
+    fun `parse single qualified value`() {
+        val parsed = PriorityList.fromHeader("a;q=0.625", valueParser)
+        assertEquals(PriorityList(listOf(Weighted(a, 0.625))), parsed)
+    }
+    
+    @Test
+    fun `parse mixed qualified and unqualified values`() {
+        val parsed = PriorityList.fromHeader("a,b;q=0.625,c;q=0.25", valueParser)
+        assertEquals(PriorityList(listOf(Weighted(a, 1.0), Weighted(b, 0.625), Weighted(c, 0.25))), parsed)
+    }
+    
+    @Test
+    fun `returns in preference order`() {
+        val parsed = PriorityList.fromHeader("a;q=0.25,b,c;q=0.625", valueParser)
+        assertEquals(PriorityList(listOf(Weighted(b, 1.0), Weighted(c, 0.625), Weighted(a, 0.25))), parsed)
+    }
+    
+    @Test
+    fun `allows optional whitespace`() {
+        val parsed = PriorityList.fromHeader("a ; q=0.25 , b , c ; q=0.625", valueParser)
+        assertEquals(PriorityList(listOf(Weighted(b, 1.0), Weighted(c, 0.625), Weighted(a, 0.25))), parsed)
+    }
+    
+    @Test
+    fun `lens converts exception to LensFailure when parsing fails`() {
+        class ExampleException(msg: String) : Exception(msg)
+        
+        val lens = Header
+            .map<PriorityList<Int>>(
+                nextIn = { PriorityList.fromHeader(it, { _, _ -> throw ExampleException("test failure") }) },
+                nextOut = { it.toHeader { _ -> fail("should not be called") } }
+            )
+            .optional("Example-Header")
+        
+        val request = Request(GET, "/example").header("Example-Header", "x")
+        
+        assertThrows<LensFailure> {
+            lens(request)
+        }
+    }
+}


### PR DESCRIPTION
Lenses for accept-like headers, and a model for "simple" ranges suitable for  Accept-Charset, Accept-Encoding, and Accept-Language with the Basic Filtering content negotiation scheme. Functions that interpret priority lists, suitable for implementing content negotiation in the application layer.