### PR TITLE
Better error messages from content negotiation

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/lens/ParamMeta.kt
+++ b/core/core/src/main/kotlin/org/http4k/lens/ParamMeta.kt
@@ -2,11 +2,11 @@ package org.http4k.lens
 
 import kotlin.reflect.KClass
 
-sealed class ParamMeta(val description: String) {
+open class ParamMeta(val description: String) {
     data class ArrayParam(private val itemType: ParamMeta) : ParamMeta("array") {
         fun itemType() = itemType
     }
-
+    
     class EnumParam<T : Enum<T>>(val clz: KClass<T>) : ParamMeta("string")
     data object StringParam : ParamMeta("string")
     data object ObjectParam : ParamMeta("object")

--- a/core/core/src/main/kotlin/org/http4k/lens/contentNegotiationHeaders.kt
+++ b/core/core/src/main/kotlin/org/http4k/lens/contentNegotiationHeaders.kt
@@ -4,40 +4,59 @@ import org.http4k.core.ContentEncodingName
 import org.http4k.core.PriorityList
 import org.http4k.core.fromSimpleRangeHeader
 import org.http4k.core.toSimpleRangeHeader
-import org.http4k.lens.Header.map
 import java.nio.charset.Charset
 import java.util.Locale
+
+private data class PriorityListParam(val itemType: ParamMeta) :
+    ParamMeta("priority list of " + itemType.description)
 
 
 // RFC 9110 Section 12.5.2
 val Header.ACCEPT_CHARSET by lazyOf(
-    map(
+    Header.mapWithNewMeta(
         { PriorityList.fromSimpleRangeHeader(it, Charset::forName) },
-        { it.toSimpleRangeHeader { charset -> charset.name().lowercase() } }
+        { it.toSimpleRangeHeader { charset -> charset.name().lowercase() } },
+        PriorityListParam(CharsetParam)
     ).optional("accept-charset")
 )
 
+private data object CharsetParam : ParamMeta("charset")
+
 // RFC 9110 Section 12.5.3
 val Header.ACCEPT_ENCODING by lazyOf(
-    map(
+    Header.mapWithNewMeta(
         { PriorityList.fromSimpleRangeHeader(it, ::ContentEncodingName) },
-        { it.toSimpleRangeHeader(ContentEncodingName::value) }
+        { it.toSimpleRangeHeader(ContentEncodingName::value) },
+        PriorityListParam(ContentEncodingParam)
     ).optional("accept-encoding")
 )
 
 val Header.CONTENT_ENCODING by lazyOf(
-    map(::ContentEncodingName, { it.value }).optional("content-encoding")
+    Header.mapWithNewMeta(
+        ::ContentEncodingName,
+        { it.value },
+        ContentEncodingParam
+    ).optional("content-encoding")
 )
+
+private data object ContentEncodingParam : ParamMeta("content encoding")
 
 
 // RFC 9110, Section 12.5.4
 // Supports language selection by the Basic Filtering scheme only (RFC 4647, Section 3.3.1)
 val Header.ACCEPT_LANGUAGE by lazyOf(
-    map({ PriorityList.fromSimpleRangeHeader(it, Locale::forLanguageTag) },
-        { it.toSimpleRangeHeader(Locale::toLanguageTag) }
+    Header.mapWithNewMeta(
+        { PriorityList.fromSimpleRangeHeader(it, Locale::forLanguageTag) },
+        { it.toSimpleRangeHeader(Locale::toLanguageTag) },
+        PriorityListParam(LanguageParam)
     ).optional("accept-language")
 )
 
 val Header.CONTENT_LANGUAGE by lazyOf(
-    map(Locale::forLanguageTag, Locale::toLanguageTag).optional("content-language")
+    Header.mapWithNewMeta(
+        Locale::forLanguageTag, Locale::toLanguageTag,
+        LanguageParam
+    ).optional("content-language")
 )
+
+private data object LanguageParam : ParamMeta("language")

--- a/core/core/src/main/kotlin/org/http4k/routing/negotiation.kt
+++ b/core/core/src/main/kotlin/org/http4k/routing/negotiation.kt
@@ -61,21 +61,3 @@ fun contentLanguages(routes: List<Pair<Locale, HttpHandler>>) =
  */
 fun contentLanguages(vararg routes: Pair<Locale, HttpHandler>) =
     contentLanguages(routes.toList())
-
-
-/**
- * Route by proactive negotiation of content encoding.
- */
-fun contentEncodings(routes: List<Pair<ContentEncodingName, HttpHandler>>) =
-    proactiveContentNegotiation(
-        acceptBy = Header.ACCEPT_ENCODING,
-        reportBy = Header.CONTENT_ENCODING,
-        match = { r, o -> r.matches(o) },
-        routes
-    )
-
-/**
- * Route by proactive negotiation of content language.
- */
-fun contentEncodings(vararg routes: Pair<ContentEncodingName, HttpHandler>) =
-    contentEncodings(routes.toList())

--- a/core/core/src/test/kotlin/org/http4k/routing/StandardAcceptHeadersRoutingTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/routing/StandardAcceptHeadersRoutingTest.kt
@@ -53,30 +53,4 @@ class StandardAcceptHeadersRoutingTest {
         assertEquals("fr", rsp.header("content-language"))
         assertEquals("accept-language", rsp.header("vary")?.lowercase())
     }
-    
-    @Test
-    fun `routes by encoding content negotiation`() {
-        val router = routes(
-            "/hello" bind GET to contentEncodings(
-                GZIP to { Response(OK).body("gzipped") },
-                DEFLATE to { Response(OK).body("deflated") },
-                COMPRESS to { Response(OK).body("compressed") }
-            )
-        ).withFilter(SetContentType(TEXT_PLAIN))
-        
-        val rsp = router(
-            Request(GET, "/hello").with(
-                Header.ACCEPT_ENCODING of PriorityList(
-                    Exactly(DEFLATE) q 1.0,
-                    Exactly(COMPRESS) q 0.75,
-                    Wildcard q 0.25
-                )
-            )
-        )
-        
-        assertEquals(OK, rsp.status)
-        assertEquals("deflated", rsp.bodyString())
-        assertEquals("deflate", rsp.header("content-encoding"))
-        assertEquals("accept-encoding", rsp.header("vary")?.lowercase())
-    }
 }


### PR DESCRIPTION
Also removes routing by negotiated content encoding.  This will be better implemented as a filter, and I don't want to add an unnecessary feature to the public API.