### PR TITLE
Add support for HtmlFlow templates

### DIFF
--- a/core/template/htmlflow/build.gradle.kts
+++ b/core/template/htmlflow/build.gradle.kts
@@ -1,0 +1,13 @@
+description = "http4k HtmlFlow templating support"
+
+plugins {
+    id("org.http4k.community")
+}
+
+dependencies {
+    api(project(":http4k-template-core"))
+    api(libs.htmlflow)
+    api(libs.htmlflow.view.loader)
+    testImplementation(testFixtures(project(":http4k-core")))
+    testImplementation(testFixtures(project(":http4k-template-core")))
+}

--- a/core/template/htmlflow/src/main/kotlin/org/http4k/template/HtmlFlowExtensions.kt
+++ b/core/template/htmlflow/src/main/kotlin/org/http4k/template/HtmlFlowExtensions.kt
@@ -1,0 +1,13 @@
+package org.http4k.template
+
+import htmlflow.HtmlView
+
+fun <T : ViewModel> HtmlView<T>.renderer(): TemplateRenderer {
+    return { viewModel: ViewModel ->
+        try {
+            @Suppress("UNCHECKED_CAST") this.render(viewModel as T)
+        } catch (_: ClassCastException) {
+            throw ViewNotFound(viewModel)
+        }
+    }
+}

--- a/core/template/htmlflow/src/main/kotlin/org/http4k/template/HtmlFlowTemplates.kt
+++ b/core/template/htmlflow/src/main/kotlin/org/http4k/template/HtmlFlowTemplates.kt
@@ -1,0 +1,50 @@
+package org.http4k.template
+
+import htmlflow.HtmlFlow
+import htmlflow.viewloader.ClasspathLoader
+
+class HtmlFlowTemplates: Templates {
+
+    private val loader = ClasspathLoader(ViewModel::class.java)
+
+    private val factory = HtmlFlow.ViewFactory
+        .builder()
+        .threadSafe(true)
+        .preEncoding(true)
+
+    override fun CachingClasspath(baseClasspathPackage: String): TemplateRenderer {
+        return renderer(baseClasspathPackage, hotReload = false)
+    }
+
+    fun HotReloadClasspath(baseClasspathPackage: String = ""): TemplateRenderer {
+        return renderer(baseClasspathPackage, hotReload = true)
+    }
+
+    override fun Caching(baseTemplateDir: String): TemplateRenderer {
+        val basePackage = convertPathToPackage(baseTemplateDir)
+        return renderer(basePackage, hotReload = false)
+    }
+
+    override fun HotReload(baseTemplateDir: String): TemplateRenderer {
+        val basePackage = convertPathToPackage(baseTemplateDir)
+        return renderer(basePackage, hotReload = true)
+    }
+
+    private fun renderer(basePackage: String, hotReload: Boolean): TemplateRenderer {
+        val renderer = loader.createRenderer(basePackage, hotReload, factory.preEncoding(!hotReload).build())
+        return { model ->
+            try {
+                renderer(model)
+            } catch (e: htmlflow.viewloader.ViewNotFound) {
+                throw ViewNotFound(model)
+            }
+        }
+    }
+
+    private fun convertPathToPackage(path: String): String {
+        return path
+            .replace(Regex("^(src[/\\\\](main|test)[/\\\\]kotlin([/\\\\])?)"), "")
+            .replace(Regex("[/\\\\]"), ".")
+            .trim('.')
+    }
+}

--- a/core/template/htmlflow/src/test/kotlin/AtRootBob.kt
+++ b/core/template/htmlflow/src/test/kotlin/AtRootBob.kt
@@ -1,0 +1,37 @@
+import htmlflow.HtmlFlow
+import htmlflow.HtmlView
+import htmlflow.dyn
+import htmlflow.html
+import org.http4k.template.AtRoot
+import org.xmlet.htmlapifaster.body
+import org.xmlet.htmlapifaster.li
+import org.xmlet.htmlapifaster.span
+import org.xmlet.htmlapifaster.ul
+
+val atRootBob: HtmlView<AtRoot> =
+    HtmlFlow.view<AtRoot> { page ->
+        page.html {
+            body {
+                dyn { model: AtRoot ->
+                    ul {
+                        model.items.forEach { item ->
+                            li {
+                                text("AtRootName:")
+                                span { text(item.name) }
+                                text("Price:")
+                                span { text(item.price) }
+                                ul {
+                                    item.features.forEach { feature ->
+                                        li {
+                                            text("Feature:")
+                                            span { text(feature.description) }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }

--- a/core/template/htmlflow/src/test/kotlin/org/http4k/template/HtmlFlowTemplatesTest.kt
+++ b/core/template/htmlflow/src/test/kotlin/org/http4k/template/HtmlFlowTemplatesTest.kt
@@ -1,0 +1,41 @@
+package org.http4k.template
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.throws
+import org.http4k.template.contract.HtmlFlowTemplatesContract
+import org.http4k.template.contract.HtmlFlowViewModelContract
+import org.junit.jupiter.api.Test
+
+class HtmlFlowTemplatesTest : HtmlFlowTemplatesContract<HtmlFlowTemplates>(HtmlFlowTemplates()) {
+    private val items = listOf(
+        Item("item1", "£1", listOf(Feature("pretty"))),
+        Item("item2", "£3", listOf(Feature("nasty")))
+    )
+
+    @Test
+    fun `hot reload classpath`(){
+        val renderer = templates.HotReloadClasspath()
+        assertOnClasspath(renderer)
+    }
+
+    @Test
+    fun `renderer extension function`() {
+        val renderer = onClassPath.renderer()
+        assertOnClasspath(renderer)
+        val notAtRootViewModel = onClasspathNotAtRootViewModel(items)
+        assertThat(
+            { renderer(notAtRootViewModel) },
+            throws(equalTo(ViewNotFound(notAtRootViewModel)))
+        )
+    }
+
+    fun assertOnClasspath(renderer: TemplateRenderer) {
+        assertThat(
+            renderer(onClasspathViewModel(items)).trimHtml(),
+            equalTo("<!DOCTYPE html><html><body><ul><li>Name:<span>item1</span>Price:<span>£1</span><ul><li>Feature:<span>pretty</span></li></ul></li><li>Name:<span>item2</span>Price:<span>£3</span><ul><li>Feature:<span>nasty</span></li></ul></li></ul></body></html>")
+        )
+    }
+}
+
+class HtmlFlowViewModelTest : HtmlFlowViewModelContract(HtmlFlowTemplates())

--- a/core/template/htmlflow/src/test/kotlin/org/http4k/template/contract/HtmlFlowTemplatesContract.kt
+++ b/core/template/htmlflow/src/test/kotlin/org/http4k/template/contract/HtmlFlowTemplatesContract.kt
@@ -1,0 +1,89 @@
+package org.http4k.template.contract
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.throws
+import org.http4k.format.Jackson.pretty
+import org.http4k.template.AtRoot
+import org.http4k.template.Feature
+import org.http4k.template.Item
+import org.http4k.template.NonExistent
+import org.http4k.template.OnClasspath
+import org.http4k.template.OnClasspathNotAtRoot
+import org.http4k.template.TemplateRenderer
+import org.http4k.template.Templates
+import org.http4k.template.ViewModel
+import org.http4k.template.ViewNotFound
+import org.junit.jupiter.api.Test
+
+abstract class HtmlFlowTemplatesContract<out T : Templates>(protected val templates: T) {
+
+    open val supportsRoot = true
+
+    private val items = listOf(
+        Item("item1", "£1", listOf(Feature("pretty"))),
+        Item("item2", "£3", listOf(Feature("nasty")))
+    )
+
+    @Test
+    fun `caching classpath`() {
+        val renderer = templates.CachingClasspath()
+        checkOnClasspath(renderer)
+        if (supportsRoot) checkAtRoot(renderer)
+        checkNonExistent(renderer)
+    }
+
+    @Test
+    fun caching() {
+        val renderer = templates.Caching()
+        checkOnClasspath(renderer)
+        if (supportsRoot) checkAtRoot(renderer)
+        checkNonExistent(renderer)
+    }
+
+    @Test
+    fun `caching classpath not at root`() {
+        val renderer = templates.CachingClasspath("org.http4k.template")
+        assertThat(
+            renderer(onClasspathNotAtRootViewModel(items)).trimHtml(),
+            equalTo("<!DOCTYPE html><html><body><ul><li>Name:<span>item1</span>Price:<span>£1</span><ul><li>Feature:<span>pretty</span></li></ul></li><li>Name:<span>item2</span>Price:<span>£3</span><ul><li>Feature:<span>nasty</span></li></ul></li></ul></body></html>")
+        )
+    }
+
+    open fun onClasspathNotAtRootViewModel(items: List<Item>): ViewModel = OnClasspathNotAtRoot(items)
+
+    @Test
+    fun `hot reload`() {
+        val renderer = templates.HotReload("src/test/kotlin")
+        checkOnClasspath(renderer)
+        if (supportsRoot) checkAtRoot(renderer)
+        checkNonExistent(renderer)
+    }
+
+    private fun checkOnClasspath(renderer: TemplateRenderer) {
+        assertThat(
+            renderer(onClasspathViewModel(items)).trimHtml(),
+            equalTo("<!DOCTYPE html><html><body><ul><li>Name:<span>item1</span>Price:<span>£1</span><ul><li>Feature:<span>pretty</span></li></ul></li><li>Name:<span>item2</span>Price:<span>£3</span><ul><li>Feature:<span>nasty</span></li></ul></li></ul></body></html>")
+        )
+    }
+
+    open fun onClasspathViewModel(items: List<Item>): ViewModel = OnClasspath(items)
+
+    open fun atRootViewModel(items: List<Item>): ViewModel = AtRoot(items)
+
+    private fun checkAtRoot(renderer: TemplateRenderer) {
+        assertThat(
+            renderer(atRootViewModel(items)).trimHtml(), equalTo("<!DOCTYPE html><html><body><ul><li>AtRootName:<span>item1</span>Price:<span>£1</span><ul><li>Feature:<span>pretty</span></li></ul></li><li>AtRootName:<span>item2</span>Price:<span>£3</span><ul><li>Feature:<span>nasty</span></li></ul></li></ul></body></html>")
+        )
+    }
+
+    private fun checkNonExistent(renderer: TemplateRenderer) {
+        assertThat({ renderer(NonExistent) }, throws(equalTo(ViewNotFound(NonExistent))))
+    }
+
+    fun String.trimHtml(): String =
+        replace(Regex(">\\s+<"), "><")
+            .replace(Regex(">\\s+"), ">")
+            .replace(Regex("\\s+<"), "<")
+            .trim()
+}

--- a/core/template/htmlflow/src/test/kotlin/org/http4k/template/contract/HtmlFlowViewModelContract.kt
+++ b/core/template/htmlflow/src/test/kotlin/org/http4k/template/contract/HtmlFlowViewModelContract.kt
@@ -1,0 +1,59 @@
+package org.http4k.template.contract
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.core.Body
+import org.http4k.core.ContentType.Companion.TEXT_HTML
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.OK
+import org.http4k.lens.Header.CONTENT_TYPE
+import org.http4k.template.Feature
+import org.http4k.template.Item
+import org.http4k.template.OnClasspath
+import org.http4k.template.Templates
+import org.http4k.template.viewModel
+import org.http4k.websocket.WsMessage
+import org.junit.jupiter.api.Test
+
+abstract class HtmlFlowViewModelContract(private val templates: Templates) {
+
+    private val items = listOf(
+        Item("item1", "£1", listOf(Feature("pretty"))),
+        Item("item2", "£3", listOf(Feature("nasty")))
+    )
+
+    @Test
+    fun `renders into Body`() {
+        val renderer = templates.CachingClasspath()
+
+        val view = Body.Companion.viewModel(renderer, TEXT_HTML).toLens()
+
+        val response = view(OnClasspath(items), Response(OK))
+
+        assertThat(
+            response.bodyString().trimHtml(),
+            equalTo("<!DOCTYPE html><html><body><ul><li>Name:<span>item1</span>Price:<span>£1</span><ul><li>Feature:<span>pretty</span></li></ul></li><li>Name:<span>item2</span>Price:<span>£3</span><ul><li>Feature:<span>nasty</span></li></ul></li></ul></body></html>")
+        )
+        assertThat(response.status, equalTo(OK))
+        assertThat(CONTENT_TYPE(response), equalTo(TEXT_HTML))
+    }
+
+    @Test
+    fun `renders into WsMessage`() {
+        val renderer = templates.CachingClasspath()
+
+        val view = WsMessage.viewModel(renderer).toLens()
+        val response = view.create(OnClasspath(items))
+
+        assertThat(
+            response.bodyString().trimHtml(),
+            equalTo("<!DOCTYPE html><html><body><ul><li>Name:<span>item1</span>Price:<span>£1</span><ul><li>Feature:<span>pretty</span></li></ul></li><li>Name:<span>item2</span>Price:<span>£3</span><ul><li>Feature:<span>nasty</span></li></ul></li></ul></body></html>")
+        )
+    }
+
+    fun String.trimHtml(): String =
+        replace(Regex(">\\s+<"), "><")
+            .replace(Regex(">\\s+"), ">")
+            .replace(Regex("\\s+<"), "<")
+            .trim()
+}

--- a/core/template/htmlflow/src/test/kotlin/org/http4k/template/onClassPathNotAtRoot.kt
+++ b/core/template/htmlflow/src/test/kotlin/org/http4k/template/onClassPathNotAtRoot.kt
@@ -1,0 +1,40 @@
+package org.http4k.template
+
+import htmlflow.HtmlFlow
+import htmlflow.HtmlView
+import htmlflow.dyn
+import htmlflow.html
+import org.http4k.template.OnClasspath
+import org.xmlet.htmlapifaster.body
+import org.xmlet.htmlapifaster.li
+import org.xmlet.htmlapifaster.span
+import org.xmlet.htmlapifaster.ul
+
+val onClassPathNotAtRoot: HtmlView<OnClasspathNotAtRoot> =
+    HtmlFlow.view { view ->
+        view
+            .html {
+                body {
+                    ul {
+                        dyn { model: OnClasspathNotAtRoot ->
+                            model.items.forEach { item ->
+                                li {
+                                    text("Name:")
+                                    span { text(item.name) }
+                                    text("Price:")
+                                    span { text(item.price) }
+                                    ul {
+                                        item.features.forEach { feature ->
+                                            li {
+                                                text("Feature:")
+                                                span { text(feature.description) }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+    }

--- a/core/template/htmlflow/src/test/kotlin/org/http4k/template/onClasspath.kt
+++ b/core/template/htmlflow/src/test/kotlin/org/http4k/template/onClasspath.kt
@@ -1,0 +1,41 @@
+package org.http4k.template
+
+import htmlflow.HtmlFlow
+import htmlflow.HtmlView
+import htmlflow.dyn
+import htmlflow.html
+import org.xmlet.htmlapifaster.body
+import org.xmlet.htmlapifaster.li
+import org.xmlet.htmlapifaster.span
+import org.xmlet.htmlapifaster.ul
+
+val onClassPath: HtmlView<OnClasspath> =
+    HtmlFlow.view { view ->
+        view
+            .html {
+                body {
+                    ul {
+                        dyn { model: OnClasspath ->
+                            model.items.forEach { item ->
+                                li {
+                                    text("Name:")
+                                    span { text(item.name) }
+                                    text("Price:")
+                                    span { text(item.price) }
+                                    ul {
+                                        item.features.forEach { feature ->
+                                            li {
+                                                text("Feature:")
+                                                span { text(feature.description) }
+                                            }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,8 @@ handlebars = "4.5.0"
 helidon-bom = "4.2.7"
 hikaricp = "7.0.2"
 hsqldb = "2.7.4"
+htmlflow = "5.0.1"
+htmlflow-view-loader = "5.0.1"
 htmx-org = "2.0.7"
 hyperscript-org = "0.9.14"
 jackson-bom = "2.20.0"
@@ -180,6 +182,8 @@ helidon-webserver-sse = { module = "io.helidon.webserver:helidon-webserver-sse",
 helidon-webserver-websocket = { module = "io.helidon.webserver:helidon-webserver-websocket", version.ref = "helidon-bom" }
 hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp" }
 hsqldb = { module = "org.hsqldb:hsqldb", version.ref = "hsqldb" }
+htmlflow = { module = "com.github.xmlet:htmlflow", version.ref = "htmlflow" }
+htmlflow-view-loader = { module = "com.github.xmlet:htmlflow-view-loader", version.ref = "htmlflow-view-loader" }
 htmx-org = { module = "org.webjars.npm:htmx.org", version.ref = "htmx-org" }
 hyperscript-org = { module = "org.webjars.npm:hyperscript.org", version.ref = "hyperscript-org" }
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson-bom" }


### PR DESCRIPTION
Adds HtmlFlow Templates support, as discussed [here](https://github.com/xmlet/HtmlFlow/issues/122#issuecomment-3185468741)

Supported methods:
- `CachingClasspath`: Scans package paths for `HtmlView` definitions with view caching
- `HotReloadClasspath`: Same scanning with hot reload capability  
- `Caching`: Converts directory paths to package paths for classpath-based scanning
- `HotReload`: Same as `Caching` with hot reload enabled
- `HtmlView<T>.renderer()`: Creates a `TemplateRenderer` directly from an `HtmlView`