### PR TITLE
Handle additional connection issues in client HttpHandlers

### DIFF
--- a/core/client/apache/src/main/kotlin/org/http4k/client/ApacheClient.kt
+++ b/core/client/apache/src/main/kotlin/org/http4k/client/ApacheClient.kt
@@ -15,6 +15,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.apache.hc.core5.http.ClassicHttpResponse
 import org.apache.hc.core5.http.Header
 import org.apache.hc.core5.http.HttpResponse
+import org.apache.hc.core5.http.MalformedChunkCodingException
 import org.apache.hc.core5.http.NoHttpResponseException
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity
 import org.apache.hc.core5.http.io.entity.InputStreamEntity
@@ -69,6 +70,8 @@ object ApacheClient {
         } catch (e: SocketException) {
             Response(SERVICE_UNAVAILABLE.toClientStatus(e))
         } catch (e: NoHttpResponseException) {
+            Response(SERVICE_UNAVAILABLE.toClientStatus(e))
+        } catch (e: MalformedChunkCodingException) {
             Response(SERVICE_UNAVAILABLE.toClientStatus(e))
         }
     }

--- a/core/client/apache/src/test/kotlin/org/http4k/client/ApacheClientStreamingTest.kt
+++ b/core/client/apache/src/test/kotlin/org/http4k/client/ApacheClientStreamingTest.kt
@@ -4,6 +4,8 @@ import org.apache.hc.client5.http.config.RequestConfig
 import org.apache.hc.core5.util.Timeout
 import org.http4k.core.BodyMode.Stream
 import org.http4k.server.ApacheServer
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
 
 class ApacheClientStreamingTest : HttpClientContract(::ApacheServer,
     ApacheClient(requestBodyMode = Stream, responseBodyMode = Stream),
@@ -15,4 +17,7 @@ class ApacheClientStreamingTest : HttpClientContract(::ApacheServer,
         ).build(),
         responseBodyMode = Stream,
         requestBodyMode = Stream)
-)
+) {
+    @Test
+    override fun `malformed response chunk is converted into 503`() = assumeTrue(false, "Unsupported feature")
+}

--- a/core/client/apache4/src/main/kotlin/org/http4k/client/Apache4Client.kt
+++ b/core/client/apache4/src/main/kotlin/org/http4k/client/Apache4Client.kt
@@ -1,6 +1,7 @@
 package org.http4k.client
 
 import org.apache.http.Header
+import org.apache.http.MalformedChunkCodingException
 import org.apache.http.NoHttpResponseException
 import org.apache.http.StatusLine
 import org.apache.http.client.config.CookieSpecs.IGNORE_COOKIES
@@ -71,6 +72,8 @@ object Apache4Client {
         } catch (e: SocketException) {
             Response(SERVICE_UNAVAILABLE.toClientStatus(e))
         } catch (e: NoHttpResponseException) {
+            Response(SERVICE_UNAVAILABLE.toClientStatus(e))
+        } catch (e: MalformedChunkCodingException) {
             Response(SERVICE_UNAVAILABLE.toClientStatus(e))
         }
     }

--- a/core/client/apache4/src/test/kotlin/org/http4k/client/Apache4ClientStreamingTest.kt
+++ b/core/client/apache4/src/test/kotlin/org/http4k/client/Apache4ClientStreamingTest.kt
@@ -4,6 +4,8 @@ import org.apache.http.config.SocketConfig
 import org.apache.http.impl.client.HttpClients
 import org.http4k.core.BodyMode.Stream
 import org.http4k.server.ApacheServer
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
 
 class Apache4ClientStreamingTest : HttpClientContract(
     ::ApacheServer,
@@ -18,4 +20,7 @@ class Apache4ClientStreamingTest : HttpClientContract(
         responseBodyMode = Stream,
         requestBodyMode = Stream
     )
-)
+) {
+    @Test
+    override fun `malformed response chunk is converted into 503`() = assumeTrue(false, "Unsupported feature")
+}

--- a/core/client/apache4/src/test/kotlin/org/http4k/client/Apache4ClientStreamingTest.kt
+++ b/core/client/apache4/src/test/kotlin/org/http4k/client/Apache4ClientStreamingTest.kt
@@ -23,4 +23,7 @@ class Apache4ClientStreamingTest : HttpClientContract(
 ) {
     @Test
     override fun `malformed response chunk is converted into 503`() = assumeTrue(false, "Unsupported feature")
+
+    @Test
+    override fun `random data then close is converted into 503`() = assumeTrue(false, "Unsupported feature")
 }

--- a/core/client/apache4/src/test/kotlin/org/http4k/client/Apache4ClientTest.kt
+++ b/core/client/apache4/src/test/kotlin/org/http4k/client/Apache4ClientTest.kt
@@ -17,6 +17,7 @@ import org.http4k.core.Status.Companion.CLIENT_TIMEOUT
 import org.http4k.core.Status.Companion.SERVICE_UNAVAILABLE
 import org.http4k.hamkrest.hasStatus
 import org.http4k.server.ApacheServer
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 
 class Apache4ClientTest : HttpClientContract(
@@ -75,4 +76,7 @@ class Apache4ClientTest : HttpClientContract(
             }
         })(Request(GET, "http://localhost:8000")), hasStatus(SERVICE_UNAVAILABLE))
     }
+
+    @Test
+    override fun `random data then close is converted into 503`() = assumeTrue(false, "Unsupported feature")
 }

--- a/core/client/fuel/src/main/kotlin/org/http4k/client/Fuel.kt
+++ b/core/client/fuel/src/main/kotlin/org/http4k/client/Fuel.kt
@@ -12,6 +12,7 @@ import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.toParametersMap
 import java.net.ConnectException
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.time.Duration
@@ -42,6 +43,7 @@ class Fuel(
             is ConnectException -> return Response(Status.CONNECTION_REFUSED.toClientStatus(error.exception as ConnectException))
             is UnknownHostException -> return Response(Status.UNKNOWN_HOST.toClientStatus(error.exception as UnknownHostException))
             is SocketTimeoutException -> return Response(Status.CLIENT_TIMEOUT.toClientStatus(error.exception as SocketTimeoutException))
+            is SocketException -> return Response(Status.SERVICE_UNAVAILABLE.toClientStatus(error.exception as SocketException))
         }
         val headers: Parameters = response.headers.toList().fold(listOf()) { acc, next ->
             acc + next.second.fold(listOf()) { keyAcc, nextValue -> keyAcc + (next.first to nextValue) }

--- a/core/client/fuel/src/main/kotlin/org/http4k/client/Fuel.kt
+++ b/core/client/fuel/src/main/kotlin/org/http4k/client/Fuel.kt
@@ -11,6 +11,7 @@ import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.toParametersMap
+import java.io.IOException
 import java.net.ConnectException
 import java.net.SocketException
 import java.net.SocketTimeoutException
@@ -44,6 +45,7 @@ class Fuel(
             is UnknownHostException -> return Response(Status.UNKNOWN_HOST.toClientStatus(error.exception as UnknownHostException))
             is SocketTimeoutException -> return Response(Status.CLIENT_TIMEOUT.toClientStatus(error.exception as SocketTimeoutException))
             is SocketException -> return Response(Status.SERVICE_UNAVAILABLE.toClientStatus(error.exception as SocketException))
+            is IOException -> return Response(Status.SERVICE_UNAVAILABLE.toClientStatus(error.exception as IOException))
         }
         val headers: Parameters = response.headers.toList().fold(listOf()) { acc, next ->
             acc + next.second.fold(listOf()) { keyAcc, nextValue -> keyAcc + (next.first to nextValue) }

--- a/core/client/fuel/src/test/kotlin/org/http4k/client/FuelStreamingTest.kt
+++ b/core/client/fuel/src/test/kotlin/org/http4k/client/FuelStreamingTest.kt
@@ -2,6 +2,7 @@ package org.http4k.client
 
 import org.http4k.core.BodyMode.Stream
 import org.http4k.server.ApacheServer
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.Duration
@@ -16,4 +17,7 @@ class FuelStreamingTest : HttpClientContract(
     override fun `can send multiple headers with same name`() {
         super.`can send multiple headers with same name`()
     }
+
+    @Test
+    override fun `random data then close is converted into 503`() = assumeTrue(false, "Unsupported feature")
 }

--- a/core/client/fuel/src/test/kotlin/org/http4k/client/FuelTest.kt
+++ b/core/client/fuel/src/test/kotlin/org/http4k/client/FuelTest.kt
@@ -1,6 +1,7 @@
 package org.http4k.client
 
 import org.http4k.server.ApacheServer
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import java.time.Duration
@@ -14,4 +15,7 @@ class FuelTest :
     override fun `can send multiple headers with same name`() {
         super.`can send multiple headers with same name`()
     }
+
+    @Test
+    override fun `random data then close is converted into 503`() = assumeTrue(false, "Unsupported feature")
 }

--- a/core/client/helidon/src/main/kotlin/org/http4k/client/HelidonClient.kt
+++ b/core/client/helidon/src/main/kotlin/org/http4k/client/HelidonClient.kt
@@ -12,11 +12,13 @@ import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.Status.Companion.CLIENT_TIMEOUT
+import org.http4k.core.Status.Companion.SERVICE_UNAVAILABLE
 import org.http4k.core.Status.Companion.UNKNOWN_HOST
 import org.http4k.core.queries
 import org.http4k.core.toParametersMap
 import java.io.UncheckedIOException
 import java.net.ConnectException
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 
@@ -44,6 +46,7 @@ object HelidonClient {
                 is UnknownHostException -> Response(UNKNOWN_HOST.toClientStatus(e))
                 is ConnectException -> Response(UNKNOWN_HOST.toClientStatus(e))
                 is SocketTimeoutException -> Response(CLIENT_TIMEOUT.toClientStatus(e))
+                is SocketException -> Response(SERVICE_UNAVAILABLE.toClientStatus(e))
                 else -> throw e
             }
         }

--- a/core/client/helidon/src/main/kotlin/org/http4k/client/HelidonClient.kt
+++ b/core/client/helidon/src/main/kotlin/org/http4k/client/HelidonClient.kt
@@ -1,5 +1,6 @@
 package org.http4k.client
 
+import io.helidon.common.buffers.DataReader
 import io.helidon.http.Method
 import io.helidon.webclient.api.ClientRequest
 import io.helidon.webclient.api.HttpClientRequest
@@ -49,6 +50,8 @@ object HelidonClient {
                 is SocketException -> Response(SERVICE_UNAVAILABLE.toClientStatus(e))
                 else -> throw e
             }
+        } catch (e: DataReader.InsufficientDataAvailableException) {
+            Response(SERVICE_UNAVAILABLE.toClientStatus(e))
         }
 
         private fun HttpClientResponse.asHttp4k() =

--- a/core/client/helidon/src/test/kotlin/org/http4k/client/HelidonClientStreamingTest.kt
+++ b/core/client/helidon/src/test/kotlin/org/http4k/client/HelidonClientStreamingTest.kt
@@ -5,6 +5,7 @@ import org.http4k.core.BodyMode.Stream
 import org.http4k.server.ApacheServer
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
 import java.time.Duration
 
 class HelidonClientStreamingTest : HttpClientContract(
@@ -22,4 +23,7 @@ class HelidonClientStreamingTest : HttpClientContract(
     @Disabled
     override fun `fails with no protocol`() {
     }
+
+    @Test
+    override fun `malformed response chunk is converted into 503`() = assumeTrue(false, "Unsupported feature")
 }

--- a/core/client/jetty/src/main/kotlin/org/http4k/client/JettyClient.kt
+++ b/core/client/jetty/src/main/kotlin/org/http4k/client/JettyClient.kt
@@ -3,6 +3,7 @@ package org.http4k.client
 import org.eclipse.jetty.client.BufferingResponseListener
 import org.eclipse.jetty.client.ByteBufferRequestContent
 import org.eclipse.jetty.client.HttpClient
+import org.eclipse.jetty.client.HttpResponseException
 import org.eclipse.jetty.client.InputStreamRequestContent
 import org.eclipse.jetty.client.InputStreamResponseListener
 import org.eclipse.jetty.client.Result
@@ -66,6 +67,7 @@ object JettyClient {
                         is UnknownHostException -> Response(UNKNOWN_HOST.toClientStatus(e))
                         is ConnectException -> Response(CONNECTION_REFUSED.toClientStatus(e))
                         is EOFException -> Response(SERVICE_UNAVAILABLE.toClientStatus(e))
+                        is HttpResponseException -> Response(SERVICE_UNAVAILABLE.toClientStatus(e))
                         else -> throw e
                     }
                 } catch (e: TimeoutException) {

--- a/core/client/jetty/src/main/kotlin/org/http4k/client/JettyClient.kt
+++ b/core/client/jetty/src/main/kotlin/org/http4k/client/JettyClient.kt
@@ -25,6 +25,7 @@ import org.http4k.core.Status.Companion.CONNECTION_REFUSED
 import org.http4k.core.Status.Companion.SERVICE_UNAVAILABLE
 import org.http4k.core.Status.Companion.UNKNOWN_HOST
 import org.http4k.core.toParametersMap
+import java.io.EOFException
 import java.net.ConnectException
 import java.net.UnknownHostException
 import java.util.concurrent.ExecutionException
@@ -64,6 +65,7 @@ object JettyClient {
                     when (e.cause) {
                         is UnknownHostException -> Response(UNKNOWN_HOST.toClientStatus(e))
                         is ConnectException -> Response(CONNECTION_REFUSED.toClientStatus(e))
+                        is EOFException -> Response(SERVICE_UNAVAILABLE.toClientStatus(e))
                         else -> throw e
                     }
                 } catch (e: TimeoutException) {

--- a/core/client/jetty/src/test/kotlin/org/http4k/client/JettyClientStreamingTest.kt
+++ b/core/client/jetty/src/test/kotlin/org/http4k/client/JettyClientStreamingTest.kt
@@ -6,6 +6,7 @@ import org.http4k.core.Method
 import org.http4k.core.Request
 import org.http4k.hamkrest.hasBody
 import org.http4k.server.ApacheServer
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 
 class JettyClientStreamingTest : HttpClientContract(
@@ -26,4 +27,7 @@ class JettyClientStreamingTest : HttpClientContract(
     @Test
     override fun `socket timeouts are converted into 504`() {
     }
+
+    @Test
+    override fun `malformed response chunk is converted into 503`() = assumeTrue(false, "Unsupported feature")
 }

--- a/core/client/okhttp/src/main/kotlin/org/http4k/client/OkHttp.kt
+++ b/core/client/okhttp/src/main/kotlin/org/http4k/client/OkHttp.kt
@@ -18,6 +18,7 @@ import java.io.IOException
 import java.io.InterruptedIOException
 import java.net.ConnectException
 import java.net.NoRouteToHostException
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.security.SecureRandom
@@ -50,6 +51,8 @@ object OkHttp {
                         e.message == "timeout" -> Response(CLIENT_TIMEOUT.toClientStatus(e))
                         else -> throw e
                     }
+                } catch (e: SocketException) {
+                    Response(SERVICE_UNAVAILABLE.toClientStatus(e))
                 }
 
             override operator fun invoke(request: Request, fn: (Response) -> Unit) =

--- a/core/client/okhttp/src/main/kotlin/org/http4k/client/OkHttp.kt
+++ b/core/client/okhttp/src/main/kotlin/org/http4k/client/OkHttp.kt
@@ -53,6 +53,8 @@ object OkHttp {
                     }
                 } catch (e: SocketException) {
                     Response(SERVICE_UNAVAILABLE.toClientStatus(e))
+                } catch (e: IOException) {
+                    Response(SERVICE_UNAVAILABLE.toClientStatus(e))
                 }
 
             override operator fun invoke(request: Request, fn: (Response) -> Unit) =

--- a/core/client/okhttp/src/test/kotlin/org/http4k/client/OkHttpStreamingTest.kt
+++ b/core/client/okhttp/src/test/kotlin/org/http4k/client/OkHttpStreamingTest.kt
@@ -2,6 +2,11 @@ package org.http4k.client
 
 import org.http4k.core.BodyMode
 import org.http4k.server.ApacheServer
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
 
 class OkHttpStreamingTest : HttpClientContract(::ApacheServer, OkHttp(bodyMode = BodyMode.Stream),
-    OkHttp(timeout, bodyMode = BodyMode.Stream))
+    OkHttp(timeout, bodyMode = BodyMode.Stream)) {
+    @Test
+    override fun `malformed response chunk is converted into 503`() = assumeTrue(false, "Unsupported feature")
+}

--- a/core/core/build.gradle.kts
+++ b/core/core/build.gradle.kts
@@ -13,6 +13,8 @@ dependencies {
 
     testImplementation(libs.junit.jupiter.params)
 
+    testFixturesImplementation("org.wiremock:wiremock-standalone:3.13.1")
+
     testFixturesImplementation(platform(libs.opentelemetry.bom))
     testFixturesImplementation(libs.opentelemetry.sdk)
     testFixturesImplementation(libs.opentelemetry.exporter.otlp)

--- a/core/core/build.gradle.kts
+++ b/core/core/build.gradle.kts
@@ -13,11 +13,10 @@ dependencies {
 
     testImplementation(libs.junit.jupiter.params)
 
-    testFixturesImplementation("org.wiremock:wiremock-standalone:3.13.1")
-
     testFixturesImplementation(platform(libs.opentelemetry.bom))
     testFixturesImplementation(libs.opentelemetry.sdk)
     testFixturesImplementation(libs.opentelemetry.exporter.otlp)
+    testFixturesImplementation(libs.wiremock.standalone)
 
     testFixturesImplementation(libs.result4k)
     testFixturesImplementation(libs.values4k)

--- a/core/core/src/main/kotlin/org/http4k/client/Java8HttpClient.kt
+++ b/core/core/src/main/kotlin/org/http4k/client/Java8HttpClient.kt
@@ -10,6 +10,7 @@ import org.http4k.core.Status.Companion.CONNECTION_REFUSED
 import org.http4k.core.Status.Companion.SERVICE_UNAVAILABLE
 import org.http4k.core.Status.Companion.UNKNOWN_HOST
 import java.io.ByteArrayInputStream
+import java.io.IOException
 import java.net.ConnectException
 import java.net.HttpURLConnection
 import java.net.SocketException
@@ -69,6 +70,8 @@ object Java8HttpClient {
         } catch (e: SocketTimeoutException) {
             Response(CLIENT_TIMEOUT.toClientStatus(e))
         } catch (e: SocketException) {
+            Response(SERVICE_UNAVAILABLE.toClientStatus(e))
+        } catch (e: IOException) {
             Response(SERVICE_UNAVAILABLE.toClientStatus(e))
         }
     }

--- a/core/core/src/main/kotlin/org/http4k/client/Java8HttpClient.kt
+++ b/core/core/src/main/kotlin/org/http4k/client/Java8HttpClient.kt
@@ -7,13 +7,16 @@ import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.Status.Companion.CLIENT_TIMEOUT
 import org.http4k.core.Status.Companion.CONNECTION_REFUSED
+import org.http4k.core.Status.Companion.SERVICE_UNAVAILABLE
 import org.http4k.core.Status.Companion.UNKNOWN_HOST
 import java.io.ByteArrayInputStream
 import java.net.ConnectException
 import java.net.HttpURLConnection
+import java.net.SocketException
 import java.net.SocketTimeoutException
 import java.net.URI
 import java.net.UnknownHostException
+import java.net.http.HttpTimeoutException
 import java.nio.ByteBuffer
 import java.time.Duration
 import java.time.Duration.ZERO
@@ -65,6 +68,8 @@ object Java8HttpClient {
             Response(CONNECTION_REFUSED.toClientStatus(e))
         } catch (e: SocketTimeoutException) {
             Response(CLIENT_TIMEOUT.toClientStatus(e))
+        } catch (e: SocketException) {
+            Response(SERVICE_UNAVAILABLE.toClientStatus(e))
         }
     }
 

--- a/core/core/src/main/kotlin/org/http4k/client/JavaHttpClient.kt
+++ b/core/core/src/main/kotlin/org/http4k/client/JavaHttpClient.kt
@@ -11,7 +11,9 @@ import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.Status.Companion.CLIENT_TIMEOUT
 import org.http4k.core.Status.Companion.CONNECTION_REFUSED
+import org.http4k.core.Status.Companion.SERVICE_UNAVAILABLE
 import org.http4k.core.Status.Companion.UNKNOWN_HOST
+import java.io.IOException
 import java.net.ConnectException
 import java.net.URI
 import java.net.UnknownHostException
@@ -54,6 +56,8 @@ object JavaHttpClient {
             Response(CONNECTION_REFUSED.toClientStatus(e))
         } catch (e: HttpTimeoutException) {
             Response(CLIENT_TIMEOUT.toClientStatus(e))
+        } catch (e: IOException) {
+            Response(SERVICE_UNAVAILABLE.toClientStatus(e))
         }
     }
 }

--- a/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
+++ b/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
@@ -356,4 +356,27 @@ abstract class HttpClientContract(
             server.stop()
         }
     }
+
+    @Test
+    fun `empty response is converted into 503`() {
+        val server = WireMockServer(WireMockConfiguration.options().dynamicPort())
+        server.start()
+
+        try {
+            server.stubFor(
+                get(urlEqualTo("/badResponse"))
+                    .willReturn(
+                        aResponse()
+                            .withFault(Fault.EMPTY_RESPONSE)
+                    )
+            )
+
+            val response = client(Request(GET, "http://localhost:${server.port()}/badResponse"))
+
+            assertThat(response.status, equalTo(SERVICE_UNAVAILABLE))
+//            assertThat(response.status.toString().lowercase(ROOT), containsSubstring("???"))
+        } finally {
+            server.stop()
+        }
+    }
 }

--- a/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
+++ b/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
@@ -351,7 +351,6 @@ abstract class HttpClientContract(
             val response = client(Request(GET, "http://localhost:${server.port()}/badResponse"))
 
             assertThat(response.status, equalTo(SERVICE_UNAVAILABLE))
-//            assertThat(response.status.toString().lowercase(ROOT), containsSubstring("connection reset"))
         } finally {
             server.stop()
         }
@@ -374,7 +373,6 @@ abstract class HttpClientContract(
             val response = client(Request(GET, "http://localhost:${server.port()}/badResponse"))
 
             assertThat(response.status, equalTo(SERVICE_UNAVAILABLE))
-//            assertThat(response.status.toString().lowercase(ROOT), containsSubstring("???"))
         } finally {
             server.stop()
         }
@@ -397,7 +395,6 @@ abstract class HttpClientContract(
             val response = client(Request(GET, "http://localhost:${server.port()}/badResponse"))
 
             assertThat(response.status, equalTo(SERVICE_UNAVAILABLE))
-//            assertThat(response.status.toString().lowercase(ROOT), containsSubstring("???"))
         } finally {
             server.stop()
         }
@@ -420,7 +417,6 @@ abstract class HttpClientContract(
             val response = client(Request(GET, "http://localhost:${server.port()}/badResponse"))
 
             assertThat(response.status, equalTo(SERVICE_UNAVAILABLE))
-//            assertThat(response.status.toString().lowercase(ROOT), containsSubstring("???"))
         } finally {
             server.stop()
         }

--- a/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
+++ b/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
@@ -402,4 +402,27 @@ abstract class HttpClientContract(
             server.stop()
         }
     }
+
+    @Test
+    open fun `random data then close is converted into 503`() {
+        val server = WireMockServer(WireMockConfiguration.options().dynamicPort())
+        server.start()
+
+        try {
+            server.stubFor(
+                get(urlEqualTo("/badResponse"))
+                    .willReturn(
+                        aResponse()
+                            .withFault(Fault.RANDOM_DATA_THEN_CLOSE)
+                    )
+            )
+
+            val response = client(Request(GET, "http://localhost:${server.port()}/badResponse"))
+
+            assertThat(response.status, equalTo(SERVICE_UNAVAILABLE))
+//            assertThat(response.status.toString().lowercase(ROOT), containsSubstring("???"))
+        } finally {
+            server.stop()
+        }
+    }
 }

--- a/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
+++ b/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
@@ -381,7 +381,7 @@ abstract class HttpClientContract(
     }
 
     @Test
-    fun `malformed response chunk is converted into 503`() {
+    open fun `malformed response chunk is converted into 503`() {
         val server = WireMockServer(WireMockConfiguration.options().dynamicPort())
         server.start()
 

--- a/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
+++ b/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
@@ -348,10 +348,10 @@ abstract class HttpClientContract(
                     )
             )
 
-            val response = client(Request(Method.GET, "http://localhost:${server.port()}/badResponse"))
+            val response = client(Request(GET, "http://localhost:${server.port()}/badResponse"))
 
             assertThat(response.status, equalTo(SERVICE_UNAVAILABLE))
-            assertThat(response.status.toString().lowercase(ROOT), containsSubstring("connection reset"))
+//            assertThat(response.status.toString().lowercase(ROOT), containsSubstring("connection reset"))
         } finally {
             server.stop()
         }

--- a/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
+++ b/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
@@ -351,6 +351,7 @@ abstract class HttpClientContract(
             val response = client(Request(Method.GET, "http://localhost:${server.port()}/badResponse"))
 
             assertThat(response.status, equalTo(SERVICE_UNAVAILABLE))
+            assertThat(response.status.toString().lowercase(ROOT), containsSubstring("connection reset"))
         } finally {
             server.stop()
         }

--- a/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
+++ b/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
@@ -335,7 +335,7 @@ abstract class HttpClientContract(
     }
 
     @Test
-    fun `connection reset is converted into 503`() {
+    open fun `connection reset is converted into 503`() {
         val server = WireMockServer(WireMockConfiguration.options().dynamicPort())
         server.start()
 
@@ -357,7 +357,7 @@ abstract class HttpClientContract(
     }
 
     @Test
-    fun `empty response is converted into 503`() {
+    open fun `empty response is converted into 503`() {
         val server = WireMockServer(WireMockConfiguration.options().dynamicPort())
         server.start()
 

--- a/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
+++ b/core/core/src/testFixtures/kotlin/org/http4k/client/HttpClientContract.kt
@@ -379,4 +379,27 @@ abstract class HttpClientContract(
             server.stop()
         }
     }
+
+    @Test
+    fun `malformed response chunk is converted into 503`() {
+        val server = WireMockServer(WireMockConfiguration.options().dynamicPort())
+        server.start()
+
+        try {
+            server.stubFor(
+                get(urlEqualTo("/badResponse"))
+                    .willReturn(
+                        aResponse()
+                            .withFault(Fault.MALFORMED_RESPONSE_CHUNK)
+                    )
+            )
+
+            val response = client(Request(GET, "http://localhost:${server.port()}/badResponse"))
+
+            assertThat(response.status, equalTo(SERVICE_UNAVAILABLE))
+//            assertThat(response.status.toString().lowercase(ROOT), containsSubstring("???"))
+        } finally {
+            server.stop()
+        }
+    }
 }

--- a/core/serverless/lambda/integration-test/src/test/kotlin/org/http4k/serverless/lambda/ApiGatewayHttpClientTest.kt
+++ b/core/serverless/lambda/integration-test/src/test/kotlin/org/http4k/serverless/lambda/ApiGatewayHttpClientTest.kt
@@ -39,6 +39,10 @@ abstract class ApiGatewayHttpClientTest(version: ApiIntegrationVersion) :
     override fun `fails with no protocol`() = assumeTrue(false, "Unsupported client feature")
     override fun `unknown host is correctly reported`() = assumeTrue(false, "Unsupported client feature")
     override fun `socket timeouts are converted into 504`() = assumeTrue(false, "Unsupported client feature")
+    override fun `connection reset is converted into 503`() = assumeTrue(false, "Unsupported client feature")
+    override fun `empty response is converted into 503`() = assumeTrue(false, "Unsupported client feature")
+    override fun `malformed response chunk is converted into 503`() = assumeTrue(false, "Unsupported client feature")
+    override fun `random data then close is converted into 503`() = assumeTrue(false, "Unsupported client feature")
 }
 
 class ApiGatewayV1ClientTest : ApiGatewayHttpClientTest(v1) {

--- a/core/serverless/lambda/integration-test/src/test/kotlin/org/http4k/serverless/lambda/ApiGatewayRestClientTest.kt
+++ b/core/serverless/lambda/integration-test/src/test/kotlin/org/http4k/serverless/lambda/ApiGatewayRestClientTest.kt
@@ -33,6 +33,10 @@ abstract class ApiGatewayRestHttpClientTest :
     override fun `connection refused are converted into 503`() = assumeTrue(false, "Unsupported client feature")
     override fun `handles response with custom status message`() = assumeTrue(false, "Unsupported client feature")
     override fun `unknown host are converted into 503`() = assumeTrue(false, "Unsupported client feature")
+    override fun `connection reset is converted into 503`() = assumeTrue(false, "Unsupported client feature")
+    override fun `empty response is converted into 503`() = assumeTrue(false, "Unsupported client feature")
+    override fun `malformed response chunk is converted into 503`() = assumeTrue(false, "Unsupported client feature")
+    override fun `random data then close is converted into 503`() = assumeTrue(false, "Unsupported client feature")
 }
 
 class ApiGatewayRestV1ClientTest : ApiGatewayRestHttpClientTest() {

--- a/core/serverless/lambda/integration-test/src/test/kotlin/org/http4k/serverless/lambda/ApplicationLoadBalancerHttpClientTest.kt
+++ b/core/serverless/lambda/integration-test/src/test/kotlin/org/http4k/serverless/lambda/ApplicationLoadBalancerHttpClientTest.kt
@@ -30,4 +30,8 @@ class ApplicationLoadBalancerHttpClientTest :
     override fun `can receive multiple headers with same name`() = assumeTrue(false, "Unsupported feature")
     override fun `can send multiple cookies`() = assumeTrue(false, "Unsupported feature")
     override fun `can receive multiple cookies`() = assumeTrue(false, "Unsupported feature")
+    override fun `connection reset is converted into 503`() = assumeTrue(false, "Unsupported client feature")
+    override fun `empty response is converted into 503`() = assumeTrue(false, "Unsupported client feature")
+    override fun `malformed response chunk is converted into 503`() = assumeTrue(false, "Unsupported client feature")
+    override fun `random data then close is converted into 503`() = assumeTrue(false, "Unsupported client feature")
 }

--- a/core/serverless/lambda/integration-test/src/test/kotlin/org/http4k/serverless/lambda/LambdaHttpClientTest.kt
+++ b/core/serverless/lambda/integration-test/src/test/kotlin/org/http4k/serverless/lambda/LambdaHttpClientTest.kt
@@ -37,6 +37,10 @@ abstract class LambdaHttpClientTest(
     override fun `socket timeouts are converted into 504`() = unsupportedFeature()
     override fun `fails with no protocol`() = unsupportedFeature()
     override fun `unknown host is correctly reported`() = unsupportedFeature()
+    override fun `connection reset is converted into 503`() = unsupportedFeature()
+    override fun `empty response is converted into 503`() = unsupportedFeature()
+    override fun `malformed response chunk is converted into 503`() = unsupportedFeature()
+    override fun `random data then close is converted into 503`() = unsupportedFeature()
 }
 
 class LambdaV1HttpClientTest : LambdaHttpClientTest(ApiGatewayV1, ::ApiGatewayV1LambdaClient) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -123,6 +123,7 @@ underscore = "1.117"
 undertow-core = "2.3.19.Final"
 version-catalog-update = "1.0.0"
 vertx-web = "5.0.4"
+wiremock = "3.13.1"
 
 [libraries]
 aliyun-fc-java-core = { module = "com.aliyun.fc.runtime:fc-java-core", version.ref = "aliyun-fc-java-core" }
@@ -303,6 +304,7 @@ underscore = { module = "com.github.javadev:underscore", version.ref = "undersco
 undertow-core = { module = "io.undertow:undertow-core", version.ref = "undertow-core" }
 values4k = { module = "dev.forkhandles:values4k", version.ref = "forkhandles-bom" }
 vertx-web = { module = "io.vertx:vertx-web", version.ref = "vertx-web" }
+wiremock-standalone = { module = "org.wiremock:wiremock-standalone", version.ref = "wiremock" }
 
 [plugins]
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
Fixes #1414 

I used WireMock to reproduce the issues, it was quite handy, though I’m happy to explore alternatives if you prefer.

I haven’t added assertions on the status description, since different clients throw different exceptions with varying messages.

One concern I have is that catching those exceptions hides the root cause, which can be useful when investigating issues.

Looking forward to your feedback. Thanks! ☺️