### PR TITLE
AWS Xray requires message.type and messaging.message_payload_size_byt…

### DIFF
--- a/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
+++ b/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
@@ -139,8 +139,8 @@ val defaultSpanNamer: (Request) -> String = {
 private fun Span.addStandardDataFrom(resp: Response, req: Request) {
     resp.body.length?.also {
         setAttribute(HTTP_RESPONSE_BODY_SIZE, it)
-            .setAttribute("message.type", "RECEIVED")
-            .setAttribute("messaging.message_payload_size_bytes", it)
+        setAttribute("message.type", "RECEIVED")
+        setAttribute("messaging.message_payload_size_bytes", it)
     }
     req.body.length?.also { setAttribute(HTTP_REQUEST_BODY_SIZE, it) }
     setAttribute("http.status_code", resp.status.code.toLong())


### PR DESCRIPTION
Currently response content length is not reported in AWS Xray. According to https://aws-otel.github.io/docs/getting-started/x-ray: 

> If message.type attribute key exists and value = "RECEIVED" then http.content_length is set to messaging.message_payload_size_bytes if it is set; otherwise http.content_length is set to 0. 

This pull request sets message.type and messaging.message_payload_size_bytes attributes which fixes reporting of response content length in AWS Xray.