### PR TITLE
AWS Xray requires open telemetry http.user_agent and http.client_ip attributes

### DIFF
--- a/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
+++ b/core/ops/opentelemetry/src/main/kotlin/org/http4k/filter/tracingFiltersOpenTelemetryExtensions.kt
@@ -96,6 +96,9 @@ fun ServerFilters.OpenTelemetryTracing(
 
                         setAttribute("http.method", req.method.name)
                         setAttribute("http.url", req.uri.toString())
+
+                        req.header("User-Agent")?.also { setAttribute("http.user_agent", it) }
+                        req.remoteAddress()?.also { setAttribute("http.client_ip", it) }
                 }
                 .let { spanCreationMutator(it, req) }
                 .startSpan()) {
@@ -149,4 +152,7 @@ private fun Span.addStandardDataFrom(resp: Response, req: Request) {
     req.body.length?.also { setAttribute(HTTP_REQUEST_BODY_SIZE, it) }
     setAttribute("http.status_code", resp.status.code.toLong())
 }
+
+private fun Request.remoteAddress(): String? =
+    header("X-Forwarded-For")?.split(",")?.firstOrNull() ?: source?.address
 


### PR DESCRIPTION
Currently user agent and client ip are not reported in AWS Xray. This PR sets http.user_agent and http.client_ip as per https://aws-otel.github.io/docs/getting-started/x-ray