### PR TITLE
Add `Body.text` property for getting the string representation of a body

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/core/http.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/http.kt
@@ -66,10 +66,14 @@ fun Body.hasContentToRead() = stream.read(ByteArray(0)) > -1
  * Represents a body that is backed by an in-memory ByteBuffer. Closing this has no effect.
  **/
 data class MemoryBody(override val payload: ByteBuffer) : Body {
-    constructor(payload: String) : this(payload.asByteBuffer())
+    private var _text: String? = null
+
+    constructor(payload: String) : this(payload.asByteBuffer()) {
+        _text = payload
+    }
     constructor(payload: ByteArray) : this(ByteBuffer.wrap(payload))
 
-    override val text: String by lazy { payload.asString() }
+    override val text: String by lazy { _text ?: payload.asString() }
 
     override val length get() = payload.length().toLong()
     override fun close() {}

--- a/core/core/src/main/kotlin/org/http4k/core/http.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/http.kt
@@ -66,14 +66,10 @@ fun Body.hasContentToRead() = stream.read(ByteArray(0)) > -1
  * Represents a body that is backed by an in-memory ByteBuffer. Closing this has no effect.
  **/
 data class MemoryBody(override val payload: ByteBuffer) : Body {
-    private var _text: String? = null
-
-    constructor(payload: String) : this(payload.asByteBuffer()) {
-        _text = payload
-    }
+    constructor(payload: String) : this(payload.asByteBuffer())
     constructor(payload: ByteArray) : this(ByteBuffer.wrap(payload))
 
-    override val text: String by lazy { _text ?: payload.asString() }
+    override val text: String by lazy { payload.asString() }
 
     override val length get() = payload.length().toLong()
     override fun close() {}

--- a/core/core/src/test/kotlin/org/http4k/core/BodyTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/BodyTest.kt
@@ -134,10 +134,13 @@ class BodyTest {
     }
 
     @Test
-    fun `body initialized with string returns same instance as text`() {
+    fun `body initialized with string memoizes text`() {
         val bodyString = "abc"
         val body = Body(bodyString)
-        assertThat("body text", body.text, sameInstance(bodyString))
+        val text1 = body.text
+        val text2 = body.text
+        assertThat("body text is equal", text1, equalTo(bodyString))
+        assertThat("text is memoized", text1, sameInstance(text2))
     }
 
     @Test

--- a/core/core/src/test/kotlin/org/http4k/core/BodyTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/BodyTest.kt
@@ -2,6 +2,7 @@ package org.http4k.core
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.sameInstance
 import org.http4k.core.Method.GET
 import org.http4k.core.Status.Companion.OK
 import org.junit.jupiter.api.Test
@@ -107,6 +108,45 @@ class BodyTest {
         val body = Body(ByteBuffer.wrap(bytes, 2, 4))
 
         assertThat("body to string", body.toString(), equalTo("cdef"))
+    }
+
+    @Test
+    fun `text converts body to string`() {
+        val bytes = "abc".toByteArray(Charsets.UTF_8)
+        val body = Body(ByteBuffer.wrap(bytes))
+        assertThat("body text", body.text, equalTo("abc"))
+    }
+
+    @Test
+    fun `body text is memoized after first call`() {
+        val bytes = "abc".toByteArray(Charsets.UTF_8)
+
+        // Both MemoryBody and StreamBody implement text memoization, so we test both here
+        val memoryBody = MemoryBody(bytes)
+        val text1 = memoryBody.text
+        val text2 = memoryBody.text
+        assertThat("memory body text", text2, sameInstance(text1))
+
+        val streamBody = StreamBody(ByteArrayInputStream(bytes))
+        val text3 = streamBody.text
+        val text4 = streamBody.text
+        assertThat("stream body text", text4, sameInstance(text3))
+    }
+
+    @Test
+    fun `body initialized with string returns same instance as text`() {
+        val bodyString = "abc"
+        val body = Body(bodyString)
+        assertThat("body text", body.text, sameInstance(bodyString))
+    }
+
+    @Test
+    fun `bodyString on HttpMessage uses same memoization as body text`() {
+        val bytes = "abc".toByteArray()
+        val response = Response(OK).body(Body(ByteBuffer.wrap(bytes)))
+        val bodyString1 = response.bodyString()
+        val bodyString2 = response.bodyString()
+        assertThat("body string", bodyString2, sameInstance(bodyString1))
     }
 
     @Test


### PR DESCRIPTION
- Add `text` property to the `Body` interface, with a default implementation for backwards compatibility
- Change `HttpMessage.bodyString()` to call `body.text`
- Override `text` in `MemoryBody` and `StreamBody` to memoize the first result of calling it, to avoid the body being copied on each call

This resolves issue #1426.

`BodyTest` has been expanded to cover the new API surface, and test that memoization works as expected.

I've tried to keep the code style of my implementation the same as what I've seen elsewhere in http4k, but let me know if you'd like me to do things differently.

I made `text` a property instead of a method, because you seemed to want that [in your comment on my issue](https://github.com/http4k/http4k/issues/1426#issuecomment-3473911653).