### PR TITLE
Client metrics "path" dimension was  always set to UNMAPPED

### DIFF
--- a/core/ops/core/src/main/kotlin/org/http4k/metrics/MetricsDefaults.kt
+++ b/core/ops/core/src/main/kotlin/org/http4k/metrics/MetricsDefaults.kt
@@ -36,7 +36,7 @@ data class MetricsDefaults(
                     "method" to it.request.method.toString(),
                     "status" to it.response.status.code.toString(),
                     "host" to it.request.uri.host.replace('.', '_'),
-                    "path" to it.routingGroup.replace('/', '_').replaceRegexes().replace('.', '_')
+                    "path" to it.request.uri.path.trimStart('/').replace('/', '_').replaceRegexes().replace('.', '_')
                         .replace(notAlphaNumUnderscore, "")
                 )
             )


### PR DESCRIPTION
Client metrics filter is currently setting path dimension from routingGroup, just like the server filter. However, that results to path dimension being set to UNMAPPED for client metrics. I think path dimension for client should be set from uri.path