### PR TITLE
Check also for empty string in honeycomb test reporting setup

### DIFF
--- a/core/core/src/testFixtures/kotlin/org/http4k/junit/OpenTracingTestReporting.kt
+++ b/core/core/src/testFixtures/kotlin/org/http4k/junit/OpenTracingTestReporting.kt
@@ -24,7 +24,7 @@ class OpenTracingTestReporting : TestExecutionListener {
     init {
         val honeycombApiKey = System.getenv("HONEYCOMB_API_KEY")
 
-        if (honeycombApiKey == null) {
+        if (honeycombApiKey == null || honeycombApiKey.isEmpty()) {
             openTelemetry = null
         } else {
             val resource = Resource.getDefault()


### PR DESCRIPTION
 
doing this in whatever.yml

```
      env:
        HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
```

sets the api key to "" (empty string), not unset. so the telemetry is being initialised with empty api key, in forks.