### PR TITLE
fallback to the actual size of data, if content-length is not set.

### DIFF
--- a/core/multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
+++ b/core/multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
@@ -162,7 +162,7 @@ data class MultipartFormBody private constructor(
                         it.fileName!!,
                         ContentType(it.contentType!!, TEXT_HTML.directives),
                         it.newInputStream,
-                        it.headers.mapKeys { it.key.lowercase() }["content-length"]?.toLongOrNull(),
+                        it.headers.mapKeys { it.key.lowercase() }["content-length"]?.toLongOrNull() ?: it.length.toLong(),
                         it,
                     )
                 )


### PR DESCRIPTION
clients do not always provide `content-length` for individual parts (neither Firefox, nor Postman did, when i tried out).