### PR TITLE
Fix build for Windows

### DIFF
--- a/gradle/gradle-plugins/gradle/libs.versions.toml
+++ b/gradle/gradle-plugins/gradle/libs.versions.toml
@@ -1,1 +1,0 @@
-../../libs.versions.toml

--- a/gradle/gradle-plugins/settings.gradle.kts
+++ b/gradle/gradle-plugins/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../../gradle/libs.versions.toml"))
+        }
+    }
+}


### PR DESCRIPTION
The TOML symlink won't work outside UNIX.  Configuring the build module to use the root version catalog via Gradle settings is a more cross-platform solution.