### PR TITLE
Add button/interactive element support to Slack Block Kit

### DIFF
--- a/connect/slack/client/src/main/kotlin/org/http4k/connect/slack/model/SlackMessage.kt
+++ b/connect/slack/client/src/main/kotlin/org/http4k/connect/slack/model/SlackMessage.kt
@@ -33,14 +33,33 @@ enum class TextType {
 }
 
 @JsonSerializable
-data class Text(val text: String, val type: TextType)
+data class Text(val text: String, val type: TextType, val emoji: Boolean? = null)
 
 enum class BlockType {
-    section, header, divider
+    section, header, divider, actions
 }
+
+enum class BlockElementType {
+    button
+}
+
+@JsonSerializable
+data class BlockElement(
+    val type: BlockElementType,
+    val text: Text,
+    val url: String? = null,
+    val action_id: String? = null,
+    val style: String? = null,
+)
 
 @JsonSerializable
 data class Attachment(val text: String, val fallback: String, val color: String)
 
 @JsonSerializable
-data class Block(val text: Text? = null, val fields: List<Text>? = null, val type: BlockType = header, val expand: Boolean? = null)
+data class Block(
+    val text: Text? = null,
+    val fields: List<Text>? = null,
+    val type: BlockType = header,
+    val expand: Boolean? = null,
+    val elements: List<BlockElement>? = null
+)


### PR DESCRIPTION
Extends the existing Block Kit support with:
- BlockElementType enum (button)
- BlockElement data class for interactive elements
- elements field in Block for action blocks
- actions value in BlockType enum
- emoji field in Text for button text formatting


Example: 
<img width="201" height="39" alt="image" src="https://github.com/user-attachments/assets/d687cde0-31e8-4ef2-937f-7d978c4774fb" />
