### PR TITLE
feat(datastar): only include useViewTransition and mode fields in events if values are overridden

### DIFF
--- a/core/web/datastar/src/main/kotlin/org/http4k/datastar/DatastarEvent.kt
+++ b/core/web/datastar/src/main/kotlin/org/http4k/datastar/DatastarEvent.kt
@@ -24,16 +24,11 @@ sealed class DatastarEvent(val name: String, val data: List<String>, open val id
         override val id: SseEventId? = null,
     ) : DatastarEvent(
         "datastar-patch-elements",
-        run {
-            val nullable = listOfNotNull(
-                selector?.value?.let { "selector $it" },
-            )
-            val other = listOf(
-                "mode $mode",
-                "useViewTransition $useViewTransition"
-            )
-            elements.map { "elements $it" } + nullable + other
-        },
+        elements.map { "elements $it" } + listOfNotNull(
+            selector?.value?.let { "selector $it" },
+            mode.takeIf { it != outer }?.let { "mode $it" },
+            useViewTransition.takeIf { it }?.let { "useViewTransition $it" }
+        ),
         id
     ) {
         constructor(
@@ -81,7 +76,7 @@ sealed class DatastarEvent(val name: String, val data: List<String>, open val id
                 "datastar-patch-elements" -> {
                     PatchElements(
                         data("elements", Element.Companion::of),
-                        data("mode", MorphMode::valueOf).first(),
+                        data("mode", MorphMode::valueOf).firstOrNull() ?: outer,
                         data("selector", Selector.Companion::of).firstOrNull(),
                         data("useViewTransition", String::toBoolean).firstOrNull() ?: false,
                         event.id

--- a/core/web/datastar/src/test/kotlin/org/http4k/datastar/DatastarEventTest.kt
+++ b/core/web/datastar/src/test/kotlin/org/http4k/datastar/DatastarEventTest.kt
@@ -8,13 +8,27 @@ import org.junit.jupiter.api.Test
 class DatastarEventTest {
 
     @Test
-    fun `path element to event`() {
+    fun `patch elements to event`() {
         assertThat(
             DatastarEvent.PatchElements(Element.of("foo"), Element.of("bar")).toSseEvent(),
             equalTo(
                 SseMessage.Event(
                     "datastar-patch-elements",
-                    "elements foo\nelements bar\nmode outer\nuseViewTransition false",
+                    "elements foo\nelements bar",
+                    null
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `only include useViewTransition and mode in event if defaults are overridden`() {
+        assertThat(
+            DatastarEvent.PatchElements(Element.of("foo"), morphMode = MorphMode.replace, useViewTransition = true).toSseEvent(),
+            equalTo(
+                SseMessage.Event(
+                    "datastar-patch-elements",
+                    "elements foo\nmode replace\nuseViewTransition true",
                     null
                 )
             )

--- a/core/web/datastar/src/test/kotlin/org/http4k/lens/DatastarExtensionsTest.kt
+++ b/core/web/datastar/src/test/kotlin/org/http4k/lens/DatastarExtensionsTest.kt
@@ -7,6 +7,7 @@ import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
 import org.http4k.datastar.DatastarEvent.PatchElements
 import org.http4k.datastar.DatastarEvent.PatchSignals
+import org.http4k.datastar.MorphMode.inner
 import org.http4k.datastar.Signal
 import org.http4k.testing.ApprovalTest
 import org.http4k.testing.Approver
@@ -20,6 +21,11 @@ class DatastarExtensionsTest {
     @Test
     fun `can inject a datastar element into a response`(approver: Approver) {
         approver.assertApproved(Response(OK).datastarElements("foo", "bar"))
+    }
+
+    @Test
+    fun `can inject a datastar element with overridden defaults into a response`(approver: Approver) {
+        approver.assertApproved(Response(OK).datastarElements("foo", "bar", morphMode = inner, useViewTransition = true))
     }
 
     @Test

--- a/core/web/datastar/src/test/resources/org/http4k/lens/DatastarExtensionsTest.can inject a datastar element with overridden defaults into a response.approved
+++ b/core/web/datastar/src/test/resources/org/http4k/lens/DatastarExtensionsTest.can inject a datastar element with overridden defaults into a response.approved
@@ -1,3 +1,5 @@
 event: datastar-patch-elements
 data: elements foo
 data: elements bar
+data: mode inner
+data: useViewTransition true


### PR DESCRIPTION
## Description
In a recent conversation with the author of Datastar, it was revealed that sending the default `useViewTransition false` line in a datastar event caused the view transition to be enabled. [A bug report has been created here.](https://github.com/starfederation/datastar/issues/1120) Nevertheless, it's still desirable to avoid sending `useViewTransition` and `mode` if the defaults aren't overridden. 

This PR changes `DatastarEvent` so that these values are only sent if they're not `mode outer` or `useViewTransition false`.