### PR TITLE
Default to application/octet-stream when multipart file part has no Content-Type

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/lens/header.kt
+++ b/core/core/src/main/kotlin/org/http4k/lens/header.kt
@@ -86,7 +86,7 @@ object Header : BiDiLensSpec<HttpMessage, String>(
         with(it.split(";").mapNotNull { it.trim().takeIf(String::isNotEmpty) }) {
             first() to drop(1).map {
                 with(it.split("=")) {
-                    first() to if (size == 1) null else drop(1).joinToString("=")
+                    first() to if (size == 1) null else drop(1).joinToString("=").removeSurrounding("\"")
                 }
             }
         }

--- a/core/core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/lens/HeaderTest.kt
@@ -213,6 +213,8 @@ class HeaderTest {
         assertThat(Header.parseValueAndDirectives("some value; bob   ;bob2=anotherValue   "),
             equalTo("some value" to
                 listOf("bob" to null, "bob2" to "anotherValue")))
+        assertThat(Header.parseValueAndDirectives("multipart/form-data; boundary=\"abc123\""),
+            equalTo("multipart/form-data" to listOf("boundary" to "abc123")))
     }
 
     @Test

--- a/core/multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
+++ b/core/multipart/src/main/kotlin/org/http4k/core/MultipartFormBody.kt
@@ -1,4 +1,5 @@
 package org.http4k.core
+import org.http4k.core.ContentType.Companion.OCTET_STREAM
 
 import org.http4k.core.ContentType.Companion.TEXT_HTML
 import org.http4k.lens.Header.CONTENT_TYPE
@@ -62,7 +63,7 @@ fun HttpMessage.multipartIterator(): Iterator<MultipartEntity> {
             if (it.isFormField) MultipartEntity.Field(it.fieldName!!, it.contentsAsString, it.headers.toList())
             else MultipartEntity.File(
                 it.fieldName!!,
-                MultipartFormFile(it.fileName!!, ContentType(it.contentType!!, TEXT_HTML.directives), it.inputStream),
+                MultipartFormFile(it.fileName!!, it.contentType?.let { ct -> ContentType(ct, TEXT_HTML.directives) } ?: OCTET_STREAM, it.inputStream),
                 it.headers.toList()
             )
         }.iterator()
@@ -160,7 +161,7 @@ data class MultipartFormBody private constructor(
                     it.fieldName!!,
                     MultipartFormFile(
                         it.fileName!!,
-                        ContentType(it.contentType!!, TEXT_HTML.directives),
+                        it.contentType?.let { ct -> ContentType(ct, TEXT_HTML.directives) } ?: OCTET_STREAM,
                         it.newInputStream,
                         it.headers.mapKeys { it.key.lowercase() }["content-length"]?.toLongOrNull() ?: it.length.toLong(),
                         it,


### PR DESCRIPTION
## Summary

- When a multipart file part has no `Content-Type` header, the parser now defaults to `application/octet-stream` instead of throwing a NullPointerException
- Fix applied to both the streaming (`multipartIterator()`) and buffered (`MultipartFormBody.from()`) parsing paths
- Added tests for both code paths

Fixes #1486