### PR TITLE
`ContractRouteMatcher` doesn't consider routers added with `withRoute…

### DIFF
--- a/core/api/openapi/src/main/kotlin/org/http4k/contract/ContractRouteMatcher.kt
+++ b/core/api/openapi/src/main/kotlin/org/http4k/contract/ContractRouteMatcher.kt
@@ -20,6 +20,7 @@ import org.http4k.routing.RouteMatcher
 import org.http4k.routing.Router
 import org.http4k.routing.RouterDescription.Companion.unavailable
 import org.http4k.routing.RoutingMatch
+import org.http4k.routing.RoutingResult
 import org.http4k.routing.and
 import org.http4k.security.NoSecurity.filter
 import org.http4k.security.Security
@@ -64,6 +65,10 @@ data class ContractRouteMatcher(
 
     private fun internalMatch(request: Request): ContractRouterMatch {
         val unmatched: ContractRouterMatch = Unmatched
+
+        if (router(request) is RoutingResult.NotMatched) {
+            return unmatched
+        }
 
         return if (request.isIn(contractRoot)) {
             routers.fold(unmatched) { memo, (routeFilter, router) ->

--- a/core/api/openapi/src/test/kotlin/org/http4k/contract/ContractRouteMatcherTest.kt
+++ b/core/api/openapi/src/test/kotlin/org/http4k/contract/ContractRouteMatcherTest.kt
@@ -36,6 +36,7 @@ import org.http4k.lens.Query
 import org.http4k.lens.int
 import org.http4k.routing.ResponseWithContext
 import org.http4k.routing.bind
+import org.http4k.routing.reverseProxy
 import org.http4k.routing.routes
 import org.http4k.security.ApiKeySecurity
 import org.http4k.security.BasicAuthSecurity
@@ -90,6 +91,19 @@ class ContractRouteMatcherTest {
                 )
             )
         assertThat(app(Request(GET, "/hello/there$validPath")), hasStatus(OK))
+    }
+
+    @Test
+    fun `can bind under reverse proxy`() {
+        val app = reverseProxy(
+            "host" to contract {
+                renderer = SimpleJson(Jackson)
+                routes += validPath bindContract GET to { _ -> Response(OK) }
+            }
+        )
+
+        assertThat(app(Request(GET, "http://host$validPath")), hasStatus(OK))
+        assertThat(app(Request(GET, "http://anotherHost$validPath")), hasStatus(NOT_FOUND))
     }
 
     @Test


### PR DESCRIPTION
…r()`

`ContractRouterMatcher.withRouter()` updates the private `router` field, but it isn't considered in `match()`. 