### PR TITLE
Add support for configuring ReturnResponse chaos behaviour remotely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ changes with their rationale when appropriate:
 
 ### v6.43.0.1 (uncut)
 - **http4k-ai-mcp-sdk**: [Fix] X402 and MPP payment filters fail with correct error message.
+- **http4k-testing-chaos**: Add `ReturnResponse` behaviour. H/T @jamieredding.
 
 ### v6.43.0.0 
 - **http4k-***: Upgrade versions

--- a/core/testing/chaos/src/main/kotlin/org/http4k/chaos/ChaosBehaviours.kt
+++ b/core/testing/chaos/src/main/kotlin/org/http4k/chaos/ChaosBehaviours.kt
@@ -196,7 +196,7 @@ object ChaosBehaviours {
     object ReturnResponse {
         operator fun invoke(response: Response) = object : Behaviour() {
             override fun invoke(next: HttpHandler): HttpHandler = { response }
-            override fun toString() = "ReturnResponse ($response)"
+            override fun toString() = "ReturnResponse(${response.status.code})"
         }
     }
 

--- a/core/testing/chaos/src/main/kotlin/org/http4k/chaos/ChaosBehaviours.kt
+++ b/core/testing/chaos/src/main/kotlin/org/http4k/chaos/ChaosBehaviours.kt
@@ -234,6 +234,8 @@ internal fun JsonNode.asBehaviour() = when (nonNullable<String>("type")) {
     "overflow" -> StackOverflow()
     "block" -> BlockThread()
     "none" -> None()
+    "response" -> ChaosBehaviours.ReturnResponse(asResponse())
+
     else -> throw IllegalArgumentException("unknown behaviour")
 }
 
@@ -243,4 +245,16 @@ private fun Body.snipTo(limit: Long): Body {
     return Body(object : InputStream() {
         override fun read() = if (left-- > 0) original.read() else -1
     }, limit)
+}
+
+private fun JsonNode.asResponse(): Response {
+    var response = Response(Status(nonNullable("status"), "x-http4k-chaos"))
+    asNullable<Map<String, String>>("headers")?.map { (key, value) -> key to value }?.let {
+        response = response.headers(it)
+    }
+    asNullable<String>("body")?.let {
+        response = response.body(it)
+    }
+
+    return response
 }

--- a/core/testing/chaos/src/test/kotlin/org/http4k/chaos/ChaosBehaviourTests.kt
+++ b/core/testing/chaos/src/test/kotlin/org/http4k/chaos/ChaosBehaviourTests.kt
@@ -122,19 +122,20 @@ class ReturnStatusBehaviourTest : ChaosBehaviourContract() {
 }
 
 class ReturnResponseTest : ChaosBehaviourContract() {
-    private val description = "ReturnResponse (HTTP/1.1 500 x-http4k-chaos\r\nx-name: value\r\nx-other: another-value\r\n\r\na returned body)"
+    private val description = "ReturnResponse(500)"
 
     @Test
     fun `should return response`() {
-        val expected = Response(INTERNAL_SERVER_ERROR.description("x-http4k-chaos"))
-            .body("a returned body")
+        val expected = Response(INTERNAL_SERVER_ERROR)
             .header("x-name", "value")
             .header("x-other", "another-value")
+            .body("a returned body")
+
         val returnResponse = ChaosBehaviours.ReturnResponse(expected)
         assertThat(returnResponse.toString(), equalTo(description))
 
         val injectedResponse = returnResponse.then { response }(request)
-        assertEquals(expected, injectedResponse)
+        assertThat(injectedResponse, equalTo(expected))
     }
 
     @Test
@@ -150,7 +151,7 @@ class ReturnResponseTest : ChaosBehaviourContract() {
     @Test
     fun `deserialises response with minimum JSON`() {
         assertBehaviour("""{"type":"response","status":500}""",
-            "ReturnResponse (HTTP/1.1 500 x-http4k-chaos\r\n\r\n\r\n)",
+            description,
             hasStatus(INTERNAL_SERVER_ERROR.description("x-http4k-chaos"))
                 .and(hasBody(isNullOrBlank)))
     }

--- a/core/testing/chaos/src/test/kotlin/org/http4k/chaos/ChaosBehaviourTests.kt
+++ b/core/testing/chaos/src/test/kotlin/org/http4k/chaos/ChaosBehaviourTests.kt
@@ -3,8 +3,8 @@ package org.http4k.chaos
 import com.natpryce.hamkrest.and
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.isNullOrBlank
 import com.natpryce.hamkrest.matches
-import com.natpryce.hamkrest.startsWith
 import com.natpryce.hamkrest.throws
 import org.http4k.chaos.ChaosBehaviours.KillProcess
 import org.http4k.chaos.ChaosBehaviours.Latency
@@ -122,21 +122,37 @@ class ReturnStatusBehaviourTest : ChaosBehaviourContract() {
 }
 
 class ReturnResponseTest : ChaosBehaviourContract() {
-    private val description = """ReturnResponse (HTTP/1.1 500 Internal Server Error"""
+    private val description = "ReturnResponse (HTTP/1.1 500 x-http4k-chaos\r\nx-name: value\r\nx-other: another-value\r\n\r\na returned body)"
 
     @Test
-    fun `should return response `() {
-        val expected = Response(INTERNAL_SERVER_ERROR)
+    fun `should return response`() {
+        val expected = Response(INTERNAL_SERVER_ERROR.description("x-http4k-chaos"))
+            .body("a returned body")
+            .header("x-name", "value")
+            .header("x-other", "another-value")
         val returnResponse = ChaosBehaviours.ReturnResponse(expected)
-        assertThat(returnResponse.toString(), startsWith(description))
+        assertThat(returnResponse.toString(), equalTo(description))
 
         val injectedResponse = returnResponse.then { response }(request)
         assertEquals(expected, injectedResponse)
     }
 
     @Test
-    @Disabled("not supported remotely")
     override fun `deserialises from JSON`() {
+        assertBehaviour("""{"type":"response","status":500,"body":"a returned body", "headers": {"x-name": "value", "x-other": "another-value"}}""",
+            description,
+            hasStatus(INTERNAL_SERVER_ERROR.description("x-http4k-chaos"))
+                .and(hasBody("a returned body"))
+                .and(hasHeader("x-name", equalTo("value")))
+                .and(hasHeader("x-other", equalTo("another-value"))))
+    }
+
+    @Test
+    fun `deserialises response with minimum JSON`() {
+        assertBehaviour("""{"type":"response","status":500}""",
+            "ReturnResponse (HTTP/1.1 500 x-http4k-chaos\r\n\r\n\r\n)",
+            hasStatus(INTERNAL_SERVER_ERROR.description("x-http4k-chaos"))
+                .and(hasBody(isNullOrBlank)))
     }
 }
 


### PR DESCRIPTION
I'm unclear if this was omitted deliberately, as there was previously a disabled test for this when it was originally implemented.

Couple of notes:
1. I've not set a `x-http4k-chaos` header as the purpose of this is unclear to me. Happy for it to be included but possibly we don't want to just `toString()` the whole `ReturnResponse` into it?
   - I didn't like the idea of only adding the header when deserialising json, and not adding it when the response is provided via kotlin. But also didn't want to overwrite the user requested headers.
3. I've mirrored the json structure to be similar to the `ChaosTriggers.MatchRequest`. This means also not supporting multi-value headers. I don't have a use case for this and likely the trigger format would need to be revisited if we wanted support.