### PR TITLE
Add better support for A2A and MCP in Wiretap Intercept

### DIFF
--- a/core/ops/opentelemetry/src/test/kotlin/org/http4k/filter/OpenTelemetryTracingTest.kt
+++ b/core/ops/opentelemetry/src/test/kotlin/org/http4k/filter/OpenTelemetryTracingTest.kt
@@ -224,7 +224,6 @@ class OpenTelemetryTracingTest {
         app(Request(GET, "http://localhost:8080/foo/bar?a=b"))
 
         with(createdContext!!) {
-            println(attributes.asMap())
             assertThat(name, equalTo("GET http://localhost:8080/foo/bar?a=b"))
             assertThat(attributes.get(stringKey(method)), equalTo("GET"))
             assertThat(attributes.get(stringKey(clientUrl)), equalTo("http://localhost:8080/foo/bar?a=b"))

--- a/core/realtime-core/src/main/kotlin/org/http4k/core/poly.kt
+++ b/core/realtime-core/src/main/kotlin/org/http4k/core/poly.kt
@@ -1,8 +1,6 @@
 package org.http4k.core
 
-import org.http4k.lens.Header
 import org.http4k.sse.SseHandler
-import org.http4k.testing.PolyHandlerTestClient
 import org.http4k.websocket.WsHandler
 
 /**
@@ -23,18 +21,3 @@ fun interface PolyFilter : (PolyHandler) -> PolyHandler {
 fun PolyFilter.then(next: PolyFilter): PolyFilter = PolyFilter { this(next(it)) }
 
 fun PolyFilter.then(next: PolyHandler): PolyHandler = this(next)
-
-fun PolyHandler.toHttpHandler(): HttpHandler {
-    val polyClient = PolyHandlerTestClient(this)
-    return { request ->
-        when {
-            request.header("Accept")?.contains("text/event-stream") == true -> {
-                val sseClient = polyClient.sse(request)
-                Response(sseClient.status)
-                    .with(Header.CONTENT_TYPE of ContentType.TEXT_EVENT_STREAM)
-                    .body(sseClient.received().joinToString("") { it.toMessage() })
-            }
-            else -> polyClient.http(request)
-        }
-    }
-}

--- a/core/realtime-core/src/main/kotlin/org/http4k/core/poly.kt
+++ b/core/realtime-core/src/main/kotlin/org/http4k/core/poly.kt
@@ -1,6 +1,8 @@
 package org.http4k.core
 
+import org.http4k.lens.Header
 import org.http4k.sse.SseHandler
+import org.http4k.testing.PolyHandlerTestClient
 import org.http4k.websocket.WsHandler
 
 /**
@@ -21,3 +23,18 @@ fun interface PolyFilter : (PolyHandler) -> PolyHandler {
 fun PolyFilter.then(next: PolyFilter): PolyFilter = PolyFilter { this(next(it)) }
 
 fun PolyFilter.then(next: PolyHandler): PolyHandler = this(next)
+
+fun PolyHandler.toHttpHandler(): HttpHandler {
+    val polyClient = PolyHandlerTestClient(this)
+    return { request ->
+        when {
+            request.header("Accept")?.contains("text/event-stream") == true -> {
+                val sseClient = polyClient.sse(request)
+                Response(sseClient.status)
+                    .with(Header.CONTENT_TYPE of ContentType.TEXT_EVENT_STREAM)
+                    .body(sseClient.received().joinToString("") { it.toMessage() })
+            }
+            else -> polyClient.http(request)
+        }
+    }
+}

--- a/core/realtime-core/src/main/kotlin/org/http4k/sse/chunkedSseSequence.kt
+++ b/core/realtime-core/src/main/kotlin/org/http4k/sse/chunkedSseSequence.kt
@@ -27,7 +27,7 @@ fun InputStream.chunkedSseSequence(): Sequence<SseMessage> = sequence {
                     is AfterCRLF -> state.buffer
                     is ConsumingTrailingLineBreak -> null // No buffer to emit
                 }
-                if (finalBuffer != null && finalBuffer.isNotEmpty()) {
+                if (!finalBuffer.isNullOrEmpty()) {
                     val content = finalBuffer.toString().trim()
                     if (content.isNotEmpty()) {
                         try {

--- a/core/realtime-core/src/main/kotlin/org/http4k/testing/PolyHandlerTestClient.kt
+++ b/core/realtime-core/src/main/kotlin/org/http4k/testing/PolyHandlerTestClient.kt
@@ -4,12 +4,8 @@ import org.http4k.core.ContentType
 import org.http4k.core.HttpHandler
 import org.http4k.core.PolyHandler
 import org.http4k.core.Request
-import org.http4k.core.Response
 import org.http4k.core.with
 import org.http4k.lens.Header
-import java.io.PipedInputStream
-import java.io.PipedOutputStream
-import kotlin.concurrent.thread
 
 /**
  * This class is a test client for a [PolyHandler] which allows the invocation of the underlying handlers.
@@ -41,19 +37,9 @@ fun PolyHandler.toHttpHandler(): HttpHandler {
     return { request ->
         if (request.header("Accept")?.contains("text/event-stream") == true) {
             val sseClient = polyClient.sse(request)
-            val pipedIn = PipedInputStream()
-            val pipedOut = PipedOutputStream(pipedIn)
-            thread(isDaemon = true) {
-                try {
-                    sseClient.received().forEach { pipedOut.write(it.toMessage().toByteArray()) }
-                } catch (_: Exception) {
-                } finally {
-                    pipedOut.close()
-                }
-            }
-            Response(sseClient.status)
+            sseClient.response
                 .with(Header.CONTENT_TYPE of ContentType.TEXT_EVENT_STREAM)
-                .body(pipedIn)
+                .body(sseClient.received().joinToString("") { it.toMessage() })
         } else {
             polyClient.http(request)
         }

--- a/core/realtime-core/src/main/kotlin/org/http4k/testing/PolyHandlerTestClient.kt
+++ b/core/realtime-core/src/main/kotlin/org/http4k/testing/PolyHandlerTestClient.kt
@@ -1,7 +1,15 @@
 package org.http4k.testing
 
+import org.http4k.core.ContentType
+import org.http4k.core.HttpHandler
 import org.http4k.core.PolyHandler
 import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.with
+import org.http4k.lens.Header
+import java.io.PipedInputStream
+import java.io.PipedOutputStream
+import kotlin.concurrent.thread
 
 /**
  * This class is a test client for a [PolyHandler] which allows the invocation of the underlying handlers.
@@ -22,4 +30,32 @@ class PolyHandlerTestClient(private val poly: PolyHandler) {
      * Invoke the Server-Sent Events handler of the [PolyHandler] with the given [Request].
      */
     fun sse(request: Request) = poly.sse?.testSseClient(request) ?: error("sse not implemented")
+}
+
+/**
+ * Converts a [PolyHandler] into an [HttpHandler] for testing, dispatching SSE requests
+ * to the SSE handler (via piped streams) and all other requests to the HTTP handler.
+ */
+fun PolyHandler.toHttpHandler(): HttpHandler {
+    val polyClient = PolyHandlerTestClient(this)
+    return { request ->
+        if (request.header("Accept")?.contains("text/event-stream") == true) {
+            val sseClient = polyClient.sse(request)
+            val pipedIn = PipedInputStream()
+            val pipedOut = PipedOutputStream(pipedIn)
+            thread(isDaemon = true) {
+                try {
+                    sseClient.received().forEach { pipedOut.write(it.toMessage().toByteArray()) }
+                } catch (_: Exception) {
+                } finally {
+                    pipedOut.close()
+                }
+            }
+            Response(sseClient.status)
+                .with(Header.CONTENT_TYPE of ContentType.TEXT_EVENT_STREAM)
+                .body(pipedIn)
+        } else {
+            polyClient.http(request)
+        }
+    }
 }

--- a/pro/ai/a2a/client/src/main/kotlin/org/http4k/ai/a2a/client/HttpA2AClient.kt
+++ b/pro/ai/a2a/client/src/main/kotlin/org/http4k/ai/a2a/client/HttpA2AClient.kt
@@ -9,23 +9,23 @@ import dev.forkhandles.result4k.Success
 import dev.forkhandles.result4k.map
 import org.http4k.ai.a2a.A2AError
 import org.http4k.ai.a2a.A2AResult
-import org.http4k.ai.a2a.model.MessageResponse
 import org.http4k.ai.a2a.model.AgentCard
+import org.http4k.ai.a2a.model.AuthenticationInfo
 import org.http4k.ai.a2a.model.ContextId
 import org.http4k.ai.a2a.model.Message
+import org.http4k.ai.a2a.model.MessageResponse
 import org.http4k.ai.a2a.model.PageToken
-import org.http4k.ai.a2a.model.ResponseStream
-import org.http4k.ai.a2a.protocol.ProtocolVersion
-import org.http4k.ai.a2a.protocol.ProtocolVersion.Companion.LATEST_VERSION
-import org.http4k.ai.a2a.model.AuthenticationInfo
 import org.http4k.ai.a2a.model.PushNotificationConfigId
+import org.http4k.ai.a2a.model.ResponseStream
+import org.http4k.ai.a2a.model.StreamItem
 import org.http4k.ai.a2a.model.Task
 import org.http4k.ai.a2a.model.TaskId
 import org.http4k.ai.a2a.model.TaskPage
 import org.http4k.ai.a2a.model.TaskPushNotificationConfig
-import org.http4k.ai.a2a.model.StreamItem
 import org.http4k.ai.a2a.model.TaskState
 import org.http4k.ai.a2a.model.Tenant
+import org.http4k.ai.a2a.protocol.ProtocolVersion
+import org.http4k.ai.a2a.protocol.ProtocolVersion.Companion.LATEST_VERSION
 import org.http4k.ai.a2a.protocol.messages.A2AAgentCard
 import org.http4k.ai.a2a.protocol.messages.A2AJsonRpcRequest
 import org.http4k.ai.a2a.protocol.messages.A2AMessage
@@ -33,15 +33,12 @@ import org.http4k.ai.a2a.protocol.messages.A2APushNotificationConfig
 import org.http4k.ai.a2a.protocol.messages.A2ATask
 import org.http4k.ai.a2a.protocol.messages.SendMessageConfiguration
 import org.http4k.ai.a2a.util.A2AJson
-import org.http4k.ai.a2a.util.A2AJson.auto
 import org.http4k.ai.a2a.util.A2AJson.json
-import org.http4k.ai.a2a.util.A2ANodeType
 import org.http4k.client.JavaHttpClient
 import org.http4k.core.Accept
-import org.http4k.core.Body
 import org.http4k.core.BodyMode.Stream
-import org.http4k.core.Filter
 import org.http4k.core.ContentType
+import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -59,8 +56,6 @@ import org.http4k.sse.SseMessage
 import org.http4k.sse.chunkedSseSequence
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicLong
-
-private val jsonRpcRequestLens = Body.auto<A2ANodeType>().toLens()
 
 class HttpA2AClient(
     private val baseUri: Uri,
@@ -93,27 +88,19 @@ class HttpA2AClient(
         sendRpc<MoshiNode>(A2AMessage.Send.Request(A2AMessage.Send.Request.Params(message, configuration, metadata, tenant = tenant), nextId()))
             .map { parseSendResponse(it as MoshiObject) }
 
-    override fun messageStream(message: Message, configuration: SendMessageConfiguration?, metadata: Map<String, Any>?): A2AResult<MessageResponse> {
-        val request = A2AMessage.Stream.Request(A2AMessage.Stream.Request.Params(message, configuration, metadata, tenant = tenant), nextId())
-
-        val response = client(
-            Request(POST, baseUri.path)
-                .with(jsonRpcRequestLens of A2AJson.asJsonObject(request))
-                .with(Header.ACCEPT of Accept(listOf(QualifiedContent(ContentType.TEXT_EVENT_STREAM))))
-        )
-
-        return when {
-            response.status.successful ->
-                Success(
-                    ResponseStream(
-                        response.body.stream.chunkedSseSequence()
-                            .filterIsInstance<SseMessage.Data>()
-                            .map { A2AJson.asA<StreamItem>(it.data) }
-                    ))
-
-            else -> Failure(A2AError.Http(response))
-        }
-    }
+    override fun messageStream(
+        message: Message,
+        configuration: SendMessageConfiguration?,
+        metadata: Map<String, Any>?
+    ) =
+        A2AMessage.Stream.Request(
+            A2AMessage.Stream.Request.Params(
+                message,
+                configuration,
+                metadata,
+                tenant = tenant
+            ), nextId()
+        ).sendAndStreamResponse()
 
     override fun tasks() = httpTasks
 
@@ -129,24 +116,12 @@ class HttpA2AClient(
             sendRpc<A2ATask.Get.Response.Result>(A2ATask.Get.Request(A2ATask.Get.Request.Params(taskId, historyLength, tenant = tenant), nextId()))
                 .map { it.task }
 
-        override fun subscribe(taskId: TaskId): A2AResult<MessageResponse> {
-            val request = A2ATask.Resubscribe.Request(A2ATask.Resubscribe.Request.Params(taskId, tenant = tenant), nextId())
-            val response = client(
-                Request(POST, baseUri.path)
-                    .with(jsonRpcRequestLens of A2AJson.asJsonObject(request))
-                    .with(Header.ACCEPT of Accept(listOf(QualifiedContent(ContentType.TEXT_EVENT_STREAM))))
-            )
-            return when {
-                response.status.successful ->
-                    Success(
-                        ResponseStream(
-                            response.body.stream.chunkedSseSequence()
-                                .filterIsInstance<SseMessage.Data>()
-                                .map { A2AJson.asA<StreamItem>(it.data) }
-                        ))
-                else -> Failure(A2AError.Http(response))
-            }
-        }
+        override fun subscribe(taskId: TaskId) = A2ATask.Resubscribe.Request(
+            A2ATask.Resubscribe.Request.Params(
+                taskId,
+                tenant = tenant
+            ), nextId()
+        ).sendAndStreamResponse()
 
         override fun cancel(taskId: TaskId, metadata: Map<String, Any>?) =
             sendRpc<A2ATask.Cancel.Response.Result>(A2ATask.Cancel.Request(A2ATask.Cancel.Request.Params(taskId, metadata, tenant = tenant), nextId()))
@@ -174,7 +149,7 @@ class HttpA2AClient(
     }
 
     private inline fun <reified T : Any> sendRpc(request: A2AJsonRpcRequest): A2AResult<T> {
-        val response = client(Request(POST, baseUri.path).json(A2AJson.asJsonObject(request)))
+        val response = client(Request(POST, baseUri.path).json(request))
         val fields = A2AJson.fields(A2AJson.parse(response.bodyString()) as MoshiObject).toMap()
 
         return when {
@@ -187,6 +162,26 @@ class HttpA2AClient(
         val fields = A2AJson.fields(errorNode).toMap()
         val code = (fields["code"] as? Number)?.toInt() ?: -1
         return ErrorMessage(code, fields["message"]?.toString() ?: "Unknown error")
+    }
+
+    private fun A2AJsonRpcRequest.sendAndStreamResponse(): A2AResult<MessageResponse> {
+        val response = client(
+            Request(POST, baseUri.path)
+                .json(this)
+                .with(Header.ACCEPT of Accept(listOf(QualifiedContent(ContentType.TEXT_EVENT_STREAM))))
+        )
+        return when {
+            response.status.successful ->
+                Success(
+                    ResponseStream(
+                        response.body.stream.chunkedSseSequence()
+                            .filterIsInstance<SseMessage.Data>()
+                            .map { A2AJson.asA<StreamItem>(it.data) }
+                    )
+                )
+
+            else -> Failure(A2AError.Http(response))
+        }
     }
 
     override fun close() {}

--- a/pro/ai/a2a/client/src/main/kotlin/org/http4k/ai/a2a/client/testClients.kt
+++ b/pro/ai/a2a/client/src/main/kotlin/org/http4k/ai/a2a/client/testClients.kt
@@ -6,7 +6,7 @@ package org.http4k.ai.a2a.client
 
 import org.http4k.core.PolyHandler
 import org.http4k.core.Uri
-import org.http4k.core.toHttpHandler
+import org.http4k.testing.toHttpHandler
 
 /**
  * Create a test A2A JSON-RPC client from a PolyHandler, dispatching SSE requests

--- a/pro/ai/a2a/client/src/main/kotlin/org/http4k/ai/a2a/client/testClients.kt
+++ b/pro/ai/a2a/client/src/main/kotlin/org/http4k/ai/a2a/client/testClients.kt
@@ -4,15 +4,33 @@
  */
 package org.http4k.ai.a2a.client
 
+import org.http4k.core.ContentType
 import org.http4k.core.PolyHandler
+import org.http4k.core.Response
 import org.http4k.core.Uri
+import org.http4k.testing.PolyHandlerTestClient
 
 /**
- * Create a test A2A client from an PolyHandler.
+ * Create a test A2A JSON-RPC client from a PolyHandler, dispatching SSE requests
+ * to the SSE handler and all other requests to the HTTP handler.
  */
-fun PolyHandler.testA2AJsonRpcClient(baseUri: Uri = Uri.of("")): A2AClient = HttpA2AClient(baseUri, http!!)
+fun PolyHandler.testA2AJsonRpcClient(baseUri: Uri = Uri.of("")): A2AClient {
+    val polyClient = PolyHandlerTestClient(this)
+
+    return HttpA2AClient(baseUri, http = { request ->
+        if (request.header("Accept")?.contains("text/event-stream") == true) {
+            val sseClient = polyClient.sse(request)
+            val body = sseClient.received().joinToString("") { it.toMessage() }
+            Response(sseClient.status)
+                .header("content-type", ContentType.TEXT_EVENT_STREAM.toHeaderValue())
+                .body(body)
+        } else {
+            polyClient.http(request)
+        }
+    })
+}
 
 /**
- * Create a test A2A client from an PolyHandler.
+ * Create a test A2A REST client from a PolyHandler.
  */
 fun PolyHandler.testA2ARestClient(baseUri: Uri = Uri.of("")): A2AClient = RestA2AClient(baseUri, http!!)

--- a/pro/ai/a2a/client/src/main/kotlin/org/http4k/ai/a2a/client/testClients.kt
+++ b/pro/ai/a2a/client/src/main/kotlin/org/http4k/ai/a2a/client/testClients.kt
@@ -4,33 +4,20 @@
  */
 package org.http4k.ai.a2a.client
 
-import org.http4k.core.ContentType
 import org.http4k.core.PolyHandler
-import org.http4k.core.Response
 import org.http4k.core.Uri
-import org.http4k.testing.PolyHandlerTestClient
+import org.http4k.core.toHttpHandler
 
 /**
  * Create a test A2A JSON-RPC client from a PolyHandler, dispatching SSE requests
  * to the SSE handler and all other requests to the HTTP handler.
  */
-fun PolyHandler.testA2AJsonRpcClient(baseUri: Uri = Uri.of("")): A2AClient {
-    val polyClient = PolyHandlerTestClient(this)
-
-    return HttpA2AClient(baseUri, http = { request ->
-        if (request.header("Accept")?.contains("text/event-stream") == true) {
-            val sseClient = polyClient.sse(request)
-            val body = sseClient.received().joinToString("") { it.toMessage() }
-            Response(sseClient.status)
-                .header("content-type", ContentType.TEXT_EVENT_STREAM.toHeaderValue())
-                .body(body)
-        } else {
-            polyClient.http(request)
-        }
-    })
-}
+fun PolyHandler.testA2AJsonRpcClient(baseUri: Uri = Uri.of("")): A2AClient =
+    HttpA2AClient(baseUri, http = toHttpHandler())
 
 /**
- * Create a test A2A REST client from a PolyHandler.
+ * Create a test A2A REST client from a PolyHandler, dispatching SSE requests
+ * to the SSE handler and all other requests to the HTTP handler.
  */
-fun PolyHandler.testA2ARestClient(baseUri: Uri = Uri.of("")): A2AClient = RestA2AClient(baseUri, http!!)
+fun PolyHandler.testA2ARestClient(baseUri: Uri = Uri.of("")): A2AClient =
+    RestA2AClient(baseUri, http = toHttpHandler())

--- a/pro/ai/a2a/client/src/test/kotlin/org/http4k/ai/a2a/client/HttpA2AClientTest.kt
+++ b/pro/ai/a2a/client/src/test/kotlin/org/http4k/ai/a2a/client/HttpA2AClientTest.kt
@@ -10,8 +10,9 @@ import org.http4k.ai.a2a.server.storage.PushNotificationConfigStorage
 import org.http4k.ai.a2a.server.storage.TaskStorage
 import org.http4k.core.Uri
 import org.http4k.routing.a2aJsonRpc
+import org.http4k.util.PortBasedTest
 
-class HttpA2AClientTest : A2AClientContract() {
+class HttpA2AClientTest : A2AClientContract(), PortBasedTest {
     override fun serverFor(
         cards: AgentCardProvider,
         handler: MessageHandler,

--- a/pro/ai/a2a/client/src/test/kotlin/org/http4k/ai/a2a/client/RestA2AClientTest.kt
+++ b/pro/ai/a2a/client/src/test/kotlin/org/http4k/ai/a2a/client/RestA2AClientTest.kt
@@ -10,8 +10,9 @@ import org.http4k.ai.a2a.server.storage.PushNotificationConfigStorage
 import org.http4k.ai.a2a.server.storage.TaskStorage
 import org.http4k.core.Uri
 import org.http4k.routing.a2aRest
+import org.http4k.util.PortBasedTest
 
-class RestA2AClientTest : A2AClientContract() {
+class RestA2AClientTest : A2AClientContract(), PortBasedTest {
     override fun serverFor(
         cards: AgentCardProvider,
         handler: MessageHandler,

--- a/pro/ai/a2a/client/src/testFixtures/kotlin/org/http4k/ai/a2a/client/A2AClientContract.kt
+++ b/pro/ai/a2a/client/src/testFixtures/kotlin/org/http4k/ai/a2a/client/A2AClientContract.kt
@@ -38,7 +38,7 @@ import org.http4k.server.Helidon
 import org.http4k.server.asServer
 import org.junit.jupiter.api.Test
 
-abstract class A2AClientContract {
+abstract class A2AClientContract{
 
     private var idCounter = 0
     private var msgCounter = 0

--- a/pro/ai/a2a/core/src/main/kotlin/org/http4k/ai/a2a/model/AgentCapabilities.kt
+++ b/pro/ai/a2a/core/src/main/kotlin/org/http4k/ai/a2a/model/AgentCapabilities.kt
@@ -8,8 +8,8 @@ import se.ansman.kotshi.JsonSerializable
 
 @JsonSerializable
 data class AgentCapabilities(
-    val streaming: Boolean? = null,
-    val pushNotifications: Boolean? = null,
-    val extendedAgentCard: Boolean? = null,
+    val streaming: Boolean? = true,
+    val pushNotifications: Boolean? = true,
+    val extendedAgentCard: Boolean? = true,
     val extensions: List<AgentExtension>? = null
 )

--- a/pro/ai/a2a/core/src/test/resources/org/http4k/ai/a2a/model/AgentCardTest.AgentCard roundtrips correctly.approved
+++ b/pro/ai/a2a/core/src/test/resources/org/http4k/ai/a2a/model/AgentCardTest.AgentCard roundtrips correctly.approved
@@ -3,7 +3,9 @@
   "version": "1.0.0",
   "description": "A test agent",
   "capabilities": {
-    "streaming": true
+    "streaming": true,
+    "pushNotifications": true,
+    "extendedAgentCard": true
   },
   "skills": [
     {

--- a/pro/ai/a2a/sdk/src/main/kotlin/org/http4k/ai/a2a/server/A2AProtocolNegotiation.kt
+++ b/pro/ai/a2a/sdk/src/main/kotlin/org/http4k/ai/a2a/server/A2AProtocolNegotiation.kt
@@ -7,7 +7,6 @@ package org.http4k.ai.a2a.server
 import org.http4k.ai.a2a.model.AgentCapabilities
 import org.http4k.ai.a2a.protocol.ProtocolVersion
 import org.http4k.ai.a2a.protocol.ProtocolVersion.Companion.LATEST_VERSION
-import org.http4k.ai.a2a.server.a2aExtensionsHeader
 import org.http4k.core.Filter
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.BAD_REQUEST
@@ -30,8 +29,8 @@ fun A2AProtocolNegotiation(
                 val clientExtensions = a2aExtensionsHeader(request)
 
                 val requiredExtensions = capabilities.extensions
-                    ?.filter { it.required == true }
-                    ?.mapNotNull { it.uri?.toString() }
+                    ?.filter { it.required }
+                    ?.map { it.uri.toString() }
                     ?: emptyList()
 
                 val missingRequired = requiredExtensions.filterNot { it in clientExtensions }

--- a/pro/ai/a2a/sdk/src/main/kotlin/org/http4k/routing/a2aJsonRpc.kt
+++ b/pro/ai/a2a/sdk/src/main/kotlin/org/http4k/routing/a2aJsonRpc.kt
@@ -26,19 +26,17 @@ import org.http4k.ai.a2a.server.storage.PushNotificationConfigStorage
 import org.http4k.ai.a2a.server.storage.TaskStorage
 import org.http4k.ai.a2a.util.A2AJson
 import org.http4k.ai.a2a.util.A2AJson.json
-import org.http4k.core.ContentType
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
 import org.http4k.core.PolyHandler
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.BAD_REQUEST
+import org.http4k.core.Status.Companion.NOT_ACCEPTABLE
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.then
 import org.http4k.filter.ServerFilters.CatchAll
 import org.http4k.filter.ServerFilters.CatchLensFailure
-import org.http4k.lens.contentType
 import org.http4k.protocol.A2A
-import org.http4k.protocol.toSseStream
 import org.http4k.routing.sse.bind
 import org.http4k.sse.SseMessage
 import org.http4k.sse.SseResponse
@@ -90,8 +88,8 @@ fun a2aJsonRpc(a2a: A2A, rpcPath: String = "/"): PolyHandler {
     val sseHandler = rpcPath bind sse(POST to { req ->
         when (val message = runCatching { req.json<A2AJsonRpcRequest>() }.getOrNull()) {
             is A2AMessage.Stream.Request if capabilities.streaming == true -> SseResponse { sse ->
-                val responses = a2a.stream(message.params, req)
-                responses.forEach { sse.send(SseMessage.Data(A2AJson.asJsonString(it, StreamItem::class))) }
+                a2a.stream(message.params, req)
+                    .forEach { sse.send(SseMessage.Data(A2AJson.asJsonString(it, StreamItem::class))) }
                 sse.close()
             }
 
@@ -106,10 +104,7 @@ fun a2aJsonRpc(a2a: A2A, rpcPath: String = "/"): PolyHandler {
     }
     )
 
-    return poly(
-        httpHandler,
-        sseHandler
-    )
+    return poly(httpHandler, sseHandler)
 }
 
 private fun A2A.dispatchJsonRpc(
@@ -128,14 +123,7 @@ private fun A2A.dispatchJsonRpc(
 
         is A2AMessage.Send.Request -> Response(OK).json(send(message.params, httpReq).toSendResponse(message.id))
 
-        is A2AMessage.Stream.Request ->
-            when (capabilities.streaming) {
-                true -> Response(OK)
-                    .contentType(ContentType.TEXT_EVENT_STREAM)
-                    .body(stream(message.params, httpReq).toSseStream())
-
-                else -> Response(OK).json(A2AJsonRpcErrorResponse(message.id, A2AErrors.UnsupportedOperation))
-            }
+        is A2AMessage.Stream.Request -> Response(NOT_ACCEPTABLE)
 
         is A2ATask.Get.Request ->
             getTask(message.params)

--- a/pro/ai/a2a/sdk/src/main/kotlin/org/http4k/wiretap/junit/interceptExtensionsA2a.kt
+++ b/pro/ai/a2a/sdk/src/main/kotlin/org/http4k/wiretap/junit/interceptExtensionsA2a.kt
@@ -10,8 +10,6 @@ import org.http4k.core.Uri
 import org.http4k.core.then
 import org.http4k.filter.OpenTelemetryTracing
 import org.http4k.filter.PolyFilters
-import org.http4k.filter.ServerFilters
-import org.http4k.filter.debug
 import org.http4k.protocol.A2A
 import org.http4k.routing.a2aJsonRpc
 import org.http4k.wiretap.Context

--- a/pro/ai/a2a/sdk/src/main/kotlin/org/http4k/wiretap/junit/interceptExtensionsA2a.kt
+++ b/pro/ai/a2a/sdk/src/main/kotlin/org/http4k/wiretap/junit/interceptExtensionsA2a.kt
@@ -29,5 +29,5 @@ fun Intercept.Companion.a2a(
     baseUrl: Uri = Uri.of(""),
     appFn: Context.() -> A2A
 ) = poly(renderMode, redirectFilter, clock, random, serverName, baseUrl) {
-    PolyFilters.OpenTelemetryTracing().then(a2aJsonRpc(appFn(), baseUrl.path))
+    PolyFilters.OpenTelemetryTracing(otel()).then(a2aJsonRpc(appFn(), baseUrl.path))
 }

--- a/pro/ai/a2a/sdk/src/test/kotlin/org/http4k/wiretap/junit/A2AInterceptTest.kt
+++ b/pro/ai/a2a/sdk/src/test/kotlin/org/http4k/wiretap/junit/A2AInterceptTest.kt
@@ -7,6 +7,7 @@ package org.http4k.wiretap.junit
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import dev.forkhandles.result4k.Success
+import dev.forkhandles.result4k.valueOrNull
 import org.http4k.ai.a2a.client.A2AClient
 import org.http4k.ai.a2a.model.AgentCard
 import org.http4k.ai.a2a.model.Message
@@ -14,6 +15,7 @@ import org.http4k.ai.a2a.model.MessageId
 import org.http4k.ai.a2a.model.Part
 import org.http4k.ai.a2a.model.Version
 import org.http4k.ai.a2a.model.A2ARole
+import org.http4k.ai.a2a.model.ResponseStream
 import org.http4k.core.Uri
 import org.http4k.protocol.A2A
 import org.http4k.wiretap.junit.RenderMode.Always
@@ -28,12 +30,20 @@ class A2AInterceptTest {
 
     @RegisterExtension
     val intercept = Intercept.a2a(Always, baseUrl = url) {
-        A2A(AgentCard("name", version, "desc")) { message }
+        A2A(AgentCard("name", version, "desc")) { ResponseStream(sequenceOf(message, message)) }
     }
 
     @Test
     fun `can pass through an a2a client`(a2AClient: A2AClient) {
         assertThat(a2AClient.agentCard(), equalTo(Success(AgentCard("name", version, "desc"))))
-        assertThat(a2AClient.message(Message(MessageId.of("msg-2"), A2ARole.ROLE_USER, listOf(Part.Text("foo")))), equalTo(Success(message)))
+        val single =
+            a2AClient.message(Message(MessageId.of("msg-2"), A2ARole.ROLE_USER, listOf(Part.Text("foo"))))
+                .valueOrNull()
+        assertThat(single, equalTo(message))
+
+        val stream =
+            a2AClient.messageStream(Message(MessageId.of("msg-2"), A2ARole.ROLE_USER, listOf(Part.Text("foo"))))
+                .valueOrNull()!! as ResponseStream
+        assertThat(stream.toList(), equalTo(listOf(message, message)))
     }
 }

--- a/pro/wiretap/src/examples/kotlin/wiretap/site.kt
+++ b/pro/wiretap/src/examples/kotlin/wiretap/site.kt
@@ -41,7 +41,7 @@ class OtelCaptureTest {
 class TrafficCaptureTest {
     @RegisterExtension
     @JvmField
-    val intercept = Intercept { MyHttp4kApp(http(), otel()) }
+    val intercept = Intercept.http { MyHttp4kApp(http(), otel()) }
 
     @Test
     fun `greets the user`(http: HttpHandler) {

--- a/pro/wiretap/src/main/kotlin/org/http4k/wiretap/domain/TransactionMapping.kt
+++ b/pro/wiretap/src/main/kotlin/org/http4k/wiretap/domain/TransactionMapping.kt
@@ -60,7 +60,7 @@ internal fun WiretapTransaction.toDetail(clock: Clock): TransactionDetail {
 }
 
 internal fun HttpMessage.prettifyBody() =
-    formatBody(bodyString(), contentType()?.value ?: "")
+    formatBody(body.stream.reader().readText(), contentType()?.value ?: "")
 
 internal fun WiretapTransaction.traceparent(): OtelTraceId? =
     (transaction.request.header("traceparent") ?: transaction.response.header("traceparent"))

--- a/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/Intercept.kt
+++ b/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/Intercept.kt
@@ -6,14 +6,16 @@ package org.http4k.wiretap.junit
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import org.http4k.ai.a2a.client.A2AClient
-import org.http4k.ai.a2a.client.HttpA2AClient
+import org.http4k.ai.a2a.client.testA2AJsonRpcClient
 import org.http4k.ai.mcp.client.McpClient
 import org.http4k.ai.mcp.testing.testMcpClient
 import org.http4k.chaos.ChaosEngine
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
+import org.http4k.core.Method.POST
 import org.http4k.core.NoOp
 import org.http4k.core.PolyHandler
+import org.http4k.core.Request
 import org.http4k.core.Uri
 import org.http4k.core.then
 import org.http4k.filter.ResponseFilters
@@ -154,9 +156,9 @@ class Intercept(
     override fun resolveParameter(pc: ParameterContext, ec: ExtensionContext): Any =
         when (pc.parameter.type) {
             ChaosEngine::class.java -> state.get().outboundChaos
-            McpClient::class.java -> state.get().poly.testMcpClient()
-            A2AClient::class.java -> HttpA2AClient(baseUrl, http = state.get().http)
-            else -> state.get().http
+            McpClient::class.java -> state.get().poly.testMcpClient(Request(POST, baseUrl.path("/mcp")))
+            A2AClient::class.java -> state.get().poly.testA2AJsonRpcClient(baseUrl)
+            else -> state.get().poly.toHttpHandler()
         }
 
     override fun beforeTestExecution(context: ExtensionContext) {
@@ -179,7 +181,7 @@ class Intercept(
             .then(ResponseFilters.ReportHttpTransaction(clock) { tx -> transactionStore.record(tx, Inbound) })
         val poly = inboundFilter.then(setup.appFn())
 
-        state.set(TestState(poly.toHttpHandler(), poly, outboundChaos, stdOutCapture, stdErrCapture))
+        state.set(TestState(poly, outboundChaos, stdOutCapture, stdErrCapture))
     }
 
     override fun afterTestExecution(context: ExtensionContext) {
@@ -199,7 +201,7 @@ class Intercept(
         val testClass = context.requiredTestClass
         val testName = "${testClass.simpleName}.${context.requiredTestMethod.name}"
         val packageDir = testClass.packageName.replace('.', '/')
-        val (_, _, stdOutCapture, stdErrCapture) = state.get()
+        val actualState = state.get()
         val fileName = testName.replace(' ', '-')
         val dir = File(reportDir, packageDir).apply { mkdirs() }
 
@@ -215,16 +217,20 @@ class Intercept(
         File(dir, "${fileName}.md").writeText(livingDocRenderer(testName))
 
         val htmlFile = File(dir, "${fileName}.html").apply {
-            writeText(testReportRenderer(testName, stdOutCapture.toString(), stdErrCapture.toString()))
+            writeText(
+                testReportRenderer(
+                    testName,
+                    actualState.stdOutCapture.toString(),
+                    actualState.stdErrCapture.toString()
+                )
+            )
         }
 
         println("Wiretap report: file://${htmlFile.absolutePath}")
         context.publishReportEntry("wiretap", "file://${htmlFile.absolutePath}")
     }
 
-
     private data class TestState(
-        val http: HttpHandler,
         val poly: PolyHandler,
         val outboundChaos: ChaosEngine,
         val stdOutCapture: ByteArrayOutputStream,

--- a/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/Intercept.kt
+++ b/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/Intercept.kt
@@ -69,6 +69,8 @@ class Intercept @JvmOverloads constructor(
     private val appFn: Context.() -> PolyHandler
 ) : ParameterResolver, BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
+    @JvmOverloads constructor(renderMode: RenderMode = OnFailure) : this(renderMode = renderMode, appFn = { PolyHandler(http()) })
+
     companion object {
         /**
          * Intercept a simple HttpHandler.

--- a/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/Intercept.kt
+++ b/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/Intercept.kt
@@ -16,8 +16,8 @@ import org.http4k.core.NoOp
 import org.http4k.core.PolyHandler
 import org.http4k.core.Uri
 import org.http4k.core.then
-import org.http4k.testing.toHttpHandler
 import org.http4k.filter.ResponseFilters
+import org.http4k.testing.toHttpHandler
 import org.http4k.wiretap.Context
 import org.http4k.wiretap.domain.Direction.Inbound
 import org.http4k.wiretap.domain.Direction.Outbound
@@ -53,7 +53,7 @@ enum class RenderMode { Never, OnFailure, Always }
  * Wiretap Intercept is a JUnit Extension that records all traffic and telemetry inside an application
  * in order that it can be visualised post-test.
  */
-class Intercept @JvmOverloads constructor(
+class Intercept(
     private val renderMode: RenderMode = OnFailure,
     private val redirectFilter: Filter = Filter.NoOp,
     private val clock: Clock = Clock.systemUTC(),

--- a/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/Intercept.kt
+++ b/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/Intercept.kt
@@ -8,15 +8,15 @@ import io.opentelemetry.api.GlobalOpenTelemetry
 import org.http4k.ai.a2a.client.A2AClient
 import org.http4k.ai.a2a.client.HttpA2AClient
 import org.http4k.ai.mcp.client.McpClient
-import org.http4k.ai.mcp.client.http.HttpNonStreamingMcpClient
+import org.http4k.ai.mcp.testing.testMcpClient
 import org.http4k.chaos.ChaosEngine
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
 import org.http4k.core.NoOp
 import org.http4k.core.PolyHandler
 import org.http4k.core.Uri
-import org.http4k.core.extend
 import org.http4k.core.then
+import org.http4k.testing.toHttpHandler
 import org.http4k.filter.ResponseFilters
 import org.http4k.wiretap.Context
 import org.http4k.wiretap.domain.Direction.Inbound
@@ -46,7 +46,6 @@ import java.security.SecureRandom
 import java.time.Clock
 import java.util.Random
 import java.util.concurrent.atomic.AtomicReference
-import kotlin.jvm.java
 
 enum class RenderMode { Never, OnFailure, Always }
 
@@ -67,7 +66,7 @@ class Intercept @JvmOverloads constructor(
     private val livingDocsSections: List<LivingDocSection> = defaultLivingDocSections,
     private val traceReportTabs: List<TabContentRenderer> = defaultTraceReportTabs,
     private val reportDir: File = outputDir,
-    private val appFn: Context.() -> HttpHandler
+    private val appFn: Context.() -> PolyHandler
 ) : ParameterResolver, BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
     companion object {
@@ -81,6 +80,12 @@ class Intercept @JvmOverloads constructor(
             random: Random = SecureRandom(byteArrayOf()),
             serverName: String = "http4k-server",
             baseUrl: Uri = Uri.of(""),
+            traceStore: TraceStore = TraceStore.InMemory(),
+            logStore: LogStore = LogStore.InMemory(),
+            transactionStore: TransactionStore = TransactionStore.InMemory(),
+            livingDocsSections: List<LivingDocSection> = defaultLivingDocSections,
+            traceReportTabs: List<TabContentRenderer> = defaultTraceReportTabs,
+            reportDir: File = outputDir,
             appFn: Context.() -> HttpHandler
         ) = Intercept(
             renderMode,
@@ -89,7 +94,13 @@ class Intercept @JvmOverloads constructor(
             random,
             serverName,
             baseUrl,
-            appFn = appFn
+            traceStore,
+            logStore,
+            transactionStore,
+            livingDocsSections,
+            traceReportTabs,
+            reportDir,
+            appFn = { PolyHandler(appFn()) }
         )
 
         /**
@@ -102,6 +113,12 @@ class Intercept @JvmOverloads constructor(
             random: Random = SecureRandom(byteArrayOf()),
             serverName: String = "http4k-server",
             baseUrl: Uri = Uri.of(""),
+            traceStore: TraceStore = TraceStore.InMemory(),
+            logStore: LogStore = LogStore.InMemory(),
+            transactionStore: TransactionStore = TransactionStore.InMemory(),
+            livingDocsSections: List<LivingDocSection> = defaultLivingDocSections,
+            traceReportTabs: List<TabContentRenderer> = defaultTraceReportTabs,
+            reportDir: File = outputDir,
             appFn: Context.() -> PolyHandler
         ) = Intercept(
             renderMode,
@@ -110,10 +127,15 @@ class Intercept @JvmOverloads constructor(
             random,
             serverName,
             baseUrl,
-            appFn = { appFn().http!! })
+            traceStore,
+            logStore,
+            transactionStore,
+            livingDocsSections,
+            traceReportTabs,
+            reportDir,
+            appFn
+        )
     }
-
-    @JvmOverloads constructor(renderMode: RenderMode = OnFailure) : this(renderMode = renderMode, appFn = { http() })
 
     private val state = AtomicReference<TestState>()
 
@@ -130,7 +152,7 @@ class Intercept @JvmOverloads constructor(
     override fun resolveParameter(pc: ParameterContext, ec: ExtensionContext): Any =
         when (pc.parameter.type) {
             ChaosEngine::class.java -> state.get().outboundChaos
-            McpClient::class.java -> HttpNonStreamingMcpClient(baseUrl.extend(Uri.of("/mcp")), http = state.get().http)
+            McpClient::class.java -> state.get().poly.testMcpClient()
             A2AClient::class.java -> HttpA2AClient(baseUrl, http = state.get().http)
             else -> state.get().http
         }
@@ -151,11 +173,11 @@ class Intercept @JvmOverloads constructor(
             .then(outboundChaos)
         val setup = Context(clientFilter, clock, random) { WiretapOpenTelemetry(traceStore, logStore, clock, it) }
 
-        val app = redirectFilter
+        val inboundFilter = redirectFilter
             .then(ResponseFilters.ReportHttpTransaction(clock) { tx -> transactionStore.record(tx, Inbound) })
-            .then(setup.appFn())
+        val poly = inboundFilter.then(setup.appFn())
 
-        state.set(TestState(app, outboundChaos, stdOutCapture, stdErrCapture))
+        state.set(TestState(poly.toHttpHandler(), poly, outboundChaos, stdOutCapture, stdErrCapture))
     }
 
     override fun afterTestExecution(context: ExtensionContext) {
@@ -201,15 +223,14 @@ class Intercept @JvmOverloads constructor(
 
     private data class TestState(
         val http: HttpHandler,
+        val poly: PolyHandler,
         val outboundChaos: ChaosEngine,
         val stdOutCapture: ByteArrayOutputStream,
         val stdErrCapture: ByteArrayOutputStream
     )
 }
 
-private val outputDir by lazy {
-    File("build/reports/http4k/wiretap").apply { mkdirs() }
-}
+val outputDir by lazy { File("build/reports/http4k/wiretap").apply { mkdirs() } }
 
 private class TeeOutputStream(private val primary: OutputStream, private val secondary: OutputStream) : OutputStream() {
     override fun write(b: Int) { primary.write(b); secondary.write(b) }

--- a/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/Intercept.kt
+++ b/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/Intercept.kt
@@ -6,16 +6,14 @@ package org.http4k.wiretap.junit
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import org.http4k.ai.a2a.client.A2AClient
-import org.http4k.ai.a2a.client.testA2AJsonRpcClient
+import org.http4k.ai.a2a.client.HttpA2AClient
 import org.http4k.ai.mcp.client.McpClient
-import org.http4k.ai.mcp.testing.testMcpClient
+import org.http4k.ai.mcp.client.http.HttpNonStreamingMcpClient
 import org.http4k.chaos.ChaosEngine
 import org.http4k.core.Filter
 import org.http4k.core.HttpHandler
-import org.http4k.core.Method.POST
 import org.http4k.core.NoOp
 import org.http4k.core.PolyHandler
-import org.http4k.core.Request
 import org.http4k.core.Uri
 import org.http4k.core.then
 import org.http4k.filter.ResponseFilters
@@ -156,9 +154,9 @@ class Intercept(
     override fun resolveParameter(pc: ParameterContext, ec: ExtensionContext): Any =
         when (pc.parameter.type) {
             ChaosEngine::class.java -> state.get().outboundChaos
-            McpClient::class.java -> state.get().poly.testMcpClient(Request(POST, baseUrl.path("/mcp")))
-            A2AClient::class.java -> state.get().poly.testA2AJsonRpcClient(baseUrl)
-            else -> state.get().poly.toHttpHandler()
+            McpClient::class.java -> HttpNonStreamingMcpClient(baseUrl.path("/mcp"), http = state.get().http)
+            A2AClient::class.java -> HttpA2AClient(baseUrl, http = state.get().http)
+            else -> state.get().http
         }
 
     override fun beforeTestExecution(context: ExtensionContext) {
@@ -179,9 +177,9 @@ class Intercept(
 
         val inboundFilter = redirectFilter
             .then(ResponseFilters.ReportHttpTransaction(clock) { tx -> transactionStore.record(tx, Inbound) })
-        val poly = inboundFilter.then(setup.appFn())
+        val client = inboundFilter.then(setup.appFn().toHttpHandler())
 
-        state.set(TestState(poly, outboundChaos, stdOutCapture, stdErrCapture))
+        state.set(TestState(client, outboundChaos, stdOutCapture, stdErrCapture))
     }
 
     override fun afterTestExecution(context: ExtensionContext) {
@@ -231,10 +229,10 @@ class Intercept(
     }
 
     private data class TestState(
-        val poly: PolyHandler,
+        val http: HttpHandler,
         val outboundChaos: ChaosEngine,
         val stdOutCapture: ByteArrayOutputStream,
-        val stdErrCapture: ByteArrayOutputStream
+        val stdErrCapture: ByteArrayOutputStream,
     )
 }
 

--- a/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/interceptExtensionsMcp.kt
+++ b/pro/wiretap/src/main/kotlin/org/http4k/wiretap/junit/interceptExtensionsMcp.kt
@@ -24,7 +24,15 @@ import org.http4k.filter.ReadResourceDetailSpanModifiers
 import org.http4k.filter.defaultMcpOtelSpanModifiers
 import org.http4k.routing.mcp
 import org.http4k.wiretap.Context
+import org.http4k.wiretap.domain.LogStore
+import org.http4k.wiretap.domain.TraceStore
+import org.http4k.wiretap.domain.TransactionStore
 import org.http4k.wiretap.junit.RenderMode.OnFailure
+import org.http4k.wiretap.livingdoc.LivingDocRenderer.Companion.defaultLivingDocSections
+import org.http4k.wiretap.livingdoc.LivingDocSection
+import org.http4k.wiretap.otel.breakdown.TabContentRenderer
+import org.http4k.wiretap.otel.breakdown.defaultTraceReportTabs
+import java.io.File
 import java.security.SecureRandom
 import java.time.Clock
 import java.util.Random
@@ -39,6 +47,12 @@ fun Intercept.Companion.mcpCapabilities(
     random: Random = SecureRandom(byteArrayOf()),
     serverName: String = "http4k-server",
     baseUrl: Uri = Uri.of(""),
+    traceStore: TraceStore = TraceStore.InMemory(),
+    logStore: LogStore = LogStore.InMemory(),
+    transactionStore: TransactionStore = TransactionStore.InMemory(),
+    livingDocsSections: List<LivingDocSection> = defaultLivingDocSections,
+    traceReportTabs: List<TabContentRenderer> = defaultTraceReportTabs,
+    reportDir: File = outputDir,
     vararg extensions: McpExtension,
     capabilityFn: Context.() -> Iterable<ServerCapability>
 ) = Intercept.poly(
@@ -48,6 +62,12 @@ fun Intercept.Companion.mcpCapabilities(
     random,
     serverName,
     baseUrl,
+    traceStore,
+    logStore,
+    transactionStore,
+    livingDocsSections,
+    traceReportTabs,
+    reportDir,
     appFn = {
         PolyFilters.OpenTelemetryTracing(otel())
             .then(
@@ -74,5 +94,14 @@ fun Intercept.Companion.mcp(
     random: Random = SecureRandom(byteArrayOf()),
     serverName: String = "http4k-server",
     baseUrl: Uri = Uri.of(""),
+    traceStore: TraceStore = TraceStore.InMemory(),
+    logStore: LogStore = LogStore.InMemory(),
+    transactionStore: TransactionStore = TransactionStore.InMemory(),
+    livingDocsSections: List<LivingDocSection> = defaultLivingDocSections,
+    traceReportTabs: List<TabContentRenderer> = defaultTraceReportTabs,
+    reportDir: File = outputDir,
     appFn: Context.() -> PolyHandler
-) = poly(renderMode, redirectFilter, clock, random, serverName, baseUrl, appFn)
+) = poly(
+    renderMode, redirectFilter, clock, random, serverName, baseUrl,
+    traceStore, logStore, transactionStore, livingDocsSections, traceReportTabs, reportDir, appFn
+)

--- a/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/ChaosInterceptTest.kt
+++ b/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/ChaosInterceptTest.kt
@@ -23,7 +23,7 @@ class ChaosInterceptTest {
 
     @RegisterExtension
     @JvmField
-    val intercept = Intercept(Always) {
+    val intercept = Intercept.http(Always) {
         App(http { Response(OK).body("downstream") }, "test app 1", otel("test app 1"))
     }
 

--- a/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/FailureTest.kt
+++ b/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/FailureTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 class FailureTest {
 
     @Test
+    @Disabled
     fun `it fails`() {
         App({ _: Request -> Response(OK) })(Request(Method.GET, ""))
         assertThat(false, equalTo(true));

--- a/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/FailureTest.kt
+++ b/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/FailureTest.kt
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 class FailureTest {
 
     @Test
-    @Disabled
     fun `it fails`() {
         App({ _: Request -> Response(OK) })(Request(Method.GET, ""))
         assertThat(false, equalTo(true));

--- a/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/GenerateInterceptReportsTest.kt
+++ b/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/GenerateInterceptReportsTest.kt
@@ -30,7 +30,7 @@ class GenerateInterceptReportsTest {
 
     @RegisterExtension
     @JvmField
-    val intercept = Intercept(Always, clock = FixedClock, reportDir = reportDir) { { Response(OK).body("hello") } }
+    val intercept = Intercept.http(Always, clock = FixedClock, reportDir = reportDir) { { Response(OK).body("hello") } }
 
     @Test
     fun `generates html`(approver: Approver, http: HttpHandler) {

--- a/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/GlobalOTelInterceptTest.kt
+++ b/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/GlobalOTelInterceptTest.kt
@@ -42,7 +42,7 @@ class GlobalOTelInterceptTest : PortBasedTest {
 
     @RegisterExtension
     @JvmField
-    val intercept = Intercept(renderMode = Always, traceStore = traceStore) { http() }
+    val intercept = Intercept.http(renderMode = Always, traceStore = traceStore) { http() }
 
     @Test
     fun `http traces are captured via GlobalOpenTelemetry without explicit otel wiring`(http: HttpHandler) {

--- a/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/HttpInterceptTest.kt
+++ b/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/HttpInterceptTest.kt
@@ -30,7 +30,7 @@ class HttpInterceptTest {
 
     @RegisterExtension
     @JvmField
-    val intercept = Intercept(Always, traceStore = traceStore, transactionStore = transactionStore) {
+    val intercept = Intercept.http(Always, traceStore = traceStore, transactionStore = transactionStore) {
         val myClient: HttpHandler = { Response(OK).body("downstream") }
         val methodAsFilter: Filter = { http(it) }
         App(methodAsFilter.then(myClient), "test app 1", otel("test app 1"))

--- a/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/MultiAppInterceptTest.kt
+++ b/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/MultiAppInterceptTest.kt
@@ -19,7 +19,7 @@ class MultiAppInterceptTest {
 
     @RegisterExtension
     @JvmField
-    val intercept = Intercept(Always, serverName = "foobar") {
+    val intercept = Intercept.http(Always, serverName = "foobar") {
         App(
             App(http { Response(OK).body("downstream") }, "test app 2", otel("test app 2")),
             "test app 1",

--- a/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/SimpleInterceptTest.kt
+++ b/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/SimpleInterceptTest.kt
@@ -23,7 +23,7 @@ class SimpleInterceptTest {
 
     @RegisterExtension
     @JvmField
-    val intercept = Intercept(Always) { app }
+    val intercept = Intercept.http(Always) { app }
 
     @Test
     fun `requests through httpHandler reach the original app`(http: HttpHandler) {

--- a/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/shared.kt
+++ b/pro/wiretap/src/test/kotlin/org/http4k/wiretap/junit/shared.kt
@@ -57,7 +57,7 @@ fun App(
                         .setAttribute(io.opentelemetry.api.common.AttributeKey.stringKey("log.level"), "INFO")
                         .emit()
                     events(RequestProcessed(req.uri.path, "user-42"))
-                    System.err.println("downstream warning: slow response detected")
+                    println("downstream warning: slow response detected")
 
                     val fetchSpan = tracer.spanBuilder("fetch-downstream").startSpan()
                     val result = fetchSpan.makeCurrent().use {

--- a/pro/wiretap/src/test/kotlin/org/http4k/wiretap/mcp_api/McpPromptContract.kt
+++ b/pro/wiretap/src/test/kotlin/org/http4k/wiretap/mcp_api/McpPromptContract.kt
@@ -41,7 +41,6 @@ interface McpPromptContract {
             )
 
             is Failure<*> -> {
-                println(result)
                 TODO()
             }
         }


### PR DESCRIPTION
Refactored Intercept to use PolyHandler throughout, added toHttpHandler() for SSE-aware test dispatch, and updated A2A/MCP test clients to work in-memory without real servers.