### PR TITLE
Fix for #1533: Aws sig4 path canonicalization needs double encoding 

### DIFF
--- a/core/platform/aws/src/main/kotlin/org/http4k/aws/AwsRequestPreSigner.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/aws/AwsRequestPreSigner.kt
@@ -44,7 +44,7 @@ fun AwsRequestPreSigner(
         }
 
     val canonicalRequest =
-        AwsCanonicalRequest.of(fullRequest, payloadMode(request))
+        AwsCanonicalRequest.of(fullRequest.encodeUri(scope), payloadMode(request))
     val signature = AwsSignatureV4Signer.sign(canonicalRequest, scope, credentials, awsDate)
 
     AwsPreSignedRequest(

--- a/core/platform/aws/src/main/kotlin/org/http4k/aws/requestExtensions.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/aws/requestExtensions.kt
@@ -8,6 +8,9 @@ import org.http4k.urlEncoded
 internal fun Request.encodeUri() =
     uri(uri.encodePathAndFragment())
 
+internal fun Request.encodeUri(scope: AwsCredentialScope) =
+    if (scope.service == "s3") this else encodeUri()
+
 private fun Uri.encodePathAndFragment() = if (fragment.isBlank())
     path(path.urlEncodedPath())
 else

--- a/core/platform/aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
@@ -62,7 +62,7 @@ fun ClientFilters.AwsAuth(
                     } ?: this
                 }
 
-            val canonicalRequest = AwsCanonicalRequest.of(fullRequest, payload)
+            val canonicalRequest = AwsCanonicalRequest.of(fullRequest.encodeUri(scope), payload)
 
             val signedRequest = fullRequest
                 .replaceHeader("Authorization", buildAuthHeader(scope, credentials, canonicalRequest, date))

--- a/core/platform/aws/src/test/kotlin/org/http4k/aws/AwsAuthClientFilterTest.kt
+++ b/core/platform/aws/src/test/kotlin/org/http4k/aws/AwsAuthClientFilterTest.kt
@@ -5,9 +5,11 @@ import com.natpryce.hamkrest.equalTo
 import org.http4k.client.JavaHttpClient
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
+import org.http4k.core.Method.POST
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
+import org.http4k.core.Uri
 import org.http4k.core.then
 import org.http4k.filter.AwsAuth
 import org.http4k.filter.ClientFilters
@@ -91,6 +93,45 @@ class AwsClientFilterTest: PortBasedTest {
         assertThat(
             audit.captured?.header("x-amz-content-sha256"),
             equalTo("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")
+        )
+    }
+
+
+    @Test
+    fun `path canonicalization for lambda service`() {
+
+        val scope = AwsCredentialScope("eu-west", "lambda")
+
+        val client = ClientFilters.AwsAuth(scope, credentials, clock).then(audit)
+
+        client(Request(POST, Uri.of("https://fgjrg66cimblkqcbir4yznv5wm0dkexm.lambda-url.eu-west-1.on.aws/tasks:xxxx")))
+
+        assertThat(
+            audit.captured?.uri,
+            equalTo(Uri.of("https://fgjrg66cimblkqcbir4yznv5wm0dkexm.lambda-url.eu-west-1.on.aws/tasks%3Axxxx"))
+        )
+        assertThat(
+            audit.captured?.header("Authorization"),
+            equalTo("AWS4-HMAC-SHA256 Credential=access/20160127/eu-west/lambda/aws4_request, SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, Signature=6441e79e477d75a2bd4e064e961550f4aebb1dfce9aec6f28e9030610eed1c4c")
+        )
+    }
+
+    @Test
+    fun `path canonicalization for s3 service`() {
+
+        val scope = AwsCredentialScope("eu-west", "s3")
+
+        val client = ClientFilters.AwsAuth(scope, credentials, clock).then(audit)
+
+        client(Request(POST, Uri.of("https://fgjrg66cimblkqcbir4yznv5wm0dkexm.lambda-url.eu-west-1.on.aws/tasks:xxxx")))
+
+        assertThat(
+            audit.captured?.uri,
+            equalTo(Uri.of("https://fgjrg66cimblkqcbir4yznv5wm0dkexm.lambda-url.eu-west-1.on.aws/tasks%3Axxxx"))
+        )
+        assertThat(
+            audit.captured?.header("Authorization"),
+            equalTo("AWS4-HMAC-SHA256 Credential=access/20160127/eu-west/s3/aws4_request, SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, Signature=15b575a0b48e6b9a19a33964f87e169556d835e879c77dd0f6f807ea834980c9")
         )
     }
 }


### PR DESCRIPTION
This PR should fix #1533. For the purpose of sig4 generation, paths should be double url encoded fow all services except s3