### PR TITLE
Add response expiration mechanism to cache filters

### DIFF
--- a/core/tools/traffic-capture/src/main/kotlin/org/http4k/filter/TrafficFilters.kt
+++ b/core/tools/traffic-capture/src/main/kotlin/org/http4k/filter/TrafficFilters.kt
@@ -5,32 +5,151 @@ import org.http4k.core.Filter
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status
+import org.http4k.core.maxAge
+import org.http4k.core.staleIfError
+import org.http4k.core.staleWhileRevalidate
+import org.http4k.core.then
+import org.http4k.traffic.ReadWriteCache
 import org.http4k.traffic.Replay
 import org.http4k.traffic.Sink
 import org.http4k.traffic.Source
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 object TrafficFilters {
 
     /**
+     * Internal header names to store the expiration times of the response.
+     * Removed from the response and not returned to the caller, so ensure these don't clash with real headers.
+     *
+     * @param expiry The header in which to store the expiration time of the response, calculated from age & max-age.
+     * @param staleWhileRevalidate The header in which to store the expiration time in which a stale response can be served while revalidating.
+     * @param staleIfError The header in which to store the expiration time in which a stale response can be served if an error is returned.
+     * @param launchRevalidateTask If staleWhileRevalidate is configured, this is the context in which to run a revalidate task. By default, launches this in a new thread.
+     */
+    class CacheExpiryParams(
+        val expiry: String? = "x-http4k-expiry",
+        val staleWhileRevalidate: String? = "x-http4k-stale-while-revalidate",
+        val staleIfError: String? = "x-http4k-stale-if-error",
+        val launchRevalidateTask: (Runnable) -> Unit = { Thread(it).start() }
+    )
+
+    /**
+     * Combines ServeCachedFrom and RecordTo into a single filter
+     */
+    object RecordToAndServeFromCache {
+        operator fun invoke(
+            cache: ReadWriteCache,
+            params: CacheExpiryParams? = null,
+            instant: () -> Instant = { Clock.System.now() },
+        ): Filter = Filter { next -> ServeCachedFrom(cache).then(RecordTo(cache)).then(next)}
+    }
+
+    /**
      * Responds to requests with a stored Response if possible, or falls back to the next Http Handler
+     *
+     * Pass a CacheExpiryParams to only serve responses that respect the cache control directives
      */
     object ServeCachedFrom {
-        operator fun invoke(source: Source): Filter = Filter { next -> { source[it] ?: next(it) } }
+        operator fun invoke(
+            source: Source,
+            params: CacheExpiryParams? = null,
+            instant: () -> Instant = { Clock.System.now() },
+        ): Filter = Filter { next ->
+            { request ->
+                when (val responseFromCache = source[request]) {
+                    null -> next(request)
+                    else if params == null -> responseFromCache
+                    else -> {
+
+                        val now = instant()
+                        val expiry = responseFromCache.getExpirationHeader(params.expiry)
+                        val staleWhileRevalidateExpiry = responseFromCache.getExpirationHeader(params.staleWhileRevalidate)
+                        val staleIfErrorExpiry = responseFromCache.getExpirationHeader(params.staleIfError)
+
+                        when {
+                            expiry > now -> responseFromCache
+                            staleWhileRevalidateExpiry > now -> responseFromCache.also {
+                                params.launchRevalidateTask { next(request) }
+                            }
+
+                            else -> {
+                                val serverResponse = next(request)
+                                if (serverResponse.status.serverError && staleIfErrorExpiry > now) {
+                                    responseFromCache
+                                } else {
+                                    serverResponse
+                                }
+                            }
+                        }.removeExpirationHeader(params.expiry)
+                            .removeExpirationHeader(params.staleWhileRevalidate)
+                            .removeExpirationHeader(params.staleIfError)
+                    }
+                }
+            }
+        }
+
+        private fun Response.getExpirationHeader(header: String?) =
+            if (header != null) {
+                Instant.fromEpochMilliseconds(header(header)?.toLongOrNull() ?: 0)
+            } else {
+                Instant.DISTANT_PAST
+            }
+
+        private fun Response.removeExpirationHeader(header: String?) =
+            if (header != null) {
+                removeHeader(header)
+            } else {
+                this
+            }
     }
 
     /**
      * Intercepts and Writes Request/Response traffic
+     *
+     * Pass a CacheExpiryParams to cache responses alongside expiration information from their cache-control directives.
+     * This can then be combined with ServeCachedFrom to only serve fresh responses
      */
     object RecordTo {
-        operator fun invoke(sink: Sink): Filter = Filter { next ->
+        operator fun invoke(
+            sink: Sink,
+            params: CacheExpiryParams? = null,
+            instant: () -> Instant = { Clock.System.now() },
+        ): Filter = Filter { next ->
             {
                 val copy = it.body(Body(it.body.payload))
                 next(copy).run {
                     val response = body(Body(body.payload))
-                    response.apply { sink[copy] = this }
+                    response.apply {
+                        sink[copy] = if (params != null) {
+                            val age = (header("Age")?.toLongOrNull() ?: 0).seconds
+                            val maxAge = (maxAge() ?: 0).seconds
+                            val staleWhileRevalidate = (staleWhileRevalidate() ?: 0).seconds
+                            val staleIfError = (staleIfError() ?: 0).seconds
+
+                            val expiry = instant().plus(maxAge).minus(age)
+                            val staleWhileRevalidateExpiry = expiry.plus(staleWhileRevalidate)
+                            val staleIfErrorExpiry = expiry.plus(staleIfError)
+
+                            response
+                                .addExpirationHeader(params.expiry, expiry)
+                                .addExpirationHeader(params.staleWhileRevalidate, staleWhileRevalidateExpiry)
+                                .addExpirationHeader(params.staleIfError, staleIfErrorExpiry)
+                        } else {
+                            this
+                        }
+                    }
                 }
             }
         }
+
+        private fun Response.addExpirationHeader(header: String?, expiry: Instant) =
+            if (header != null) {
+                header(header, expiry.toEpochMilliseconds().toString())
+            } else {
+                this
+            }
     }
 
     /**

--- a/core/tools/traffic-capture/src/test/kotlin/org/http4k/filter/TrafficFiltersTest.kt
+++ b/core/tools/traffic-capture/src/test/kotlin/org/http4k/filter/TrafficFiltersTest.kt
@@ -2,6 +2,7 @@ package org.http4k.filter
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.present
 import org.http4k.client.JavaHttpClient
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -10,15 +11,26 @@ import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.Uri
+import org.http4k.core.maxAge
+import org.http4k.core.staleIfError
+import org.http4k.core.staleWhileRevalidate
 import org.http4k.core.then
+import org.http4k.filter.TrafficFilters.CacheExpiryParams
 import org.http4k.filter.TrafficFilters.RecordTo
+import org.http4k.routing.path
 import org.http4k.server.SunHttp
 import org.http4k.server.asServer
 import org.http4k.traffic.ReadWriteCache
 import org.http4k.traffic.ReadWriteStream
 import org.http4k.util.PortBasedTest
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
+import java.util.concurrent.CompletableFuture
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Instant
 
 class TrafficFiltersTest : PortBasedTest {
     private val request = Request(GET, "/bob")
@@ -85,5 +97,306 @@ class TrafficFiltersTest : PortBasedTest {
         assertThat(handler(Request(GET, "/bob2")), equalTo(Response(Status.ACCEPTED)))
         assertThat(handler(Request(GET, "/bob3")), equalTo(Response(Status.NOT_FOUND)))
         assertThat(handler(Request(GET, "/bob2")), equalTo(Response(Status.BAD_REQUEST)))
+    }
+
+    @Test
+    fun `RecordToAndServeFromCache combines both RecordTo and ServeCachedFrom`() {
+        val cache = ReadWriteCache.Memory()
+
+        var requests = 0
+        val handler = TrafficFilters.RecordToAndServeFromCache(cache).then {
+            requests++
+            response
+        }
+
+        assertThat(handler(request), equalTo(response))
+        assertThat(requests, equalTo(1))
+
+        assertThat(handler(request), equalTo(response))
+        assertThat(requests, equalTo(1))
+
+        assertThat(handler(request.uri(Uri.of("/other"))), equalTo(response))
+        assertThat(requests, equalTo(2))
+    }
+
+    @Nested
+    inner class CacheExpiryParamsTest {
+
+        @Test
+        fun `when null CacheExpiryParams is provided, RecordTo stores the response without any expiry headers`() {
+            val stream = ReadWriteStream.Memory()
+            val maxAgeResponse = response.maxAge(30.seconds)
+
+            val handler = RecordTo(stream).then { maxAgeResponse }
+
+            assertThat(handler(request), equalTo(maxAgeResponse))
+
+            assertThat(stream.responses().toList(), equalTo(listOf(maxAgeResponse)))
+        }
+
+        @Test
+        fun `when non-null CacheExpiryParams is provided, RecordTo stores the response with the configured expiry headers but the untransformed response is returned`() {
+            val stream = ReadWriteStream.Memory()
+            val maxAgeResponse = response.maxAge(30.seconds)
+
+            val handler = RecordTo(
+                stream,
+                CacheExpiryParams(staleWhileRevalidate = null, staleIfError = null),
+                { Instant.fromEpochMilliseconds(123456) }
+            ).then { maxAgeResponse }
+
+            assertThat(handler(request), equalTo(maxAgeResponse))
+
+            val expectedStoredResponse = maxAgeResponse.header("x-http4k-expiry", "${123456 + 30_000}")
+            assertThat(stream.responses().toList(), equalTo(listOf(expectedStoredResponse)))
+        }
+
+        @Test
+        fun `when non-null CacheExpiryParams is provided but response has no max-age RecordTo stores the response with an expiry of now`() {
+            val stream = ReadWriteStream.Memory()
+
+            val handler = RecordTo(
+                stream,
+                CacheExpiryParams(staleWhileRevalidate = null, staleIfError = null),
+                { Instant.fromEpochMilliseconds(123456) }
+            ).then { response }
+
+            assertThat(handler(request), equalTo(response))
+
+            val expectedStoredResponse = response.header("x-http4k-expiry", "123456")
+            assertThat(stream.responses().toList(), equalTo(listOf(expectedStoredResponse)))
+        }
+
+        @Test
+        fun `when a full set of CacheExpiryParams is provided and response has all the cache control directives, RecordTo stores all the cache expiry headers`() {
+            val stream = ReadWriteStream.Memory()
+            val cacheControlResponse = response
+                .maxAge(25.seconds)
+                .staleWhileRevalidate(2.hours)
+                .staleIfError(1.days)
+
+            val handler = RecordTo(
+                stream,
+                CacheExpiryParams(),
+                { Instant.fromEpochMilliseconds(123456) }
+            ).then { cacheControlResponse }
+
+            assertThat(handler(request), equalTo(cacheControlResponse))
+
+            val expectedStoredResponse = cacheControlResponse
+                .header("x-http4k-expiry", "${123456 + 25_000}")
+                .header("x-http4k-stale-while-revalidate", "${123456 + 25_000 + 7_200_000}")
+                .header("x-http4k-stale-if-error", "${123456 + 25_000 + 8_6400_000}")
+            assertThat(stream.responses().toList(), equalTo(listOf(expectedStoredResponse)))
+        }
+
+        @Test
+        fun `when the response has an age header, RecordTo deducts this from the expiry time`() {
+            val stream = ReadWriteStream.Memory()
+            val cacheControlResponse = response
+                .header("Age", "10")
+                .maxAge(25.seconds)
+                .staleWhileRevalidate(2.hours)
+                .staleIfError(1.days)
+
+            val handler = RecordTo(
+                stream,
+                CacheExpiryParams(),
+                { Instant.fromEpochMilliseconds(123456) }
+            ).then { cacheControlResponse }
+
+            assertThat(handler(request), equalTo(cacheControlResponse))
+
+            val expectedStoredResponse = cacheControlResponse
+                .header("x-http4k-expiry", "${123456 + 15_000}")
+                .header("x-http4k-stale-while-revalidate", "${123456 + 15_000 + 7_200_000}")
+                .header("x-http4k-stale-if-error", "${123456 + 15_000 + 8_6400_000}")
+            assertThat(stream.responses().toList(), equalTo(listOf(expectedStoredResponse)))
+        }
+
+        @Test
+        fun `when the response has an invalid age header, RecordTo ignores it`() {
+            val stream = ReadWriteStream.Memory()
+            val cacheControlResponse = response
+                .header("Age", "NaN")
+                .maxAge(25.seconds)
+                .staleWhileRevalidate(2.hours)
+                .staleIfError(1.days)
+
+            val handler = RecordTo(
+                stream,
+                CacheExpiryParams(),
+                { Instant.fromEpochMilliseconds(123456) }
+            ).then { cacheControlResponse }
+
+            assertThat(handler(request), equalTo(cacheControlResponse))
+
+            val expectedStoredResponse = cacheControlResponse
+                .header("x-http4k-expiry", "${123456 + 25_000}")
+                .header("x-http4k-stale-while-revalidate", "${123456 + 25_000 + 7_200_000}")
+                .header("x-http4k-stale-if-error", "${123456 + 25_000 + 8_6400_000}")
+            assertThat(stream.responses().toList(), equalTo(listOf(expectedStoredResponse)))
+        }
+
+        @Test
+        fun `when non-null CacheExpiryParams is provided, ServeCachedFrom serves requests from the cache if they are within the expiry, minus the custom headers`() {
+            val cache = ReadWriteCache.Memory()
+            cache[request] = response.header("x-custom-expiry-header", "1234")
+
+            val notFound = Response(Status.NOT_FOUND)
+            val handler = TrafficFilters.ServeCachedFrom(
+                cache,
+                CacheExpiryParams(expiry = "x-custom-expiry-header"),
+                { Instant.fromEpochMilliseconds(1233) }
+            ).then { notFound }
+
+            assertThat(handler(request), equalTo(response))
+        }
+
+        @Test
+        fun `when non-null CacheExpiryParams is provided, ServeCachedFrom falls back to the next if the response has expired`() {
+            val cache = ReadWriteCache.Memory()
+            cache[request] = response.header("x-custom-expiry-header", "1234")
+
+            val notFound = Response(Status.NOT_FOUND)
+            val handler = TrafficFilters.ServeCachedFrom(
+                cache,
+                CacheExpiryParams(expiry = "x-custom-expiry-header"),
+                { Instant.fromEpochMilliseconds(1234) }
+            ).then { notFound }
+
+            assertThat(handler(request), equalTo(notFound))
+        }
+
+        @Test
+        fun `when non-null CacheExpiryParams with staleWhileRevalidate is provided, ServeCachedFrom will return a non fresh response while inside staleWhileRevalidate expiry while revalidating`() {
+            val cache = ReadWriteCache.Memory()
+            cache[request] = response
+                .header("x-custom-expiry-header", "111")
+                .header("x-custom-stale-while-revalidate-header", "333")
+
+            val revalidateJob = CompletableFuture<Runnable?>()
+
+            val notFound = Response(Status.NOT_FOUND)
+            val handler = TrafficFilters.ServeCachedFrom(
+                cache,
+                CacheExpiryParams(
+                    expiry = "x-custom-expiry-header",
+                    staleWhileRevalidate = "x-custom-stale-while-revalidate-header",
+                    launchRevalidateTask = { revalidateJob.complete(it) }
+                ),
+                { Instant.fromEpochMilliseconds(222) }
+            ).then { notFound }
+
+            assertThat(handler(request), equalTo(response))
+            assertThat(revalidateJob.get(), present())
+        }
+
+        @Test
+        fun `when non-null CacheExpiryParams with staleWhileRevalidate is provided, ServeCachedFrom will fall back to the next if response is too stale for the staleWhileRevalidate expiry`() {
+            val cache = ReadWriteCache.Memory()
+            cache[request] = response
+                .header("x-custom-expiry-header", "111")
+                .header("x-custom-stale-while-revalidate-header", "222")
+
+
+            val notFound = Response(Status.NOT_FOUND)
+            val handler = TrafficFilters.ServeCachedFrom(
+                cache,
+                CacheExpiryParams(
+                    expiry = "x-custom-expiry-header",
+                    staleWhileRevalidate = "x-custom-stale-while-revalidate-header",
+                ),
+                { Instant.fromEpochMilliseconds(333) }
+            ).then { notFound }
+
+            assertThat(handler(request), equalTo(notFound))
+        }
+
+
+        @Test
+        fun `when non-null CacheExpiryParams with staleIfError is provided, ServeCachedFrom will serve a stale cached response if within the staleIfError expiry and next returns a server error`() {
+            val cache = ReadWriteCache.Memory()
+            cache[request] = response
+                .header("x-custom-expiry-header", "111")
+                .header("x-custom-stale-while-revalidate-header", "222")
+                .header("x-custom-stale-if-error-header", "444")
+
+            val serverError = Response(Status.INTERNAL_SERVER_ERROR)
+            val handler = TrafficFilters.ServeCachedFrom(
+                cache,
+                CacheExpiryParams(
+                    expiry = "x-custom-expiry-header",
+                    staleWhileRevalidate = "x-custom-stale-while-revalidate-header",
+                    staleIfError = "x-custom-stale-if-error-header"
+                ),
+                { Instant.fromEpochMilliseconds(333) }
+            ).then { serverError }
+
+            assertThat(handler(request), equalTo(response))
+        }
+
+        @Test
+        fun `when non-null CacheExpiryParams with staleIfError is provided, ServeCachedFrom will not serve a stale cached response if within the staleIfError expiry but the fetched response is not a server error`() {
+            val cache = ReadWriteCache.Memory()
+            cache[request] = response
+                .header("x-custom-expiry-header", "111")
+                .header("x-custom-stale-while-revalidate-header", "222")
+                .header("x-custom-stale-if-error-header", "444")
+
+            val accepted = Response(Status.ACCEPTED)
+            val handler = TrafficFilters.ServeCachedFrom(
+                cache,
+                CacheExpiryParams(
+                    expiry = "x-custom-expiry-header",
+                    staleWhileRevalidate = "x-custom-stale-while-revalidate-header",
+                    staleIfError = "x-custom-stale-if-error-header"
+                ),
+                { Instant.fromEpochMilliseconds(333) }
+            ).then { accepted }
+
+            assertThat(handler(request), equalTo(accepted))
+        }
+
+        @Test
+        fun `when non-null CacheExpiryParams with staleIfError is provided, ServeCachedFrom will serve the fetched error response if outside of the staleIfError expiry`() {
+            val cache = ReadWriteCache.Memory()
+            cache[request] = response
+                .header("x-custom-expiry-header", "111")
+                .header("x-custom-stale-while-revalidate-header", "222")
+                .header("x-custom-stale-if-error-header", "333")
+
+            val serverError = Response(Status.INTERNAL_SERVER_ERROR)
+            val handler = TrafficFilters.ServeCachedFrom(
+                cache,
+                CacheExpiryParams(
+                    expiry = "x-custom-expiry-header",
+                    staleWhileRevalidate = "x-custom-stale-while-revalidate-header",
+                    staleIfError = "x-custom-stale-if-error-header"
+                ),
+                { Instant.fromEpochMilliseconds(444) }
+            ).then { serverError }
+
+            assertThat(handler(request), equalTo(serverError))
+        }
+
+        @Test
+        fun `when an invalid expiry value is set, this is ignored and the response is considered stale`() {
+            val cache = ReadWriteCache.Memory()
+            cache[request] = response.header("x-custom-expiry-header", "Invalid")
+
+            val serverError = Response(Status.INTERNAL_SERVER_ERROR)
+            val handler = TrafficFilters.ServeCachedFrom(
+                cache,
+                CacheExpiryParams(
+                    expiry = "x-custom-expiry-header",
+                    staleWhileRevalidate = null,
+                    staleIfError = null,
+                ),
+                { Instant.fromEpochMilliseconds(123) }
+            ).then { serverError }
+
+            assertThat(handler(request), equalTo(serverError))
+        }
     }
 }


### PR DESCRIPTION
Unsure whether you think this a bit too opinionated for this library, but it feels like it's borderline and it's something that could be useful to others. If it's not something you think would be useful or fits then feel free to close. 

Basically this allows you to have a ReadWriteCache Filter that respects the cache control directives of a response, so consumers don't have to write logic to check this themselves. 

It uses some custom headers to store the expiry times alongside the response, which seems to be a pattern that's been used elsewhere (e.g. [here](https://github.com/http4k/http4k/blob/037f430dd7c5d699da7cdc7b2660b5c0ec6969ab/pro/wiretap/src/main/kotlin/org/http4k/wiretap/domain/TransactionMapping.kt#L33-L35)). I couldn't think of another simple way to store this information, but if there is then feel free to update or let me know what changes to make. These aren't surfaced to the caller outside of these filters.

By default this behaviour is disabled by passing a null param set, so consumers will have to opt in to get this behaviour and there should be no breaking changes.