### PR TITLE
Fix Aws Auth content streaming + fix OKHttp client streaming

### DIFF
--- a/connect/amazon/s3/client/src/main/kotlin/org/http4k/connect/amazon/s3/action/PutObject.kt
+++ b/connect/amazon/s3/client/src/main/kotlin/org/http4k/connect/amazon/s3/action/PutObject.kt
@@ -18,6 +18,7 @@ import java.io.InputStream
 data class PutObject(
     val key: BucketKey,
     val content: InputStream,
+    val length: Long? = null,
     val headers: List<Pair<String, String?>> = emptyList(),
     val tags: List<Tag> = emptyList(),
     val storageClass: StorageClass? = null,
@@ -25,7 +26,7 @@ data class PutObject(
 
     override fun toRequest() = Request(PUT, Uri.of("/$key"))
         .headers(headers + headersFor(tags) + headersFor(storageClass))
-        .body(content)
+        .body(content, length)
 
     override fun toResult(response: Response) = with(response) {
         when {

--- a/connect/amazon/s3/fake/src/examples/kotlin/using_connect_client.kt
+++ b/connect/amazon/s3/fake/src/examples/kotlin/using_connect_client.kt
@@ -9,7 +9,9 @@ import org.http4k.connect.amazon.core.model.Region
 import org.http4k.connect.amazon.s3.model.BucketKey
 import org.http4k.connect.amazon.s3.model.BucketName
 import org.http4k.core.HttpHandler
+import org.http4k.filter.Payload
 import org.http4k.filter.debug
+import java.io.File
 import java.io.InputStream
 
 const val USE_REAL_CLIENT = false
@@ -32,11 +34,22 @@ fun main() {
 
     // we can store some content in the bucket...
     val putResult: Result<Unit, RemoteFailure> =
-        s3Bucket.putObject(bucketKey, "hellothere".byteInputStream(), emptyList())
+        s3Bucket.putObject(bucketKey, "hellothere".byteInputStream())
     putResult.valueOrNull()!!
 
     // and get back the content which we stored
     val getResult: Result<InputStream?, RemoteFailure> = s3Bucket.get(bucketKey)
     val content: InputStream = getResult.valueOrNull()!!
     println(content.reader().readText())
+
+    // for larger content, consider using an unsigned payload to efficiently stream data into the bucket
+    val file = File.createTempFile("content", ".bin").apply {
+        deleteOnExit()
+        val blockOfContent = ByteArray(1_000_000)
+        repeat(100) {
+            appendBytes(blockOfContent)
+        }
+    }
+    val s3BucketUnsigned = S3Bucket.Http(bucketName, region, { AwsCredentials("accessKeyId", "secretKey") }, http, payloadMode = Payload.Mode.Unsigned)
+    s3BucketUnsigned.putObject(bucketKey, file.inputStream(), file.length()).valueOrNull()!!
 }

--- a/connect/amazon/s3/fake/src/test/kotlin/org/http4k/connect/amazon/s3/fakeS3Tests.kt
+++ b/connect/amazon/s3/fake/src/test/kotlin/org/http4k/connect/amazon/s3/fakeS3Tests.kt
@@ -34,7 +34,7 @@ class FakeS3BucketTest : S3BucketContract, FakeAwsContract {
 
             assertThat(
                 s3Bucket.putObject(
-                    key, "hello".byteInputStream(), listOf(
+                    key, "hello".byteInputStream(), headers = listOf(
                         X_HTTP4K_LAST_MODIFIED to LastModified.of(lastModifiedDate).toHeaderValue()
                     )
                 ).successValue(), equalTo(Unit)
@@ -57,7 +57,7 @@ class FakeS3BucketTest : S3BucketContract, FakeAwsContract {
 
             assertThat(
                 s3Bucket.putObject(
-                    key, "génial".byteInputStream(Charsets.ISO_8859_1), listOf()
+                    key, "génial".byteInputStream(Charsets.ISO_8859_1)
                 ).successValue(), equalTo(Unit)
             )
 
@@ -73,7 +73,7 @@ class FakeS3BucketTest : S3BucketContract, FakeAwsContract {
     @Test
     fun `can copy object`() {
         try {
-            s3Bucket.putObject(key, "hello".byteInputStream(), listOf()).recover { "failed to upload" }
+            s3Bucket.putObject(key, "hello".byteInputStream()).recover { "failed to upload" }
             assertThat(s3Bucket.copyObject(bucket, key, BucketKey.of("hello-copy.txt")).successValue(), equalTo(Unit))
         } finally {
             s3Bucket.deleteObject(key)
@@ -87,7 +87,7 @@ class FakeS3BucketTest : S3BucketContract, FakeAwsContract {
         val destination = BucketKey.of("destination/hello.txt")
 
         try {
-            s3Bucket.putObject(source, "hello".byteInputStream(), listOf()).successValue()
+            s3Bucket.putObject(source, "hello".byteInputStream()).successValue()
             s3Bucket.copyObject(bucket, source, destination).successValue()
 
             assertThat(
@@ -109,7 +109,7 @@ class FakeS3BucketTest : S3BucketContract, FakeAwsContract {
         val key = BucketKey.of("foo.txt")
 
         try {
-            s3Bucket.putObject(key, "hello".byteInputStream(), listOf()).successValue()
+            s3Bucket.putObject(key, "hello".byteInputStream()).successValue()
 
             val response = Request(GET, "http://${bucket}.s3.amazonaws.com/foo.txt").let(http)
 

--- a/core/client/okhttp/src/main/kotlin/org/http4k/client/OkHttp.kt
+++ b/core/client/okhttp/src/main/kotlin/org/http4k/client/OkHttp.kt
@@ -2,9 +2,12 @@ package org.http4k.client
 
 import okhttp3.Call
 import okhttp3.Callback
+import okhttp3.MediaType
 import okhttp3.OkHttpClient
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.internal.http.HttpMethod.permitsRequestBody
+import okio.BufferedSink
 import org.http4k.client.PreCannedOkHttpClients.defaultOkHttpClient
 import org.http4k.core.BodyMode
 import org.http4k.core.Request
@@ -15,6 +18,7 @@ import org.http4k.core.Status.Companion.CONNECTION_REFUSED
 import org.http4k.core.Status.Companion.SERVICE_UNAVAILABLE
 import org.http4k.core.Status.Companion.UNKNOWN_HOST
 import java.io.IOException
+import java.io.InputStream
 import java.io.InterruptedIOException
 import java.net.ConnectException
 import java.net.NoRouteToHostException
@@ -38,7 +42,7 @@ object OkHttp {
         object : DualSyncAsyncHttpHandler {
             override fun invoke(request: Request): Response =
                 try {
-                    client.newCall(request.asOkHttp()).execute().asHttp4k(bodyMode)
+                    client.newCall(request.asOkHttp(bodyMode)).execute().asHttp4k(bodyMode)
                 } catch (e: ConnectException) {
                     Response(CONNECTION_REFUSED.toClientStatus(e))
                 } catch (e: UnknownHostException) {
@@ -58,7 +62,7 @@ object OkHttp {
                 }
 
             override operator fun invoke(request: Request, fn: (Response) -> Unit) =
-                client.newCall(request.asOkHttp()).enqueue(Http4kCallback(bodyMode, fn))
+                client.newCall(request.asOkHttp(bodyMode)).enqueue(Http4kCallback(bodyMode, fn))
         }
 
     private class Http4kCallback(private val bodyMode: BodyMode, private val fn: (Response) -> Unit) : Callback {
@@ -75,17 +79,25 @@ object OkHttp {
     }
 }
 
-internal fun Request.asOkHttp(): okhttp3.Request = headers.fold(
+internal fun Request.asOkHttp(bodyMode: BodyMode = BodyMode.Memory): okhttp3.Request = headers.fold(
     okhttp3.Request.Builder()
         .url(uri.toString())
-        .method(method.toString(), requestBody())
+        .method(method.toString(), requestBody(bodyMode))
 ) { memo, (first, second) ->
     val notNullValue = second.orEmpty()
     memo.addHeader(first, notNullValue)
 }.build()
 
-private fun Request.requestBody() =
-    if (permitsRequestBody(method.toString())) body.payload.array().toRequestBody()
+private fun Request.requestBody(bodyMode: BodyMode) =
+    if (permitsRequestBody(method.toString()))
+        when (bodyMode) {
+            BodyMode.Memory -> body.payload.array().toRequestBody()
+
+            BodyMode.Stream -> InputStreamRequestBody(
+                body.stream,
+                body.length ?: header("content-length")?.toLong() ?: -1
+            )
+        }
     else null
 
 private fun okhttp3.Response.asHttp4k(bodyMode: BodyMode): Response {
@@ -93,6 +105,24 @@ private fun okhttp3.Response.asHttp4k(bodyMode: BodyMode): Response {
     val headers = headers.toMultimap().flatMap { it.value.map { hValue -> it.key to hValue } }
 
     return body.let { init.body(bodyMode(it.byteStream())) }.headers(headers)
+}
+
+internal class InputStreamRequestBody(
+    private val inputStream: InputStream,
+    private val contentLength: Long
+) : RequestBody() {
+
+    override fun contentType() : MediaType? = null
+
+    override fun writeTo(sink: BufferedSink) {
+        inputStream.use { input ->
+            sink.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+    }
+
+    override fun contentLength(): Long = contentLength
 }
 
 object PreCannedOkHttpClients {

--- a/core/client/okhttp/src/test/kotlin/org/http4k/client/OkHttpStreamingContractTest.kt
+++ b/core/client/okhttp/src/test/kotlin/org/http4k/client/OkHttpStreamingContractTest.kt
@@ -1,0 +1,13 @@
+package org.http4k.client
+
+import org.http4k.core.BodyMode
+import org.http4k.core.HttpHandler
+import org.http4k.server.SunHttp
+import org.http4k.streaming.StreamingContract
+
+class OkHttpStreamingContractTest : StreamingContract() {
+    override fun serverConfig() = SunHttp(0)
+
+    override fun createClient(): HttpHandler = OkHttp(bodyMode = BodyMode.Stream)
+}
+

--- a/core/platform/aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
+++ b/core/platform/aws/src/main/kotlin/org/http4k/filter/awsExtensions.kt
@@ -68,7 +68,7 @@ fun ClientFilters.AwsAuth(
             val signedRequest = fullRequest
                 .replaceHeader("Authorization", buildAuthHeader(scope, credentials, canonicalRequest, date))
 
-            next(signedRequest.body(Body(it.body.payload)))
+            next(signedRequest.bodyFrom(it, payloadMode))
         }
     }
 
@@ -107,6 +107,12 @@ object Payload {
         }
     }
 }
+
+private fun Request.bodyFrom(other: Request, mode: Payload.Mode) : Request =
+    when (mode) {
+        Payload.Mode.Signed -> body(Body(other.body.payload))
+        Payload.Mode.Unsigned -> body(other.body.stream, other.body.length)
+    }
 
 fun ClientFilters.SetAwsServiceUrl(serviceName: String, region: String) =
     SetHostFrom(Uri.of("https://$serviceName.${region}.amazonaws.com"))

--- a/core/platform/aws/src/test/kotlin/org/http4k/aws/AwsAuthClientFilterTest.kt
+++ b/core/platform/aws/src/test/kotlin/org/http4k/aws/AwsAuthClientFilterTest.kt
@@ -3,6 +3,7 @@ package org.http4k.aws
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.http4k.client.JavaHttpClient
+import org.http4k.core.Body
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
@@ -13,10 +14,13 @@ import org.http4k.core.Uri
 import org.http4k.core.then
 import org.http4k.filter.AwsAuth
 import org.http4k.filter.ClientFilters
+import org.http4k.filter.Payload
 import org.http4k.server.SunHttp
 import org.http4k.server.asServer
 import org.http4k.util.PortBasedTest
 import org.junit.jupiter.api.Test
+import java.io.InputStream
+import java.nio.ByteBuffer
 import java.time.Clock.fixed
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -81,6 +85,43 @@ class AwsClientFilterTest: PortBasedTest {
             val client = ClientFilters.AwsAuth(scope, credentials, clock)
                 .then(JavaHttpClient())
             val response = client(Request(GET, "http://localhost:${it.port()}").body("foobar".byteInputStream()))
+
+            assertThat(response.bodyString(), equalTo("foobar"))
+        }
+    }
+
+    @Test
+    fun `stream body is send correctly unsigned`() {
+        val streamBody = object : Body {
+            override val stream: InputStream = "foobar".byteInputStream()
+            override val payload: ByteBuffer get() = throw IllegalStateException("stream should never be read into memory!")
+            override val length: Long = 6
+            override fun close() {}
+        }
+
+        val client = ClientFilters.AwsAuth(scope, credentials, clock, payloadMode = Payload.Mode.Unsigned)
+            .then { Response(OK).body(it.body.stream) }
+
+        val response = client(Request(GET, "http://amazon/test").body(streamBody))
+
+        assertThat(response.bodyString(), equalTo("foobar"))
+    }
+
+    @Test
+    fun `stream body is send correctly unsigned - over socket`() {
+        val streamBody = object : Body {
+            override val stream: InputStream = "foobar".byteInputStream()
+            override val payload: ByteBuffer get() = throw IllegalStateException("stream should never be read into memory!")
+            override val length: Long = 6
+            override fun close() {}
+        }
+
+        val http = { req: Request -> Response(OK).body(req.bodyString()) }
+
+        http.asServer(SunHttp(0)).start().use {
+            val client = ClientFilters.AwsAuth(scope, credentials, clock, payloadMode = Payload.Mode.Unsigned)
+                .then(JavaHttpClient())
+            val response = client(Request(GET, "http://localhost:${it.port()}").body(streamBody))
 
             assertThat(response.bodyString(), equalTo("foobar"))
         }

--- a/core/platform/aws/src/test/kotlin/org/http4k/filter/awsExtensionsTest.kt
+++ b/core/platform/aws/src/test/kotlin/org/http4k/filter/awsExtensionsTest.kt
@@ -1,8 +1,13 @@
 package org.http4k.filter
 
 import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.isEmpty
+import com.natpryce.hamkrest.isEmptyString
+import org.http4k.asByteBuffer
 import org.http4k.aws.AwsCredentialScope
 import org.http4k.aws.AwsCredentials
+import org.http4k.core.Body
 import org.http4k.core.Method
 import org.http4k.core.Request
 import org.http4k.core.Response
@@ -11,6 +16,8 @@ import org.http4k.core.then
 import org.http4k.hamkrest.hasBody
 import org.http4k.hamkrest.hasHeader
 import org.junit.jupiter.api.Test
+import java.io.InputStream
+import java.nio.ByteBuffer
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
@@ -23,14 +30,18 @@ class FilterExtensionsTest {
         assertThat(app(Request(Method.GET, "/bob")), hasBody("https://myservice.narnia.amazonaws.com/bob"))
     }
 
+    private val awsCredentialScope = AwsCredentialScope("narnia", "myservice")
+    private val awsCredentials = AwsCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+    private val clock = Clock.fixed(Instant.parse("2024-02-07T00:00:00Z"), ZoneOffset.UTC)
+
     @Test
-    fun `authorize aws request`() {
+    fun `authorize aws request with no body content`() {
         // given
         lateinit var capturedRequest: Request
         val app = ClientFilters.AwsAuth(
-            scope = AwsCredentialScope("narnia", "myservice"),
-            credentials = AwsCredentials("AKIAIOSFODNN7EXAMPLE", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
-            clock = Clock.fixed(Instant.parse("2024-02-07T00:00:00Z"), ZoneOffset.UTC)
+            scope = awsCredentialScope,
+            credentials = awsCredentials,
+            clock = clock
         ).then { request ->
             capturedRequest = request
             Response(Status.OK)
@@ -44,5 +55,58 @@ class FilterExtensionsTest {
         assertThat(capturedRequest, hasHeader("x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
         assertThat(capturedRequest, hasHeader("x-amz-date", "20240207T000000Z"))
         assertThat(capturedRequest, hasHeader("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20240207/narnia/myservice/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=314a5fa82a1688d2f1ac0ee8787276306235d5f9870723274d828d66401590c7"))
+    }
+
+    @Test
+    fun `authorize aws request with signed body content`() {
+        // given
+        lateinit var capturedRequest: Request
+        val app = ClientFilters.AwsAuth(
+            scope = awsCredentialScope,
+            credentials = awsCredentials,
+            clock = clock
+        ).then { request ->
+            capturedRequest = request
+            Response(Status.OK)
+        }
+
+        val content = "this is some content to upload"
+
+        // when
+        app(Request(Method.PUT, "http://localhost:8000/foo").body(content))
+
+        // then
+        assertThat(capturedRequest, hasHeader("host", "localhost:8000"))
+        assertThat(capturedRequest, hasHeader("x-amz-content-sha256", "0b2cede50bd744966a5571382f321d17fa174a19a1120e9823fed2ca484d6250"))
+        assertThat(capturedRequest, hasHeader("x-amz-date", "20240207T000000Z"))
+        assertThat(capturedRequest, hasHeader("content-length", content.length.toString()))
+        assertThat(capturedRequest, hasHeader("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20240207/narnia/myservice/aws4_request, SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, Signature=30520c468aca1034456bafa36f10cdc95d0ef6366569d69d7da30c8e2c6c2ff9"))
+    }
+
+    @Test
+    fun `authorize aws request with unsigned body content`() {
+        // given
+        lateinit var capturedRequest: Request
+        val app = ClientFilters.AwsAuth(
+            scope = awsCredentialScope,
+            credentials = awsCredentials,
+            clock = clock,
+            payloadMode = Payload.Mode.Unsigned
+        ).then { request ->
+            capturedRequest = request
+            Response(Status.OK)
+        }
+
+        val content = "this is some content to upload"
+
+        // when
+        app(Request(Method.PUT, "http://localhost:8000/foo").body(content))
+
+        // then
+        assertThat(capturedRequest, hasHeader("host", "localhost:8000"))
+        assertThat(capturedRequest, hasHeader("x-amz-content-sha256", "UNSIGNED-PAYLOAD"))
+        assertThat(capturedRequest, hasHeader("x-amz-date", "20240207T000000Z"))
+        assertThat(capturedRequest, hasHeader("content-length", content.length.toString()))
+        assertThat(capturedRequest, hasHeader("Authorization", "AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7EXAMPLE/20240207/narnia/myservice/aws4_request, SignedHeaders=content-length;host;x-amz-content-sha256;x-amz-date, Signature=c760a7a420fceab051da0f2094896df09d802d740ad388dc0acb81505771929d"))
     }
 }


### PR DESCRIPTION
I'm using the S3 PutObject example on https://www.http4k.org/ecosystem/connect/reference/amazon/s3/ to stream a large 1GB to S3 with OKHttp client. 
When trying to stream a large content payload to S3 I hit an out of memory exception because both the AwsAuth client filter and OKHttp client realise the body input stream. This PR attempts to fix both, and I've extended the example to include unsigned payloads as well.