### PR TITLE
FakeSTS getCallerIdentity to be deterministic and controllable

### DIFF
--- a/connect/amazon/sts/client/src/test/kotlin/org/http4k/connect/amazon/sts/RealSTSTest.kt
+++ b/connect/amazon/sts/client/src/test/kotlin/org/http4k/connect/amazon/sts/RealSTSTest.kt
@@ -1,5 +1,8 @@
 package org.http4k.connect.amazon.sts
 
 import org.http4k.connect.amazon.RealAwsContract
+import java.time.Clock
 
-class RealSTSTest : STSContract, RealAwsContract
+class RealSTSTest : STSContract, RealAwsContract {
+    override val clock: Clock = Clock.systemUTC()
+}

--- a/connect/amazon/sts/client/src/testFixtures/kotlin/org/http4k/connect/amazon/sts/STSContract.kt
+++ b/connect/amazon/sts/client/src/testFixtures/kotlin/org/http4k/connect/amazon/sts/STSContract.kt
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime
 import java.util.UUID
 
 interface STSContract : AwsContract {
-    val clock get() = Clock.systemUTC()!!
+    val clock: Clock
     val sts
         get() =
         STS.Http(aws.region, { aws.credentials }, http, clock)

--- a/connect/amazon/sts/fake/src/main/kotlin/org/http4k/connect/amazon/sts/FakeSTS.kt
+++ b/connect/amazon/sts/fake/src/main/kotlin/org/http4k/connect/amazon/sts/FakeSTS.kt
@@ -4,6 +4,8 @@ import org.http4k.aws.AwsCredentials
 import org.http4k.chaos.ChaoticHttpHandler
 import org.http4k.chaos.start
 import org.http4k.connect.amazon.core.model.Region
+import org.http4k.connect.storage.InMemory
+import org.http4k.connect.storage.Storage
 import org.http4k.core.Method.POST
 import org.http4k.routing.bind
 import org.http4k.routing.routes
@@ -13,6 +15,7 @@ import java.time.Duration.ofHours
 import java.util.Random
 
 class FakeSTS(
+    val assumedRoles: Storage<AssumedRole> = Storage.InMemory(),
     private val clock: Clock = Clock.systemUTC(),
     random: Random = Random(),
     defaultSessionValidity: Duration = ofHours(1)
@@ -20,8 +23,8 @@ class FakeSTS(
 
     override val app = routes(
         "/" bind POST to routes(
-            getCallerIdentity(),
-            assumeRole(defaultSessionValidity, clock, random),
+            getCallerIdentity(clock, assumedRoles),
+            assumeRole(defaultSessionValidity, clock, random, assumedRoles),
             assumeRoleWithWebIdentity(defaultSessionValidity, clock, random)
         )
     )

--- a/connect/amazon/sts/fake/src/main/kotlin/org/http4k/connect/amazon/sts/FakeSTS.kt
+++ b/connect/amazon/sts/fake/src/main/kotlin/org/http4k/connect/amazon/sts/FakeSTS.kt
@@ -25,7 +25,7 @@ class FakeSTS(
         "/" bind POST to routes(
             getCallerIdentity(clock, assumedRoles),
             assumeRole(defaultSessionValidity, clock, random, assumedRoles),
-            assumeRoleWithWebIdentity(defaultSessionValidity, clock, random)
+            assumeRoleWithWebIdentity(defaultSessionValidity, clock, random, assumedRoles)
         )
     )
 

--- a/connect/amazon/sts/fake/src/main/kotlin/org/http4k/connect/amazon/sts/endpoints.kt
+++ b/connect/amazon/sts/fake/src/main/kotlin/org/http4k/connect/amazon/sts/endpoints.kt
@@ -1,49 +1,84 @@
 package org.http4k.connect.amazon.sts
 
-import org.http4k.base64Encode
+import org.http4k.connect.amazon.core.model.ARN
+import org.http4k.connect.storage.Storage
 import org.http4k.core.Body
 import org.http4k.core.ContentType
 import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status
+import org.http4k.core.WwwAuthenticate
 import org.http4k.core.body.form
 import org.http4k.core.with
 import org.http4k.routing.asRouter
 import org.http4k.routing.bind
 import org.http4k.template.PebbleTemplates
 import org.http4k.template.viewModel
+import org.http4k.util.Hex
 import java.time.Clock
 import java.time.Duration
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter.ISO_ZONED_DATE_TIME
 import java.util.Random
 
-fun getCallerIdentity() =
+/**
+ * Only supports assumed roles.  Otherwise, 401
+ */
+fun getCallerIdentity(clock: Clock, roles: Storage<AssumedRole>) =
     { request: Request -> request.form("Action") == "GetCallerIdentity" }
-        .asRouter() bind { _: Request ->
+        .asRouter() bind fn@{ request: Request ->
+
+        val accessKeyId = request.header("Authorization")
+            ?.let { WwwAuthenticate.parseHeader(it) }
+            ?.get("Credential")
+            ?.split("/")
+            ?.firstOrNull()
+            ?: return@fn Response(Status.UNAUTHORIZED)
+
+        // only supports assumed roles
+        val assumedRole = request
+            .header("X-Amz-Security-Token")
+            ?.let { roles["$accessKeyId/$it"] }
+            ?.takeIf { it.expires >= clock.instant() }
+            ?: return@fn Response(Status.UNAUTHORIZED)
+
+        val roleName = assumedRole.arn.toString().split("/").last()
+
         Response(Status.OK).with(
             viewModelLens of GetCallerIdentityResponse(
-                userId = "ARO123EXAMPLE123:my-role-session-name",
-                account = "123456789012",
-                arn = "arn:aws:sts::123456789012:assumed-role/my-role-name/my-role-session-name"
+                userId = "ARO123EXAMPLE123:${assumedRole.sessionName}",
+                account = assumedRole.arn.account.value,
+                arn = "arn:aws:sts::${assumedRole.arn.account}:assumed-role/$roleName/${assumedRole.sessionName}"
             )
         )
     }
 
-fun assumeRole(defaultSessionValidity: Duration, clock: Clock, random: Random) = { r: Request -> r.form("Action") == "AssumeRole" }
-    .asRouter() bind { req: Request ->
+fun assumeRole(defaultSessionValidity: Duration, clock: Clock, random: Random, roles: Storage<AssumedRole>) = { r: Request ->
+    r.form("Action") == "AssumeRole" }.asRouter() bind { req: Request ->
     val duration = req.form("DurationSeconds")
         ?.toLong()
         ?.let(Duration::ofSeconds)
         ?: defaultSessionValidity
+
+    val assumedRole = AssumedRole(
+        arn = ARN.parse(req.form("RoleArn")!!),
+        sessionName = req.form("RoleSessionName")!!,
+        expires = clock.instant() + duration
+    )
+
+    val accessKey = nextToken(random)
+    val sessionToken = nextToken(random)
+
+    roles["$accessKey/$sessionToken"] = assumedRole
+
     Response(Status.OK).with(
         viewModelLens of AssumeRoleResponse(
-            req.form("RoleArn")!!,
-            req.form("RoleSessionName")!!,
-            "accessKeyId",
-            "secretAccessKey",
-            nextSessionToken(random),
-            ISO_ZONED_DATE_TIME.format(ZonedDateTime.now(clock) + duration)
+            arn = assumedRole.arn.value,
+            roleId = assumedRole.sessionName,
+            accessKeyId = accessKey,
+            secretAccessKey = nextToken(random),
+            sessionToken = sessionToken,
+            expiration = ISO_ZONED_DATE_TIME.format(ZonedDateTime.ofInstant(assumedRole.expires, clock.zone))
         )
     )
 }
@@ -61,7 +96,7 @@ fun assumeRoleWithWebIdentity(defaultSessionValidity: Duration, clock: Clock, ra
                 req.form("RoleSessionName")!!,
                 "accessKeyId",
                 "secretAccessKey",
-                nextSessionToken(random),
+                nextToken(random),
                 ISO_ZONED_DATE_TIME.format(ZonedDateTime.now(clock) + duration)
             )
         )
@@ -71,6 +106,6 @@ private val viewModelLens by lazy {
     Body.viewModel(PebbleTemplates().CachingClasspath(), ContentType.APPLICATION_XML).toLens()
 }
 
-private fun nextSessionToken(random: Random) = byteArrayOf(32)
+private fun nextToken(random: Random) = ByteArray(8)
     .also(random::nextBytes)
-    .base64Encode()
+    .let(Hex::hex)

--- a/connect/amazon/sts/fake/src/main/kotlin/org/http4k/connect/amazon/sts/endpoints.kt
+++ b/connect/amazon/sts/fake/src/main/kotlin/org/http4k/connect/amazon/sts/endpoints.kt
@@ -24,7 +24,7 @@ import java.util.Random
 /**
  * Only supports assumed roles.  Otherwise, 401
  */
-fun getCallerIdentity(clock: Clock, roles: Storage<AssumedRole>) =
+fun getCallerIdentity(clock: Clock, assumedRoles: Storage<AssumedRole>) =
     { request: Request -> request.form("Action") == "GetCallerIdentity" }
         .asRouter() bind fn@{ request: Request ->
 
@@ -35,10 +35,9 @@ fun getCallerIdentity(clock: Clock, roles: Storage<AssumedRole>) =
             ?.firstOrNull()
             ?: return@fn Response(Status.UNAUTHORIZED)
 
-        // only supports assumed roles
         val assumedRole = request
             .header("X-Amz-Security-Token")
-            ?.let { roles["$accessKeyId/$it"] }
+            ?.let { assumedRoles["$accessKeyId/$it"] }
             ?.takeIf { it.expires >= clock.instant() }
             ?: return@fn Response(Status.UNAUTHORIZED)
 
@@ -53,12 +52,10 @@ fun getCallerIdentity(clock: Clock, roles: Storage<AssumedRole>) =
         )
     }
 
-fun assumeRole(defaultSessionValidity: Duration, clock: Clock, random: Random, roles: Storage<AssumedRole>) = { r: Request ->
+fun assumeRole(defaultSessionValidity: Duration, clock: Clock, random: Random, assumedRoles: Storage<AssumedRole>) = { r: Request ->
     r.form("Action") == "AssumeRole" }.asRouter() bind { req: Request ->
-    val duration = req.form("DurationSeconds")
-        ?.toLong()
-        ?.let(Duration::ofSeconds)
-        ?: defaultSessionValidity
+
+    val duration = req.durationSeconds() ?: defaultSessionValidity
 
     val assumedRole = AssumedRole(
         arn = ARN.parse(req.form("RoleArn")!!),
@@ -69,7 +66,7 @@ fun assumeRole(defaultSessionValidity: Duration, clock: Clock, random: Random, r
     val accessKey = nextToken(random)
     val sessionToken = nextToken(random)
 
-    roles["$accessKey/$sessionToken"] = assumedRole
+    assumedRoles["$accessKey/$sessionToken"] = assumedRole
 
     Response(Status.OK).with(
         viewModelLens of AssumeRoleResponse(
@@ -83,21 +80,31 @@ fun assumeRole(defaultSessionValidity: Duration, clock: Clock, random: Random, r
     )
 }
 
-fun assumeRoleWithWebIdentity(defaultSessionValidity: Duration, clock: Clock, random: Random) =
+fun assumeRoleWithWebIdentity(defaultSessionValidity: Duration, clock: Clock, random: Random, assumedRoles: Storage<AssumedRole>) =
     { r: Request -> r.form("Action") == "AssumeRoleWithWebIdentity" }
         .asRouter() bind { req: Request ->
-        val duration = req.form("DurationSeconds")
-            ?.toLong()
-            ?.let(Duration::ofSeconds)
-            ?: defaultSessionValidity
+
+        val duration = req.durationSeconds() ?: defaultSessionValidity
+
+        val assumedRole = AssumedRole(
+            arn = ARN.parse(req.form("RoleArn")!!),
+            sessionName = req.form("RoleSessionName")!!,
+            expires = clock.instant() + duration
+        )
+
+        val accessKey = nextToken(random)
+        val sessionToken = nextToken(random)
+
+        assumedRoles["$accessKey/$sessionToken"] = assumedRole
+
         Response(Status.OK).with(
             viewModelLens of AssumeRoleWithWebIdentityResponse(
-                req.form("RoleArn")!!,
-                req.form("RoleSessionName")!!,
-                "accessKeyId",
-                "secretAccessKey",
-                nextToken(random),
-                ISO_ZONED_DATE_TIME.format(ZonedDateTime.now(clock) + duration)
+                arn = assumedRole.arn.value,
+                roleId = assumedRole.sessionName,
+                accessKeyId = accessKey,
+                secretAccessKey = nextToken(random),
+                sessionToken = sessionToken,
+                ISO_ZONED_DATE_TIME.format(ZonedDateTime.ofInstant(assumedRole.expires, clock.zone))
             )
         )
     }
@@ -109,3 +116,8 @@ private val viewModelLens by lazy {
 private fun nextToken(random: Random) = ByteArray(8)
     .also(random::nextBytes)
     .let(Hex::hex)
+
+
+private fun Request.durationSeconds() = form("DurationSeconds")
+    ?.toLong()
+    ?.let(Duration::ofSeconds)

--- a/connect/amazon/sts/fake/src/main/kotlin/org/http4k/connect/amazon/sts/model.kt
+++ b/connect/amazon/sts/fake/src/main/kotlin/org/http4k/connect/amazon/sts/model.kt
@@ -1,6 +1,8 @@
 package org.http4k.connect.amazon.sts
 
+import org.http4k.connect.amazon.core.model.ARN
 import org.http4k.template.ViewModel
+import java.time.Instant
 
 data class GetCallerIdentityResponse(
     val userId: String,
@@ -25,3 +27,9 @@ data class AssumeRoleWithWebIdentityResponse(
     val sessionToken: String,
     val expiration: String,
 ) : ViewModel
+
+data class AssumedRole(
+    val arn: ARN,
+    val sessionName: String,
+    val expires: Instant
+)

--- a/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/FakeSTSTest.kt
+++ b/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/FakeSTSTest.kt
@@ -3,6 +3,7 @@ package org.http4k.connect.amazon.sts
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.http4k.aws.AwsCredentials
+import org.http4k.connect.RemoteFailure
 import org.http4k.connect.TestClock
 import org.http4k.connect.amazon.CredentialsProvider
 import org.http4k.connect.amazon.FakeAwsContract
@@ -10,7 +11,11 @@ import org.http4k.connect.amazon.core.model.ARN
 import org.http4k.connect.amazon.core.model.Credentials
 import org.http4k.connect.amazon.core.model.RoleSessionName
 import org.http4k.connect.amazon.core.model.WebIdentityToken
+import org.http4k.connect.failureValue
 import org.http4k.connect.successValue
+import org.http4k.core.Method
+import org.http4k.core.Status
+import org.http4k.core.Uri
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.ZonedDateTime
@@ -66,6 +71,24 @@ class FakeSTSTest : STSContract, FakeAwsContract {
         assertThat(identity.Account.value, equalTo("123456789012"))
         assertThat(identity.UserId, equalTo("ARO123EXAMPLE123:my-role-session-name"))
         assertThat(identity.Arn.value, equalTo("arn:aws:sts::123456789012:assumed-role/my-role-name/my-role-session-name"))
+    }
+
+    @Test
+    fun `get caller identity for expired role`() {
+        val assumedRole = sts.assumeRole(
+            RoleArn = ARN.of("arn:aws:sts::123456789012:role/my-role-name"),
+            RoleSessionName = RoleSessionName.of("my-role-session-name"),
+            DurationSeconds = Duration.ofMinutes(10)
+        ).successValue()
+
+        val assumedSts = STS.Http(aws.region, assumedRole.Credentials.provider(), http, clock)
+        assumedSts.getCallerIdentity().successValue()
+
+        clock.tickBy(Duration.ofMinutes(20))
+        assertThat(
+            assumedSts.getCallerIdentity().failureValue(),
+            equalTo(RemoteFailure(Method.POST, Uri.of(""), Status.UNAUTHORIZED, ""))
+        )
     }
 }
 

--- a/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/FakeSTSTest.kt
+++ b/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/FakeSTSTest.kt
@@ -1,5 +1,8 @@
 package org.http4k.connect.amazon.sts
 
+import dev.forkhandles.result4k.map
+import org.http4k.aws.AwsCredentials
+import org.http4k.connect.TestClock
 import org.http4k.connect.amazon.FakeAwsContract
 import org.http4k.connect.amazon.core.model.ARN
 import org.http4k.connect.amazon.core.model.RoleSessionName
@@ -8,18 +11,19 @@ import org.http4k.connect.successValue
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
-import org.http4k.core.Request.Companion.invoke
 import org.http4k.core.Status
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.ZonedDateTime
+import java.util.Random
 import java.util.UUID
 
 class FakeSTSTest : STSContract, FakeAwsContract {
 
-    override val http = FakeSTS()
+    override val clock = TestClock()
+    override val http = FakeSTS(clock = clock, random = Random(42))
 
     @Test
     fun `assume role with web identity`() {
@@ -37,8 +41,16 @@ class FakeSTSTest : STSContract, FakeAwsContract {
     }
 
     @Test
-    fun `get caller identity via sts client action`() {
-        val response = sts.getCallerIdentity().successValue()
+    fun `get caller identity for assumed role`() {
+        val credentials = sts.assumeRole(
+            RoleArn = ARN.of("arn:aws:sts::123456789012:role/my-role-name"),
+            RoleSessionName = RoleSessionName.of("my-role-session-name")
+        )
+            .map { AwsCredentials(it.Credentials.AccessKeyId.value, it.Credentials.SecretAccessKey.value, it.Credentials.Token.value) }
+            .successValue()
+
+        val response = STS.Http(aws.region, { credentials }, http, clock)
+            .getCallerIdentity().successValue()
 
         assertEquals("123456789012", response.Account.value)
         assertEquals("ARO123EXAMPLE123:my-role-session-name", response.UserId)
@@ -46,30 +58,5 @@ class FakeSTSTest : STSContract, FakeAwsContract {
             "arn:aws:sts::123456789012:assumed-role/my-role-name/my-role-session-name",
             response.Arn.value
         )
-    }
-    @Test
-    fun `get caller identity via form encoded post`() {
-        val response = http(
-            Request(POST, "/")
-                .header("Content-Type", "application/x-www-form-urlencoded")
-                .body("Action=GetCallerIdentity&Version=2011-06-15")
-        )
-
-        assertTrue(response.status.successful)
-        assertTrue(response.bodyString().contains("<GetCallerIdentityResponse"))
-        assertTrue(response.bodyString().contains("<Account>123456789012</Account>"))
-        assertTrue(response.bodyString().contains("<UserId>ARO123EXAMPLE123:my-role-session-name</UserId>"))
-        assertTrue(response.bodyString().contains("<Arn>arn:aws:sts::123456789012:assumed-role/my-role-name/my-role-session-name</Arn>"))
-    }
-
-    @Test
-    fun `get caller identity via query string is unsupported`() {
-        val response = http(
-            Request(GET, "/")
-                .query("Action", "GetCallerIdentity")
-                .query("Version", "2011-06-15")
-        )
-
-        assertEquals(Status.NOT_FOUND, response.status)
     }
 }

--- a/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/FakeSTSTest.kt
+++ b/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/FakeSTSTest.kt
@@ -1,24 +1,20 @@
 package org.http4k.connect.amazon.sts
 
-import dev.forkhandles.result4k.map
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
 import org.http4k.aws.AwsCredentials
 import org.http4k.connect.TestClock
+import org.http4k.connect.amazon.CredentialsProvider
 import org.http4k.connect.amazon.FakeAwsContract
 import org.http4k.connect.amazon.core.model.ARN
+import org.http4k.connect.amazon.core.model.Credentials
 import org.http4k.connect.amazon.core.model.RoleSessionName
 import org.http4k.connect.amazon.core.model.WebIdentityToken
 import org.http4k.connect.successValue
-import org.http4k.core.Method.GET
-import org.http4k.core.Method.POST
-import org.http4k.core.Request
-import org.http4k.core.Status
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.time.ZonedDateTime
 import java.util.Random
-import java.util.UUID
 
 class FakeSTSTest : STSContract, FakeAwsContract {
 
@@ -26,37 +22,57 @@ class FakeSTSTest : STSContract, FakeAwsContract {
     override val http = FakeSTS(clock = clock, random = Random(42))
 
     @Test
-    fun `assume role with web identity`() {
-        val result = sts.assumeRoleWithWebIdentity(
+    fun `assume role with web identity and get caller identity`() {
+        val assumedRole = sts.assumeRoleWithWebIdentity(
             ARN.of("arn:aws:iam::169766454405:role/ROLETEST"),
-            RoleSessionName.of(UUID.randomUUID().toString()),
-            DurationSeconds = Duration.ofHours(1),
-            WebIdentityToken = WebIdentityToken.of("token")
+            RoleSessionName.of("web-role-session-name"),
+            DurationSeconds = Duration.ofHours(2),
+            WebIdentityToken = WebIdentityToken.of("web-token")
+        ).successValue()
+
+        assertThat(assumedRole.AssumedRoleId.value, equalTo("web-role-session-name"))
+        assertThat(
+            assumedRole.Credentials.Expiration.value,
+            equalTo(ZonedDateTime.now(clock).plus(Duration.ofHours(2)))
         )
 
-        assertTrue(
-            result.successValue()
-                .Credentials.Expiration.value.isAfter(ZonedDateTime.now(clock))
-        )
+        val identity = STS.Http(aws.region, assumedRole.Credentials.provider(), http, clock)
+            .getCallerIdentity()
+            .successValue()
+
+        assertThat(identity.Account.value, equalTo("169766454405"))
+        assertThat(identity.UserId, equalTo("ARO123EXAMPLE123:web-role-session-name"))
+        assertThat(identity.Arn.value, equalTo("arn:aws:sts::169766454405:assumed-role/ROLETEST/web-role-session-name"))
     }
 
     @Test
-    fun `get caller identity for assumed role`() {
-        val credentials = sts.assumeRole(
+    fun `assume role and get caller identity`() {
+        val assumedRole = sts.assumeRole(
             RoleArn = ARN.of("arn:aws:sts::123456789012:role/my-role-name"),
-            RoleSessionName = RoleSessionName.of("my-role-session-name")
+            RoleSessionName = RoleSessionName.of("my-role-session-name"),
+            DurationSeconds = Duration.ofHours(3)
+        ).successValue()
+
+        assertThat(assumedRole.AssumedRoleId.value, equalTo("my-role-session-name"))
+        assertThat(
+            assumedRole.Credentials.Expiration.value,
+            equalTo(ZonedDateTime.now(clock).plus(Duration.ofHours(3)))
         )
-            .map { AwsCredentials(it.Credentials.AccessKeyId.value, it.Credentials.SecretAccessKey.value, it.Credentials.Token.value) }
+
+        val identity = STS.Http(aws.region, assumedRole.Credentials.provider(), http, clock)
+            .getCallerIdentity()
             .successValue()
 
-        val response = STS.Http(aws.region, { credentials }, http, clock)
-            .getCallerIdentity().successValue()
-
-        assertEquals("123456789012", response.Account.value)
-        assertEquals("ARO123EXAMPLE123:my-role-session-name", response.UserId)
-        assertEquals(
-            "arn:aws:sts::123456789012:assumed-role/my-role-name/my-role-session-name",
-            response.Arn.value
-        )
+        assertThat(identity.Account.value, equalTo("123456789012"))
+        assertThat(identity.UserId, equalTo("ARO123EXAMPLE123:my-role-session-name"))
+        assertThat(identity.Arn.value, equalTo("arn:aws:sts::123456789012:assumed-role/my-role-name/my-role-session-name"))
     }
+}
+
+private fun Credentials.provider() = CredentialsProvider {
+    AwsCredentials(
+        accessKey = AccessKeyId.value,
+        secretKey = SecretAccessKey.value,
+        sessionToken = Token.value
+    )
 }

--- a/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/RunningFakeSTSTest.kt
+++ b/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/RunningFakeSTSTest.kt
@@ -2,5 +2,8 @@ package org.http4k.connect.amazon.sts
 
 import org.http4k.connect.WithRunningFake
 import org.http4k.connect.amazon.FakeAwsContract
+import java.time.Clock
 
-class RunningFakeSTSTest : STSContract, FakeAwsContract, WithRunningFake(::FakeSTS)
+class RunningFakeSTSTest : STSContract, FakeAwsContract, WithRunningFake(::FakeSTS) {
+    override val clock: Clock = Clock.systemUTC()
+}

--- a/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/StsProfileCredentialsProviderTest.kt
+++ b/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/StsProfileCredentialsProviderTest.kt
@@ -60,7 +60,7 @@ class StsProfileCredentialsProviderTest {
             credentialsPath = credentialsFile,
             configPath = configFile,
             profileName = name,
-            getStsClient = { FakeSTS(clock).client() }
+            getStsClient = { FakeSTS(clock = clock).client() }
         ).invoke()
     }
 

--- a/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/StsProfileCredentialsProviderTest.kt
+++ b/connect/amazon/sts/fake/src/test/kotlin/org/http4k/connect/amazon/sts/StsProfileCredentialsProviderTest.kt
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
+import java.util.Random
 
 class StsProfileCredentialsProviderTest {
 
@@ -60,7 +61,7 @@ class StsProfileCredentialsProviderTest {
             credentialsPath = credentialsFile,
             configPath = configFile,
             profileName = name,
-            getStsClient = { FakeSTS(clock = clock).client() }
+            getStsClient = { FakeSTS(clock = clock, random = Random(42)).client() }
         ).invoke()
     }
 
@@ -98,8 +99,8 @@ class StsProfileCredentialsProviderTest {
     fun `load profile - assume with credentials`() {
         val credentials = getCredentials(ProfileName.of("dev"))
         assertThat(credentials, present())
-        assertThat(credentials!!.accessKey, equalTo("accessKeyId"))
-        assertThat(credentials.secretKey, equalTo("secretAccessKey"))
+        assertThat(credentials!!.accessKey, equalTo("359d41baf78afe0d"))
+        assertThat(credentials.secretKey, equalTo("e43c084f4bbb2bf1"))
         assertThat(credentials.sessionToken, present())
     }
 
@@ -107,8 +108,8 @@ class StsProfileCredentialsProviderTest {
     fun `load profile - assume with assumed profile`() {
         val credentials = getCredentials(ProfileName.of("dev2"))
         assertThat(credentials, present())
-        assertThat(credentials!!.accessKey, equalTo("accessKeyId"))
-        assertThat(credentials.secretKey, equalTo("secretAccessKey"))
+        assertThat(credentials!!.accessKey, equalTo("359d41baf78afe0d"))
+        assertThat(credentials.secretKey, equalTo("e43c084f4bbb2bf1"))
         assertThat(credentials.sessionToken, present())
     }
 
@@ -124,8 +125,8 @@ class StsProfileCredentialsProviderTest {
     fun `load profile from config - assume with credentials`() {
         val credentials = getCredentials(ProfileName.of("prod"))
         assertThat(credentials, present())
-        assertThat(credentials!!.accessKey, equalTo("accessKeyId"))
-        assertThat(credentials.secretKey, equalTo("secretAccessKey"))
+        assertThat(credentials!!.accessKey, equalTo("359d41baf78afe0d"))
+        assertThat(credentials.secretKey, equalTo("e43c084f4bbb2bf1"))
         assertThat(credentials.sessionToken, present())
     }
 }

--- a/connect/core/fake/src/testFixtures/kotlin/org/http4k/connect/utils.kt
+++ b/connect/core/fake/src/testFixtures/kotlin/org/http4k/connect/utils.kt
@@ -11,6 +11,7 @@ import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 import java.time.ZoneId
+import java.time.ZoneOffset
 
 class CapturingHttpHandler : HttpHandler {
     var captured: Request? = null
@@ -32,10 +33,13 @@ fun <T, E> Result<T, E>.failureValue(fn: (E) -> Unit = {}): E = when (this) {
     is Failure -> reason.also(fn)
 }
 
-class TestClock(private var time: Instant = Instant.EPOCH) : Clock() {
-    override fun getZone(): ZoneId = TODO("Not yet implemented")
+class TestClock(
+    private var time: Instant = Instant.EPOCH,
+    private val currentZone: ZoneId = ZoneOffset.UTC
+) : Clock() {
+    override fun getZone() = currentZone
 
-    override fun withZone(zone: ZoneId?): Clock = TODO("Not yet implemented")
+    override fun withZone(zone: ZoneId?) = TestClock(time, zone ?: ZoneOffset.UTC)
 
     override fun instant(): Instant = time
 


### PR DESCRIPTION
Users can now control the output of the fake STS `getCallerIdentity` function by assuming roles with `assumeRole`, `assumeRoleWithWebIdentity`, or by manually updating the storage.  It will now return a 401 when no role is assumed, or the assumed credentials have expired.  It does not support IAM users.