### PR TITLE
fix: handle brace quantifiers in UriTemplate regex patterns (#676)

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/core/UriTemplate.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/UriTemplate.kt
@@ -17,7 +17,7 @@ data class UriTemplate private constructor(private val template: String) {
     private val parameterNames = matches.map { it.groupValues[1] }.toList()
 
     companion object {
-        private val URI_TEMPLATE_FORMAT = "\\{([^}]+?)(?::([^}]+))?\\}".toRegex() // ignore redundant warning #100
+        private val URI_TEMPLATE_FORMAT = "\\{([^:}]+)(?::((?:[^{}]|\\{[^{}]*\\})+))?\\}".toRegex() // ignore redundant warning #100
         fun from(template: String) = UriTemplate(template.trimSlashes())
 
         private fun String.trimSlashes() = "^(/+)?(.*?)(/+)?$".toRegex().replace(this) { result -> result.groupValues[2] }

--- a/core/core/src/test/kotlin/org/http4k/core/UriTemplateTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/UriTemplateTest.kt
@@ -3,7 +3,6 @@ package org.http4k.core
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import org.http4k.core.UriTemplate.Companion.from
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
 class UriTemplateTest {
@@ -142,10 +141,27 @@ class UriTemplateTest {
     }
 
     @Test
-    @Disabled
     fun greedyQualifiersAreNotReplaced() {
         val patternWithGreedyQualifier = "[a-z]{3}"
         assertThat(from("/foo/{bar:$patternWithGreedyQualifier}").matches("/foo/abc"), equalTo(true))
+    }
+
+    @Test
+    fun regexWithBraceQuantifierAndAlternation() {
+        val compactUuid = "[a-fA-F0-9]{32}"
+        val prettyUuid = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+        val uuidRegex = "(?:$compactUuid|$prettyUuid)"
+        assertThat(from("/api/v1/sample/{id:$uuidRegex}").matches("/api/v1/sample/abc123abcdef1234abcd1234ab123456"), equalTo(true))
+        assertThat(from("/api/v1/sample/{id:$uuidRegex}").matches("/api/v1/sample/550e8400-e29b-41d4-a716-446655440000"), equalTo(true))
+    }
+
+    @Test
+    fun regexWithBraceQuantifierAndAlternationExtract() {
+        val compactUuid = "[a-fA-F0-9]{32}"
+        val prettyUuid = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+        val uuidRegex = "(?:$compactUuid|$prettyUuid)"
+        val template = from("/api/v1/sample/{id:$uuidRegex}")
+        assertThat(template.extract("/api/v1/sample/550e8400-e29b-41d4-a716-446655440000").getValue("id"), equalTo("550e8400-e29b-41d4-a716-446655440000"))
     }
 
     private fun pathParameters(vararg pairs: Pair<String, String>): Map<String, String> = mapOf(*pairs)


### PR DESCRIPTION
Fixes #676

## Problem
The `URI_TEMPLATE_FORMAT` regex `\{([^}]+?)(?::([^}]+))?\}` uses `[^}]+` for the regex part of path parameters. This fails when the user's regex contains `{n}` style quantifiers (e.g. `[a-z]{3}`) because the first `}` from the quantifier is matched as the closing brace of the template parameter.

For example, `/foo/{bar:[a-z]{3}}` would incorrectly parse the regex as `[a-z]{3}` and leave a trailing `}` unmatched, causing a `PatternSyntaxException`.

## Solution
Updated `URI_TEMPLATE_FORMAT` to properly handle balanced braces in the regex part by matching `{...}` groups:

```
\{([^:}]+)(?::((?:[^{}]|\{[^{}]*\})+))?\}
```

This pattern matches `{n}`, `{n,m}`, and other brace-containing regex constructs within the parameter regex while correctly finding the actual closing `}` of the template parameter.

## Changes
- `UriTemplate.kt`: Fixed `URI_TEMPLATE_FORMAT` regex to handle brace quantifiers
- `UriTemplateTest.kt`: Enabled previously disabled `greedyQualifiersAreNotReplaced` test and added tests for complex UUID regex patterns with multiple brace quantifiers and alternation