### PR TITLE
Update amazon sso grant type wire values

### DIFF
--- a/connect/amazon/iamidentitycenter/client/src/main/kotlin/org/http4k/connect/amazon/iamidentitycenter/model/GrantType.kt
+++ b/connect/amazon/iamidentitycenter/client/src/main/kotlin/org/http4k/connect/amazon/iamidentitycenter/model/GrantType.kt
@@ -2,8 +2,10 @@ package org.http4k.connect.amazon.iamidentitycenter.model
 
 enum class GrantType(val wireValue: String) {
     AuthorizationCode("authorization_code"),
+    AuthorizationCode2("AuthorizationCode"),
     DeviceCode("urn:ietf:params:oauth:grant-type:device_code"),
-    RefreshToken("refresh_token");
+    RefreshToken("refresh_token"),
+    RefreshToken2("RefreshToken");
 
     companion object {
         fun fromWire(wireValue: String) = entries.first { it.wireValue == wireValue }


### PR DESCRIPTION
There appears to have been a breaking change to the Amazon SSO API.  Updated `GrantType` with the new values.