### PR TITLE
Use CodeQL build-mode: none for Java/Kotlin analysis

### DIFF
--- a/.github/workflows/security_codeql.yml
+++ b/.github/workflows/security_codeql.yml
@@ -46,30 +46,23 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4.2.2
-    
-    - uses: actions/setup-java@v4.7.1
-      with:
-        distribution: adopt
-        java-version: 21
-        cache: gradle
+      uses: actions/checkout@v6.0.2
 
     # Initializes the CodeQL tools for scanning.
+    # build-mode: none extracts the Kotlin/Java code directly from source rather
+    # than tracing a full Gradle build, so this job no longer depends on building
+    # the entire project under the CodeQL tracer (which is what was failing here).
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
+        build-mode: none
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-
-
-    - name: Build
-      timeout-minutes: 120
-      run: bin/build_ci.sh
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Why

The **Security - Vulnerability Scanning (CodeQL)** workflow has been failing on `master` (e.g. [run 26682705189](https://github.com/http4k/http4k/actions/runs/26682705189)) while the normal **Build** workflow — which runs the *same* `bin/build_ci.sh` — stays green.

The difference is the CodeQL path: with `build-mode` unset, CodeQL v4 performs a **full traced Gradle build** of the entire project under its tracer. That's the fragile part that fails even though the project builds and tests fine normally. The run also emitted the warning:

> Cannot build an overlay-base database because build-mode is set to 'undefined' instead of 'none'. Falling back to creating a normal full database instead.

## What changed

- Set `build-mode: none` on `github/codeql-action/init`, so CodeQL extracts Kotlin/Java **directly from source** instead of tracing a Gradle build. This is the GitHub-recommended mode for JVM repos.
- Removed the now-unnecessary `actions/setup-java` and `Build` (`bin/build_ci.sh`) steps from the CodeQL job — the analysis no longer needs a JDK or a built project.
- Bumped `actions/checkout@v4.2.2` → `@v6.0.2` to match the rest of the repo and clear the Node 20 deprecation warning.

## Effects

- Removes the dependency on building the whole project under the CodeQL tracer (the failing step).
- Resolves the overlay-base / `build-mode 'undefined'` warning.
- Cuts the job from ~33 minutes to a couple of minutes.

`build_ci.sh` and the other workflows are intentionally left untouched, since the main build is green.

https://claude.ai/code/session_01BaYjpjpw3xgHMVjsGtVtgx

---
_Generated by [Claude Code](https://claude.ai/code/session_01BaYjpjpw3xgHMVjsGtVtgx)_