### PR TITLE
Render max-age=0 Cache-Control directive for a zero Duration

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
+++ b/core/core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
@@ -11,7 +11,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME
 
 open class CacheControlHeaderPart(open val name: String, val value: Duration) {
-    fun toHeaderValue(): String = if (value.seconds > 0) "$name=${value.seconds}" else ""
+    fun toHeaderValue(): String = if (value.seconds >= 0) "$name=${value.seconds}" else ""
     fun replaceIn(header: String?): String = header?.let {
         header.split(",")
             .map { it.trim() }

--- a/core/core/src/test/kotlin/org/http4k/filter/CachingFiltersTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/filter/CachingFiltersTest.kt
@@ -86,7 +86,10 @@ class CachingFiltersTest {
         val responseWithHeaders = Response(OK)
         val response = getResponseWith(timingsWithZeroValues, responseWithHeaders)
 
-        assertThat(response, hasHeader("Cache-Control", listOf("public, max-age=10")))
+        assertThat(
+            response,
+            hasHeader("Cache-Control", listOf("public, max-age=10, stale-while-revalidate=0, stale-if-error=0"))
+        )
     }
 
     @Test
@@ -119,6 +122,23 @@ class CachingFiltersTest {
         val response = MaxAge(Duration.ofHours(1)).responseFor(Request(GET, ""))
         assertThat(response, hasHeader("Cache-Control", "public, max-age=3600"))
         assertThat(response, !hasHeader("Expires"))
+    }
+
+    @Test
+    fun `MaxAge - renders max-age directive for a zero Duration`() {
+        val response = MaxAge(ZERO).responseFor(Request(GET, ""))
+        assertThat(response, hasHeader("Cache-Control", "public, max-age=0"))
+        assertThat(response, !hasHeader("Expires"))
+    }
+
+    @Test
+    fun `FallbackCacheControl - renders max-age directive for a zero Duration`() {
+        val zeroMaxAge = DefaultCacheTimings(MaxAgeTtl(ZERO), StaleIfErrorTtl(ZERO), StaleWhenRevalidateTtl(ZERO))
+        val response = getResponseWith(zeroMaxAge, Response(OK))
+        assertThat(
+            response,
+            hasHeader("Cache-Control", listOf("public, max-age=0, stale-while-revalidate=0, stale-if-error=0"))
+        )
     }
 
     @Test


### PR DESCRIPTION
## Problem

`CachingFilters.CacheResponse.MaxAge(Duration.ZERO)` (e.g. `0.seconds`) does not render the `max-age` directive. Instead of producing `Cache-Control: public, max-age=0`, it produces `Cache-Control: public,` with the directive dropped entirely.

The cause is in `CacheControlHeaderPart.toHeaderValue()`:

```kotlin
fun toHeaderValue(): String = if (value.seconds > 0) "$name=${value.seconds}" else ""
```

A zero-second duration fails the `> 0` check and yields an empty string. But `max-age=0` is a meaningful directive — it marks the response as immediately stale and forces revalidation — which is quite different from omitting `max-age` altogether.

## Fix

Change the threshold from `> 0` to `>= 0` so a zero duration renders. Negative durations still render as empty.

The `stale-while-revalidate` and `stale-if-error` directives are now also rendered at zero (`stale-while-revalidate=0`, `stale-if-error=0`), which is semantically equivalent to omitting them.

## Tests

- Added `MaxAge - renders max-age directive for a zero Duration`
- Added `FallbackCacheControl - renders max-age directive for a zero Duration`
- Updated the existing empty-Duration test to reflect zero-valued directives now rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)