### PR TITLE
Add ProxyRevalidate Cache-Control filter

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
+++ b/core/core/src/main/kotlin/org/http4k/filter/CachingFilters.kt
@@ -82,6 +82,19 @@ object CachingFilters {
         }
 
         /**
+         * Adds a "proxy-revalidate" directive, instructing shared (proxy) caches to revalidate a stale
+         * response with the origin server before serving it. Unlike "must-revalidate" this does not apply
+         * to private caches.
+         * By default, only applies when the status code of the response is < 400. This is overridable.
+         */
+        object ProxyRevalidate {
+            operator fun invoke(predicate: (Response) -> Boolean = { it.status.code < 400 }): Filter =
+                object : CacheFilter(predicate) {
+                    override fun headersFor(response: Response) = listOf("Cache-Control" to "public, proxy-revalidate")
+                }
+        }
+
+        /**
          * By default, only applies when the status code of the response is < 400. This is overridable.
          */
         object MaxAge {

--- a/core/core/src/test/kotlin/org/http4k/filter/CachingFiltersTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/filter/CachingFiltersTest.kt
@@ -13,6 +13,7 @@ import org.http4k.filter.CachingFilters.CacheRequest.AddIfModifiedSince
 import org.http4k.filter.CachingFilters.CacheResponse.FallbackCacheControl
 import org.http4k.filter.CachingFilters.CacheResponse.MaxAge
 import org.http4k.filter.CachingFilters.CacheResponse.NoCache
+import org.http4k.filter.CachingFilters.CacheResponse.ProxyRevalidate
 import org.http4k.hamkrest.hasHeader
 import org.http4k.util.FixedClock
 import org.junit.jupiter.api.Test
@@ -105,6 +106,25 @@ class CachingFiltersTest {
     @Test
     fun `NoCache - does not add headers if response fails predicate`() {
         val response = NoCache { false }.responseFor(Request(GET, ""))
+        assertThat(response.headers, equalTo(emptyList()))
+    }
+
+    @Test
+    fun `ProxyRevalidate - does not cache non-GET requests`() {
+        val response = ProxyRevalidate().responseFor(Request(PUT, ""))
+        assertThat(response.headers, equalTo(emptyList()))
+    }
+
+    @Test
+    fun `ProxyRevalidate - adds correct headers to GET responses`() {
+        val response = ProxyRevalidate().responseFor(Request(GET, ""))
+        assertThat(response, hasHeader("Cache-Control", "public, proxy-revalidate"))
+        assertThat(response, !hasHeader("Expires"))
+    }
+
+    @Test
+    fun `ProxyRevalidate - does not add headers if response fails predicate`() {
+        val response = ProxyRevalidate { false }.responseFor(Request(GET, ""))
         assertThat(response.headers, equalTo(emptyList()))
     }
 


### PR DESCRIPTION
## What

Adds a new response filter `CachingFilters.CacheResponse.ProxyRevalidate` that applies the `proxy-revalidate` Cache-Control directive.

```kotlin
ProxyRevalidate().then(handler)
// => Cache-Control: public, proxy-revalidate
```

## Why

`proxy-revalidate` (RFC 7234 §5.2.2.7) tells shared/proxy caches they must revalidate a stale response with the origin server before serving it. It behaves like `must-revalidate` but does not apply to private caches — useful when you want browsers to serve cached content freely while forcing CDNs/proxies to revalidate.

There was previously no way to emit this directive via the caching filters.

## Design

Mirrors the existing `NoCache` object filter:
- Same `operator fun invoke(predicate)` shape, defaulting to only apply for responses with status `< 400`.
- Only applies to `GET` requests (via the shared `CacheFilter` base).
- Emits `public, proxy-revalidate` — `proxy-revalidate` targets shared caches, which store `public` responses, so they are paired (analogous to `NoCache`'s `private, must-revalidate`).

## Tests

Added the standard filter test trio: skips non-GET requests, adds the header on GET, and respects the predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)