### PR TITLE
Add Response.proxyRevalidate() cache-control extension

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/ResponseCacheExt.kt
@@ -17,6 +17,8 @@ fun Response.onlyIfCached() = addCacheability("only-if-cached")
 
 fun Response.mustRevalidate() = addCacheability("must-revalidate")
 
+fun Response.proxyRevalidate() = addCacheability("proxy-revalidate")
+
 fun Response.noStore() = addCacheability("no-store")
 
 fun Response.immutable() = addCacheability("immutable")

--- a/core/core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/ResponseCacheExtTest.kt
@@ -47,6 +47,13 @@ class ResponseCacheExtTest {
     }
 
     @Test
+    fun `adds proxy-revalidate to response Cache-Control header`() {
+        val proxyRevalidateResponse = Response(OK).proxyRevalidate()
+
+        assertThat(proxyRevalidateResponse.header("Cache-Control"), equalTo("proxy-revalidate"))
+    }
+
+    @Test
     fun `adds no-store to response Cache-Control header`() {
         val noStoreResponse = Response(OK).noStore()
 


### PR DESCRIPTION
## What

Adds a `Response.proxyRevalidate()` extension function in `ResponseCacheExt.kt`:

```kotlin
Response(OK).proxyRevalidate()   // Cache-Control: proxy-revalidate
```

## Why

`proxy-revalidate` (RFC 7234 §5.2.2.7) instructs shared/proxy caches to revalidate a stale response with the origin before serving it. It behaves like `must-revalidate` but does not apply to private caches — useful when browsers may serve cached content freely while CDNs/proxies must revalidate.

## Design

Mirrors the existing valueless flag directives (`mustRevalidate()`, `noStore()`, `immutable()`, etc.) — a one-liner delegating to the private `addCacheability(...)` helper, so it composes and chains with the other cache-control extensions just like the rest.

## Tests

Added a test to `ResponseCacheExtTest` following the existing pattern for flag directives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)