### PR TITLE
Fix issue posting a multipart form with no file selected in WebDriver implementation

### DIFF
--- a/core/testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
+++ b/core/testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupWebElement.kt
@@ -104,6 +104,7 @@ data class JSoupWebElement(
                 .filter { it.getDomAttribute("name") != "" }
                 .filter { it.isNotDisabled() }
                 .filter { it.isAFileInput() }
+                .filter { !it.getDomAttribute("value").isNullOrEmpty() }
                 .map { it.getDomAttribute("name") to listOf(it.getDomAttribute("value")) }
 
             val textAreas = associatedFormElements(form, "textarea")

--- a/core/testing/webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverFormTest.kt
+++ b/core/testing/webdriver/src/test/kotlin/org/http4k/webdriver/Http4kWebDriverFormTest.kt
@@ -293,7 +293,41 @@ class Http4kWebDriverFormTest {
         assertThat(driver, hasElement(By.tagName("theotherformfields"), hasText(equalTo(expectedOtherFields))))
     }
 
+    @Test
+    fun `POST multipart form with no file selected is successful`() {
+        val driver =
+            Http4kWebDriver({ req ->
+                val body = File("src/test/resources/file_upload_test.html").readText()
+                if (req.method == GET) return@Http4kWebDriver Response(Status.OK).body(body)
 
+                val formBody = MultipartFormBody.from(req)
+                val multipleFiles = formBody.files("multiple-files")
+                val file = formBody.file("file")
+                val otherFieldNames = listOf("text1", "textarea1", "checkbox1", "select1", "button")
+                val pairsOfOtherFields =
+                    otherFieldNames.flatMap { fieldName -> formBody.fieldValues(fieldName).map { fieldName to it } }
+                val otherFieldsString =
+                    pairsOfOtherFields.joinToString("&") { (fieldName, value) -> "$fieldName=$value" }
+
+                Response(Status.OK).body(
+                    body
+                        .replace("ENCODING", req.header("content-type").orEmpty())
+                        .replace("MULTIFILENAMES", multipleFiles.joinToString(",") { it.filename })
+                        .replace("MULTIFILECONTENTS", multipleFiles.joinToString(",") { it.content.asString() })
+                        .replace("FILENAME", file?.filename.orEmpty())
+                        .replace("FILECONTENT", file?.content?.asString().orEmpty())
+                        .replace("OTHERFORMFIELDS", otherFieldsString),
+                )
+            })
+
+        driver.get("https://example.com/bob")
+        driver.findElement(By.tagName("button")).submit()
+
+        assertThat(driver, hasElement(By.tagName("thefilename"), hasText(equalTo(""))))
+        assertThat(driver, hasElement(By.tagName("themultifilenames"), hasText(equalTo(""))))
+        assertThat(driver, hasElement(By.tagName("thefilecontent"), hasText(equalTo(""))))
+        assertThat(driver, hasElement(By.tagName("themultifilecontents"), hasText(equalTo(""))))
+    }
 }
 
 private fun tempFileContaining(content: String) = createTempFile("file-upload-test", ".txt")


### PR DESCRIPTION
Hi!

Needed this fix for something at work. The issue is that when we post a multipart form without uploading a file, the WebDriver implementation returns a FileNotFoundException, which shouldn't be the case.

The test shows a reasonable example of "sending" a request without a file through a submit in the WebDriver, and we just assert that the request goes through when there are no files uploaded.

Thanks!