### PR TITLE
Specify locator name for a better debugging experience

### DIFF
--- a/core/testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupElementFinder.kt
+++ b/core/testing/webdriver/src/main/kotlin/org/http4k/webdriver/JSoupElementFinder.kt
@@ -31,6 +31,8 @@ class JSoupElementFinder(
     }
 
     private fun cssSelector(cssSelector: String) = object : By() {
+        override fun toString(): String = "By.cssSelector: " + cssSelector;
+
         override fun findElements(context: SearchContext) = when (context) {
             is JSoupElementFinder -> context.findElementsByCssQuery(cssSelector)
 


### PR DESCRIPTION
Messages like this:

```
org.openqa.selenium.NoSuchElementException: Cannot locate an element using [unknown locator]
For documentation on this error, please visit: https://www.selenium.dev/documentation/webdriver/troubleshooting/errors#nosuchelementexception
Build info: version: '4.45.0', revision: 'cd6a3cd cd6a3cdfca6970f62e5bc8344109d0fe0e2af05e'
System info: os.name: 'Mac OS X', os.arch: 'aarch64', os.version: '26.5.1', java.version: '21.0.11'
Driver info: driver.version: unknown
	at org.openqa.selenium.By.findElement(By.java:125)
	at org.http4k.webdriver.JSoupElementFinder.findElement(JSoupElementFinder.kt:22)
	at org.http4k.webdriver.JSoupWebElement.findElement(JSoupWebElement.kt:257)
	at com.github.tamj0rd2.getorgd.SmokeTest.can create and complete todos(SmokeTest.kt:56)
```

Will say `By.cssSelector: some-selector` rather than `using [unknown locator]`