### PR TITLE
MimeTypes to support files paths without extensions

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/core/MimeTypes.kt
+++ b/core/core/src/main/kotlin/org/http4k/core/MimeTypes.kt
@@ -5,10 +5,11 @@ import org.http4k.util.loadMetaResource
 import java.util.Locale.ROOT
 
 class MimeTypes private constructor(private val map: Map<String, ContentType>) {
-    fun forFile(file: String): ContentType =
-        file.drop(file.lastIndexOf('.') + 1).let {
-            if (it == file) OCTET_STREAM else map[it.lowercase(ROOT)] ?: OCTET_STREAM
-        }
+    fun forFile(path: String): ContentType {
+        val fileName = path.substringAfterLast('/')
+        val extension = if (fileName.contains('.')) fileName.substringAfterLast('.') else ""
+        return map[extension.lowercase(ROOT)] ?: OCTET_STREAM
+    }
 
     companion object {
         operator fun invoke(overrides: Map<String, ContentType> = emptyMap()): MimeTypes =

--- a/core/core/src/test/kotlin/org/http4k/core/MimeTypesTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/core/MimeTypesTest.kt
@@ -37,6 +37,11 @@ class MimeTypesTest {
         assertCorrectContentTypeFoundFor(MimeTypes(mapOf("foobar" to TEXT_HTML)), "/foo/bob.foobar", TEXT_HTML)
     }
 
+    @Test
+    fun `can override content type for extension-less file`() {
+        assertCorrectContentTypeFoundFor(MimeTypes(mapOf("" to TEXT_PLAIN)), "/foo/NOTICE", TEXT_PLAIN)
+    }
+
     private fun assertCorrectContentTypeFoundFor(mimeTypes: MimeTypes, ext: String, expected: ContentType) {
         assertThat("checking $ext", mimeTypes.forFile(ext), equalTo(expected))
         assertThat("checking ${ext.uppercase(getDefault())}", mimeTypes.forFile(ext.uppercase(getDefault())), equalTo(expected))

--- a/core/core/src/test/kotlin/org/http4k/routing/StaticPrefixRoutingTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/routing/StaticPrefixRoutingTest.kt
@@ -2,6 +2,7 @@ package org.http4k.routing
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import org.http4k.core.ContentType
 import org.http4k.core.Method.GET
 import org.http4k.core.Request
 import org.http4k.core.Status.Companion.NOT_FOUND
@@ -85,5 +86,22 @@ class StaticPrefixRoutingTest {
     @Test
     fun `cannot escape the static base package via dot-dot`() {
         assertThat(app(Request(GET, "/bar/../mybob.xml")).status, equalTo(NOT_FOUND))
+    }
+
+    @Test
+    fun `file without extension`() {
+        assertThat(app(Request(GET, "/bar/NOTICE")).status, equalTo(NOT_FOUND))
+    }
+
+    @Test
+    fun `file without extension - with explicit support`() {
+        app = routes("/bar" bind static(
+            resourceLoader = Classpath("bar"),
+            extraFileExtensionToContentTypes = arrayOf("" to ContentType.TEXT_PLAIN)
+        ))
+
+        val result = app(Request(GET, "/bar/NOTICE"))
+        assertThat(result.status, equalTo(OK))
+        assertThat(result.bodyString(), equalTo("Thank you for noticing\n"))
     }
 }

--- a/core/core/src/test/resources/bar/NOTICE
+++ b/core/core/src/test/resources/bar/NOTICE
@@ -1,0 +1,1 @@
+Thank you for noticing


### PR DESCRIPTION
`MimeTypes.forFile` is unable to parse the extension for an extension-less file, e.g. `NOTICE`.  This prevents the `static` routing handler from serving extensionless-files, like `LICENSE`.  This is problematic when you're trying to do something like serving a generated license report.

This update will cause `MimeTypes` to return an empty-string for an unknown extension, allowing the content-type to be overridden generically.