### PR TITLE
Use toolbox repo token for update-dependencies PR creation

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -46,6 +46,7 @@ jobs:
       if: steps.changes.outputs.has_changes
       uses: peter-evans/create-pull-request@v8.1.1
       with:
+        token: ${{ secrets.TOOLBOX_REPO_TOKEN }}
         commit-message: 'chore: Update dependencies'
         title: 'chore: update dependencies'
         body: |-

--- a/src/typeflows/kotlin/workflows/RefreshVersions.kt
+++ b/src/typeflows/kotlin/workflows/RefreshVersions.kt
@@ -110,7 +110,7 @@ class RefreshVersions : Builder<Workflow> {
                     **Note:** Only stable versions are included in this update.
                 """.trimIndent()
                 with["pr_draft"] = "false"
-                with["github_token"] = Secrets.GITHUB_TOKEN
+                with["github_token"] = Secrets.string("TOOLBOX_REPO_TOKEN")
             }
 
             steps += RunCommand("echo \"No dependency updates available\"") {


### PR DESCRIPTION
## What

Switches the **Create Pull Request** step of the Update Dependencies workflow to authenticate with `TOOLBOX_REPO_TOKEN` instead of the default `GITHUB_TOKEN`.

## Why

PRs opened using the default `GITHUB_TOKEN` do not trigger other workflows (a GitHub Actions safeguard against recursive runs). Using the toolbox repo token — the same PAT already used elsewhere (e.g. `CreateUpgradeBranches`) — lets the automatically-created dependency-update PR fire its downstream CI/workflows.

## Changes

- `.github/workflows/update-dependencies.yml` — add `token: ${{ secrets.TOOLBOX_REPO_TOKEN }}` to the `peter-evans/create-pull-request` step.
- `src/typeflows/kotlin/workflows/RefreshVersions.kt` — set the PR-creation step's `github_token` to `Secrets.string("TOOLBOX_REPO_TOKEN")` so the change survives the next typeflows export.

## Notes

- The change is applied to both the generated YAML and the typeflows Kotlin source. These two were already out of sync before this change (the checked-in `update-dependencies.yml` uses `peter-evans/create-pull-request`, whereas `RefreshVersions.kt` uses `repo-sync/pull-request`); this PR only touches the PR-creation token and does not attempt to reconcile that pre-existing divergence.
- `TOOLBOX_REPO_TOKEN` is an existing repository secret already referenced by other workflows in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AL95dNSURu8JWb6YVAF9uV)_