### PR TITLE
DynamoDB: support ReturnValuesOnConditionCheckFailure on PutItem/UpdateItem/DeleteItem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Given version `A.B.C.D`, breaking changes are to be expected in version number i
 - **http4k-platform-k8s**: add k8s server extension for PolyHandler. H/T @dzappold
 - **http4k-testing-webdriver** - Specify locator name for a better debugging experience H/T @tamj0rd2
 - **http4k-connect-amazon-dynamodb**: `PutItem`, `UpdateItem` and `DeleteItem` gain `ReturnValuesOnConditionCheckFailure`, so a failed conditional write can return the record which blocked it (DynamoDB reports it in the error body). The enum and `TransactWriteItem`'s support for it already existed.
+- **http4k-connect-amazon-dynamodb-fake**: [Fix] A conditional `DeleteItem` is now evaluated. The `ConditionExpression` was previously ignored outright, so a guarded delete always succeeded against the fake - including inside `transactWriteItems`, where a failing condition now correctly cancels the transaction.
 - **http4k-connect-amazon-dynamodb-fake**: [Unlikely Break] `UpdateResult.ConditionFailed` is now a `data class` carrying the item to report back, rather than a `data object`.
 
 ### v6.55.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Given version `A.B.C.D`, breaking changes are to be expected in version number i
 - **http4k-api-openapi**: add support for a JSON schema dialect selector in swagger ui.  H/T @dzappold
 - **http4k-platform-k8s**: add k8s server extension for PolyHandler. H/T @dzappold
 - **http4k-testing-webdriver** - Specify locator name for a better debugging experience H/T @tamj0rd2
+- **http4k-connect-amazon-dynamodb**: `PutItem`, `UpdateItem` and `DeleteItem` gain `ReturnValuesOnConditionCheckFailure`, so a failed conditional write can return the record which blocked it (DynamoDB reports it in the error body). The enum and `TransactWriteItem`'s support for it already existed.
+- **http4k-connect-amazon-dynamodb-fake**: [Unlikely Break] `UpdateResult.ConditionFailed` is now a `data class` carrying the item to report back, rather than a `data object`.
 
 ### v6.55.0.0
 - **http4k-***: Upgrade versions including Toon to v2.0.0

--- a/connect/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/DeleteItem.kt
+++ b/connect/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/DeleteItem.kt
@@ -7,6 +7,7 @@ import org.http4k.connect.amazon.dynamodb.model.Key
 import org.http4k.connect.amazon.dynamodb.model.ReturnConsumedCapacity
 import org.http4k.connect.amazon.dynamodb.model.ReturnItemCollectionMetrics
 import org.http4k.connect.amazon.dynamodb.model.ReturnValues
+import org.http4k.connect.amazon.dynamodb.model.ReturnValuesOnConditionCheckFailure
 import org.http4k.connect.amazon.dynamodb.model.TableName
 import org.http4k.connect.amazon.dynamodb.model.TokensToNames
 import org.http4k.connect.amazon.dynamodb.model.TokensToValues
@@ -22,5 +23,6 @@ data class DeleteItem(
     val ExpressionAttributeValues: TokensToValues? = null,
     val ReturnConsumedCapacity: ReturnConsumedCapacity? = null,
     val ReturnItemCollectionMetrics: ReturnItemCollectionMetrics? = null,
-    val ReturnValues: ReturnValues? = null
+    val ReturnValues: ReturnValues? = null,
+    val ReturnValuesOnConditionCheckFailure: ReturnValuesOnConditionCheckFailure? = null
 ) : DynamoDbAction<ModifiedItem>(ModifiedItem::class, DynamoDbMoshi)

--- a/connect/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/PutItem.kt
+++ b/connect/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/PutItem.kt
@@ -7,6 +7,7 @@ import org.http4k.connect.amazon.dynamodb.model.Item
 import org.http4k.connect.amazon.dynamodb.model.ReturnConsumedCapacity
 import org.http4k.connect.amazon.dynamodb.model.ReturnItemCollectionMetrics
 import org.http4k.connect.amazon.dynamodb.model.ReturnValues
+import org.http4k.connect.amazon.dynamodb.model.ReturnValuesOnConditionCheckFailure
 import org.http4k.connect.amazon.dynamodb.model.TableName
 import org.http4k.connect.amazon.dynamodb.model.TokensToNames
 import org.http4k.connect.amazon.dynamodb.model.TokensToValues
@@ -22,5 +23,6 @@ data class PutItem(
     val ExpressionAttributeValues: TokensToValues? = null,
     val ReturnConsumedCapacity: ReturnConsumedCapacity? = null,
     val ReturnItemCollectionMetrics: ReturnItemCollectionMetrics? = null,
-    val ReturnValues: ReturnValues? = null
+    val ReturnValues: ReturnValues? = null,
+    val ReturnValuesOnConditionCheckFailure: ReturnValuesOnConditionCheckFailure? = null
 ) : DynamoDbAction<ModifiedItem>(ModifiedItem::class, DynamoDbMoshi)

--- a/connect/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/UpdateItem.kt
+++ b/connect/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/UpdateItem.kt
@@ -7,6 +7,7 @@ import org.http4k.connect.amazon.dynamodb.model.Key
 import org.http4k.connect.amazon.dynamodb.model.ReturnConsumedCapacity
 import org.http4k.connect.amazon.dynamodb.model.ReturnItemCollectionMetrics
 import org.http4k.connect.amazon.dynamodb.model.ReturnValues
+import org.http4k.connect.amazon.dynamodb.model.ReturnValuesOnConditionCheckFailure
 import org.http4k.connect.amazon.dynamodb.model.TableName
 import org.http4k.connect.amazon.dynamodb.model.TokensToNames
 import org.http4k.connect.amazon.dynamodb.model.TokensToValues
@@ -23,5 +24,6 @@ data class UpdateItem(
     val ExpressionAttributeValues: TokensToValues? = null,
     val ReturnConsumedCapacity: ReturnConsumedCapacity? = null,
     val ReturnItemCollectionMetrics: ReturnItemCollectionMetrics? = null,
-    val ReturnValues: ReturnValues? = null
+    val ReturnValues: ReturnValues? = null,
+    val ReturnValuesOnConditionCheckFailure: ReturnValuesOnConditionCheckFailure? = null
 ) : DynamoDbAction<ModifiedItem>(ModifiedItem::class, DynamoDbMoshi)

--- a/connect/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/common.kt
+++ b/connect/amazon/dynamodb/client/src/main/kotlin/org/http4k/connect/amazon/dynamodb/action/common.kt
@@ -17,3 +17,15 @@ data class ModifiedItem(
     val ConsumedCapacity: ConsumedCapacity? = null,
     val ItemCollectionMetrics: ItemCollectionMetrics? = null
 )
+
+/**
+ * The body of the error DynamoDB returns for a failed conditional write. Item holds the record which
+ * blocked the write, and is populated only when the request set ReturnValuesOnConditionCheckFailure
+ * to ALL_OLD.
+ */
+@JsonSerializable
+data class ConditionalCheckFailed(
+    val __type: String,
+    val Message: String,
+    val Item: ItemResult? = null
+)

--- a/connect/amazon/dynamodb/client/src/testFixtures/kotlin/org/http4k/connect/amazon/dynamodb/DynamoDbContract.kt
+++ b/connect/amazon/dynamodb/client/src/testFixtures/kotlin/org/http4k/connect/amazon/dynamodb/DynamoDbContract.kt
@@ -270,6 +270,72 @@ interface DynamoDbContract : AwsContract {
     }
 
     @Test
+    fun `failed delete condition returns the current item only when requested`() {
+        with(dynamo) {
+            val stored = createMiniItem("hello", bool = true)
+            putItem(table, stored).successValue()
+
+            val requested = deleteItem(
+                table,
+                Item(attrS of "hello"),
+                ConditionExpression = "$attrBool = :expected",
+                ExpressionAttributeValues = mapOf(":expected" to attrBool.asValue(false)),
+                ReturnValuesOnConditionCheckFailure = ALL_OLD
+            ).failureValue()
+
+            assertThat(requested.status, equalTo(BAD_REQUEST))
+            assertThat(requested.conditionCheckFailureItem(), equalTo(stored))
+
+            val notRequested = deleteItem(
+                table,
+                Item(attrS of "hello"),
+                ConditionExpression = "$attrBool = :expected",
+                ExpressionAttributeValues = mapOf(":expected" to attrBool.asValue(false))
+            ).failureValue()
+
+            assertThat(notRequested.status, equalTo(BAD_REQUEST))
+            assertThat(notRequested.conditionCheckFailureItem(), absent())
+
+            // a condition which cannot hold for a record that is not there fails with nothing to return
+            val onMissing = deleteItem(
+                table,
+                Item(attrS of "ghost"),
+                ConditionExpression = "attribute_exists($attrS)",
+                ReturnValuesOnConditionCheckFailure = ALL_OLD
+            ).failureValue()
+
+            assertThat(onMissing.status, equalTo(BAD_REQUEST))
+            assertThat(onMissing.conditionCheckFailureItem(), absent())
+        }
+    }
+
+    @Test
+    fun `conditional delete applies only when the condition holds`() {
+        with(dynamo) {
+            val stored = createMiniItem("hello", bool = true)
+            putItem(table, stored).successValue()
+
+            deleteItem(
+                table,
+                Item(attrS of "hello"),
+                ConditionExpression = "$attrBool = :expected",
+                ExpressionAttributeValues = mapOf(":expected" to attrBool.asValue(false))
+            ).failureValue()
+
+            assertThat(getItem(table, Item(attrS of "hello")).successValue().item, equalTo(stored))
+
+            deleteItem(
+                table,
+                Item(attrS of "hello"),
+                ConditionExpression = "$attrBool = :expected",
+                ExpressionAttributeValues = mapOf(":expected" to attrBool.asValue(true))
+            ).successValue()
+
+            assertThat(getItem(table, Item(attrS of "hello")).successValue().item, absent())
+        }
+    }
+
+    @Test
     fun `pagination of results`() {
         with(dynamo) {
             putItem(table, createItem("hello")).successValue()

--- a/connect/amazon/dynamodb/client/src/testFixtures/kotlin/org/http4k/connect/amazon/dynamodb/DynamoDbContract.kt
+++ b/connect/amazon/dynamodb/client/src/testFixtures/kotlin/org/http4k/connect/amazon/dynamodb/DynamoDbContract.kt
@@ -8,7 +8,9 @@ import com.natpryce.hamkrest.hasElement
 import dev.forkhandles.result4k.valueOrNull
 import dev.forkhandles.values.UUIDValue
 import dev.forkhandles.values.UUIDValueFactory
+import org.http4k.connect.RemoteFailure
 import org.http4k.connect.amazon.AwsContract
+import org.http4k.connect.amazon.dynamodb.action.ConditionalCheckFailed
 import org.http4k.connect.amazon.dynamodb.action.Scan
 import org.http4k.connect.amazon.dynamodb.action.copy
 import org.http4k.connect.amazon.dynamodb.model.AttributeValue.Companion.List
@@ -23,14 +25,18 @@ import org.http4k.connect.amazon.dynamodb.model.ReqStatement
 import org.http4k.connect.amazon.dynamodb.model.ReqWriteItem
 import org.http4k.connect.amazon.dynamodb.model.ReqWriteItem.Companion.Put
 import org.http4k.connect.amazon.dynamodb.model.ReturnConsumedCapacity.TOTAL
+import org.http4k.connect.amazon.dynamodb.model.ReturnValuesOnConditionCheckFailure.ALL_OLD
 import org.http4k.connect.amazon.dynamodb.model.TableName
 import org.http4k.connect.amazon.dynamodb.model.TransactGetItem.Companion.Get
 import org.http4k.connect.amazon.dynamodb.model.TransactWriteItem.Companion.Delete
 import org.http4k.connect.amazon.dynamodb.model.TransactWriteItem.Companion.Put
 import org.http4k.connect.amazon.dynamodb.model.TransactWriteItem.Companion.Update
+import org.http4k.connect.amazon.dynamodb.model.toItem
 import org.http4k.connect.amazon.dynamodb.model.with
+import org.http4k.connect.failureValue
 import org.http4k.connect.model.Base64Blob
 import org.http4k.connect.successValue
+import org.http4k.core.Status.Companion.BAD_REQUEST
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
@@ -41,6 +47,13 @@ import java.util.UUID
 class MyValueType(value: UUID) : UUIDValue(value) {
     companion object : UUIDValueFactory<MyValueType>(::MyValueType)
 }
+
+/**
+ * DynamoDB reports a failed condition as an error body rather than a typed response, so the item it
+ * returns has to be read back out of that body.
+ */
+private fun RemoteFailure.conditionCheckFailureItem() =
+    DynamoDbMoshi.asA(message!!, ConditionalCheckFailed::class).Item?.toItem()
 
 interface DynamoDbContract : AwsContract {
     val duration: Duration
@@ -181,6 +194,78 @@ interface DynamoDbContract : AwsContract {
             assertThat(attrN[scan.first()], equalTo(321))
 
             deleteItem(table, Item(attrS of "hello")).successValue()
+        }
+    }
+
+    @Test
+    fun `failed put condition returns the current item only when requested`() {
+        with(dynamo) {
+            val stored = createMiniItem("hello", bool = true)
+            putItem(table, stored).successValue()
+
+            // the attempted item differs from the stored one, so the assertions below distinguish
+            // "returns the row which blocked the write" from "echoes back what was sent"
+            val attempted = createMiniItem("hello", bool = false)
+
+            val requested = putItem(
+                table,
+                attempted,
+                ConditionExpression = "attribute_not_exists($attrS)",
+                ReturnValuesOnConditionCheckFailure = ALL_OLD
+            ).failureValue()
+
+            assertThat(requested.status, equalTo(BAD_REQUEST))
+            assertThat(requested.conditionCheckFailureItem(), equalTo(stored))
+
+            val notRequested = putItem(
+                table,
+                attempted,
+                ConditionExpression = "attribute_not_exists($attrS)"
+            ).failureValue()
+
+            assertThat(notRequested.status, equalTo(BAD_REQUEST))
+            assertThat(notRequested.conditionCheckFailureItem(), absent())
+        }
+    }
+
+    @Test
+    fun `failed update condition returns the current item only when requested`() {
+        with(dynamo) {
+            val stored = createMiniItem("hello", bool = true)
+            putItem(table, stored).successValue()
+
+            // the stored item holds theBool = true, so requiring false is the failing condition
+            val requested = updateItem(
+                table,
+                Item(attrS of "hello"),
+                ConditionExpression = "$attrBool = :expected",
+                UpdateExpression = "SET $attrN = :updated",
+                ExpressionAttributeValues = mapOf(
+                    ":expected" to attrBool.asValue(false),
+                    ":updated" to attrN.asValue(99)
+                ),
+                ReturnValuesOnConditionCheckFailure = ALL_OLD
+            ).failureValue()
+
+            assertThat(requested.status, equalTo(BAD_REQUEST))
+            assertThat(requested.conditionCheckFailureItem(), equalTo(stored))
+
+            val notRequested = updateItem(
+                table,
+                Item(attrS of "hello"),
+                ConditionExpression = "$attrBool = :expected",
+                UpdateExpression = "SET $attrN = :updated",
+                ExpressionAttributeValues = mapOf(
+                    ":expected" to attrBool.asValue(false),
+                    ":updated" to attrN.asValue(99)
+                )
+            ).failureValue()
+
+            assertThat(notRequested.status, equalTo(BAD_REQUEST))
+            assertThat(notRequested.conditionCheckFailureItem(), absent())
+
+            // the failed condition must have left the stored record untouched
+            assertThat(getItem(table, Item(attrS of "hello")).successValue().item, equalTo(stored))
         }
     }
 

--- a/connect/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/deleteItem.kt
+++ b/connect/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/deleteItem.kt
@@ -3,18 +3,35 @@ package org.http4k.connect.amazon.dynamodb.endpoints
 import org.http4k.connect.amazon.AwsJsonFake
 import org.http4k.connect.amazon.dynamodb.DynamoTable
 import org.http4k.connect.amazon.dynamodb.action.DeleteItem
+import org.http4k.connect.amazon.dynamodb.endpoints.UpdateResult.ConditionFailed
 import org.http4k.connect.amazon.dynamodb.endpoints.UpdateResult.UpdateOk
 import org.http4k.connect.amazon.dynamodb.model.Item
+import org.http4k.connect.amazon.dynamodb.model.Key
 import org.http4k.connect.storage.Storage
 
-fun AwsJsonFake.deleteItem(tables: Storage<DynamoTable>) = route<DeleteItem> { req ->
+fun AwsJsonFake.deleteItem(tables: Storage<DynamoTable>) = route<DeleteItem>(
+    responseFn = { conditionCheckAware(it) }
+) { req ->
     tables.runUpdate(req.TableName, req, tryModifyDelete)
 }
 
 internal val tryModifyDelete = TryModifyItem<DeleteItem> { req, table ->
-    val existingItem = table.retrieve(req.Key)
-    when {
-        existingItem != null -> UpdateOk(existingItem, table.withoutItem(req.Key))
-        else -> UpdateOk(Item(), table)
+    val stored = table.retrieve(req.Key)
+    if (req.ConditionExpression != null) {
+        (stored ?: Item()).condition(
+            expression = req.ConditionExpression,
+            expressionAttributeNames = req.ExpressionAttributeNames,
+            expressionAttributeValues = req.ExpressionAttributeValues
+        )
+            ?.let { removed(table, req.Key, stored) }
+            ?: ConditionFailed(stored.returnedOnConditionFailure(req.ReturnValuesOnConditionCheckFailure))
+    } else {
+        removed(table, req.Key, stored)
     }
+}
+
+/** Deleting a record which is not there is not an error - DynamoDB reports it as a plain success. */
+private fun removed(table: DynamoTable, key: Key, stored: Item?) = when (stored) {
+    null -> UpdateOk(Item(), table)
+    else -> UpdateOk(stored, table.withoutItem(key))
 }

--- a/connect/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/dynamoHelpers.kt
+++ b/connect/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/dynamoHelpers.kt
@@ -2,9 +2,11 @@
 
 package org.http4k.connect.amazon.dynamodb.endpoints
 
+import org.http4k.connect.amazon.AwsJsonFake
 import org.http4k.connect.amazon.JsonError
 import org.http4k.connect.amazon.dynamodb.DynamoDbMoshi
 import org.http4k.connect.amazon.dynamodb.DynamoTable
+import org.http4k.connect.amazon.dynamodb.action.ConditionalCheckFailed
 import org.http4k.connect.amazon.dynamodb.action.ModifiedItem
 import org.http4k.connect.amazon.dynamodb.endpoints.UpdateResult.NotFound
 import org.http4k.connect.amazon.dynamodb.grammar.AttributeNameValue
@@ -16,14 +18,20 @@ import org.http4k.connect.amazon.dynamodb.model.AttributeName
 import org.http4k.connect.amazon.dynamodb.model.AttributeValue
 import org.http4k.connect.amazon.dynamodb.model.IndexName
 import org.http4k.connect.amazon.dynamodb.model.Item
+import org.http4k.connect.amazon.dynamodb.model.ItemResult
 import org.http4k.connect.amazon.dynamodb.model.Key
 import org.http4k.connect.amazon.dynamodb.model.KeySchema
 import org.http4k.connect.amazon.dynamodb.model.KeyType
+import org.http4k.connect.amazon.dynamodb.model.ReturnValuesOnConditionCheckFailure
+import org.http4k.connect.amazon.dynamodb.model.ReturnValuesOnConditionCheckFailure.ALL_OLD
 import org.http4k.connect.amazon.dynamodb.model.TableDescription
 import org.http4k.connect.amazon.dynamodb.model.TableName
 import org.http4k.connect.amazon.dynamodb.model.TokensToNames
 import org.http4k.connect.amazon.dynamodb.model.TokensToValues
 import org.http4k.connect.storage.Storage
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.BAD_REQUEST
+import org.http4k.core.Status.Companion.OK
 
 fun Item.asItemResult(): Map<String, Map<String, Any>> =
     mapKeys { it.key.value }.mapValues { convert(it.value) }
@@ -165,10 +173,17 @@ sealed interface UpdateResult {
         override val result = ModifiedItem(item.asItemResult())
     }
 
-    data object ConditionFailed : UpdateResult {
-        override val result = JsonError(
-            "com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException",
-            "The conditional request failed"
+    /**
+     * [item] is the record which blocked the write, and is set only when the request asked for it
+     * with ReturnValuesOnConditionCheckFailure=ALL_OLD. It cannot be reported through the shared
+     * [JsonError], which every AWS fake uses and so cannot carry a DynamoDB item - hence the
+     * dedicated body type, which [conditionCheckAware] maps back onto a 400.
+     */
+    data class ConditionFailed(val item: ItemResult? = null) : UpdateResult {
+        override val result = ConditionalCheckFailed(
+            __type = "com.amazonaws.dynamodb.v20120810#ConditionalCheckFailedException",
+            Message = "The conditional request failed",
+            Item = item
         )
     }
 
@@ -176,6 +191,22 @@ sealed interface UpdateResult {
         override val result = null
     }
 }
+
+/**
+ * Standard response handling, extended to report [ConditionalCheckFailed] as the 400 which the
+ * shared [JsonError] path would otherwise have given it.
+ */
+internal fun AwsJsonFake.conditionCheckAware(result: Any): Response = when (result) {
+    is ConditionalCheckFailed -> Response(BAD_REQUEST).body(autoMarshalling.asFormatString(result))
+    else -> Response(OK).body(autoMarshalling.asFormatString(result))
+}
+
+/**
+ * The item to report back on a failed condition: only when the request asked for it, and only when
+ * there was a stored record to return.
+ */
+internal fun Item?.returnedOnConditionFailure(returnValues: ReturnValuesOnConditionCheckFailure?) =
+    takeIf { returnValues == ALL_OLD }?.asItemResult()
 
 internal fun <Req> Storage<DynamoTable>.runUpdate(table: TableName, t: Req, update: TryModifyItem<Req>): Any? {
     val updateResult = this[table.value]?.let { update(t, it) } ?: NotFound

--- a/connect/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/putItem.kt
+++ b/connect/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/putItem.kt
@@ -8,19 +8,22 @@ import org.http4k.connect.amazon.dynamodb.endpoints.UpdateResult.UpdateOk
 import org.http4k.connect.amazon.dynamodb.model.Item
 import org.http4k.connect.storage.Storage
 
-fun AwsJsonFake.putItem(tables: Storage<DynamoTable>) = route<PutItem> { req ->
+fun AwsJsonFake.putItem(tables: Storage<DynamoTable>) = route<PutItem>(
+    responseFn = { conditionCheckAware(it) }
+) { req ->
     tables.runUpdate(req.TableName, req, tryModifyPut)
 }
 
 internal val tryModifyPut = TryModifyItem<PutItem> { req, table ->
     if (req.ConditionExpression != null) {
-        (table.retrieve(req.Item.key(table.table.KeySchema!!)) ?: Item()).condition(
+        val stored = table.retrieve(req.Item.key(table.table.KeySchema!!))
+        (stored ?: Item()).condition(
             expression = req.ConditionExpression,
             expressionAttributeNames = req.ExpressionAttributeNames,
             expressionAttributeValues = req.ExpressionAttributeValues
         )
             ?.let { UpdateOk(req.Item, table.withItem(req.Item)) }
-            ?: ConditionFailed
+            ?: ConditionFailed(stored.returnedOnConditionFailure(req.ReturnValuesOnConditionCheckFailure))
     } else {
         UpdateOk(req.Item, table.withItem(req.Item))
     }

--- a/connect/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/updateItem.kt
+++ b/connect/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/endpoints/updateItem.kt
@@ -5,12 +5,15 @@ import org.http4k.connect.amazon.dynamodb.DynamoTable
 import org.http4k.connect.amazon.dynamodb.action.UpdateItem
 import org.http4k.connect.storage.Storage
 
-fun AwsJsonFake.updateItem(tables: Storage<DynamoTable>) = route<UpdateItem> { req ->
+fun AwsJsonFake.updateItem(tables: Storage<DynamoTable>) = route<UpdateItem>(
+    responseFn = { conditionCheckAware(it) }
+) { req ->
     tables.runUpdate(req.TableName, req, tryModifyUpdate)
 }
 
 internal val tryModifyUpdate = TryModifyItem<UpdateItem> { req, table ->
-    val existingItem = table.retrieve(req.Key) ?: req.Key
+    val stored = table.retrieve(req.Key)
+    val existingItem = stored ?: req.Key
     if (req.ConditionExpression != null) {
         existingItem.condition(
             expression = req.ConditionExpression,
@@ -26,7 +29,9 @@ internal val tryModifyUpdate = TryModifyItem<UpdateItem> { req, table ->
 
                 UpdateResult.UpdateOk(updated, table.withoutItem(existingItem).withItem(updated))
             }
-            ?: UpdateResult.ConditionFailed
+            ?: UpdateResult.ConditionFailed(
+                stored.returnedOnConditionFailure(req.ReturnValuesOnConditionCheckFailure)
+            )
     } else {
 
         val updated = existingItem.update(


### PR DESCRIPTION
DynamoDB can return the record that blocked a failed conditional write, but the top-level actions had no way to ask for it, so optimistic-lock callers pay a reload read per conflict just to see what they hit. 

The `ReturnValuesOnConditionCheckFailure` enum already existed and `TransactWriteItem` already used it; this brings `PutItem`/`UpdateItem`/`DeleteItem` in line.