### PR TITLE
Add ability to chain schema model namers when defining custom namers for specific classes (ie. generics)

### DIFF
--- a/core/api/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/SchemaModelNamer.kt
+++ b/core/api/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/SchemaModelNamer.kt
@@ -2,7 +2,6 @@ package org.http4k.contract.jsonschema.v3
 
 import kotlin.reflect.KClass
 
-
 fun interface SchemaModelNamer : (Any) -> String {
     companion object {
         val Simple: SchemaModelNamer = SchemaModelNamer {

--- a/core/api/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/SchemaModelNamer.kt
+++ b/core/api/jsonschema/src/main/kotlin/org/http4k/contract/jsonschema/v3/SchemaModelNamer.kt
@@ -2,6 +2,7 @@ package org.http4k.contract.jsonschema.v3
 
 import kotlin.reflect.KClass
 
+
 fun interface SchemaModelNamer : (Any) -> String {
     companion object {
         val Simple: SchemaModelNamer = SchemaModelNamer {
@@ -15,3 +16,11 @@ fun interface SchemaModelNamer : (Any) -> String {
         }
     }
 }
+
+fun interface SchemaModelNamerChain : (Any) -> String?
+
+fun SchemaModelNamerChain.then(next: SchemaModelNamerChain) =
+    SchemaModelNamerChain { this(it) ?: next(it) }
+
+fun SchemaModelNamerChain.then(next: SchemaModelNamer) =
+    SchemaModelNamer { this(it) ?: next(it) }

--- a/core/api/jsonschema/src/test/kotlin/org/http4k/contract/jsonschema/v3/SchemaModelNamerTest.kt
+++ b/core/api/jsonschema/src/test/kotlin/org/http4k/contract/jsonschema/v3/SchemaModelNamerTest.kt
@@ -5,6 +5,7 @@ import com.natpryce.hamkrest.equalTo
 import org.junit.jupiter.api.Test
 
 class SchemaModelNamerTest {
+
     @Test
     fun `simple namer`() {
         assertThat(SchemaModelNamer.Simple("bob"), equalTo("String"))
@@ -18,6 +19,13 @@ class SchemaModelNamerTest {
     @Test
     fun `canonical namer`() {
         assertThat(SchemaModelNamer.Canonical(FooBar.BarFoo()), equalTo("org.http4k.contract.jsonschema.v3.FooBar.BarFoo"))
+    }
+
+    @Test
+    fun `filter namer`() {
+        val namer = SchemaModelNamerChain { if (it == 0) "ZERO" else null }.then(SchemaModelNamer.Simple)
+        assertThat(namer(0), equalTo("ZERO"))
+        assertThat(namer("bob"), equalTo("String"))
     }
 }
 


### PR DESCRIPTION
Adds ability to chain schema model namers, to define custom namers for generic.
Last call needs to be one of _proper_ schema namers to ensure the names are always provided.

```kotlin
SchemaModelNamerChain { if (it == 0) "ZERO" else null }
    .then(SchemaModelNamer.Simple)
```

Not sure about the naming `*Chain` sounds ok-ish, but open for better suggestions.