### PR TITLE
Add http4k-connect-amazon-iotdataplane + fake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Given version `A.B.C.D`, breaking changes are to be expected in version number i
 - **http4k-server-undertow***: [Unlikely break] SSE now falls back to HTTP handler if the request is not handled.
 - **http4k-api-jsonschema***: Ability to chain schema model namer. H/T @potfur
 - **http4k-connect-amazon-dynamodb**: Added `DescribeTimeToLive` and `UpdateTimeToLive` actions (with `TimeToLiveStatus`/`TimeToLiveDescription`/`TimeToLiveSpecification` models), so callers can read and set a table's TTL configuration. The fake supports both.
+- **http4k-connect-amazon-iotdataplane**: [New module!] AWS IoT Core Data Plane client supporting Publish, GetThingShadow, UpdateThingShadow, DeleteThingShadow, ListNamedShadowsForThing, GetRetainedMessage, ListRetainedMessages and DeleteConnection.
+- **http4k-connect-amazon-iotdataplane-fake**: [New module!] AWS IoT Core Data Plane fake which records published messages for test assertions, stores Thing Shadows, and serves the retained messages that its retained publishes create.
 
 ### v6.56.0.0
 - **http4k-***: Upgrade versions

--- a/connect/amazon/iotdataplane/client/build.gradle.kts
+++ b/connect/amazon/iotdataplane/client/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    id("org.http4k.community")
+    id("org.http4k.connect.module")
+    id("org.http4k.connect.client")
+}
+
+dependencies {
+    api(project(":http4k-connect-amazon-core"))
+    testFixturesApi(testFixtures(project(":http4k-connect-amazon-core")))
+}

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/HttpIotDataPlane.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/HttpIotDataPlane.kt
@@ -1,0 +1,51 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import org.http4k.client.JavaHttpClient
+import org.http4k.config.Environment
+import org.http4k.connect.amazon.AWS_REGION
+import org.http4k.connect.amazon.CredentialsProvider
+import org.http4k.connect.amazon.Environment
+import org.http4k.connect.amazon.core.model.Region
+import org.http4k.core.HttpHandler
+import org.http4k.core.Uri
+import org.http4k.core.then
+import org.http4k.filter.Payload.Mode.Signed
+import java.time.Clock
+
+/**
+ * Standard HTTP implementation of IotDataPlane. The endpoint is account-specific
+ * (eg. https://xxxxxxxx-ats.iot.<region>.amazonaws.com) so cannot be derived from the region.
+ */
+fun IotDataPlane.Companion.Http(
+    endpoint: Uri,
+    region: Region,
+    credentialsProvider: CredentialsProvider,
+    http: HttpHandler = JavaHttpClient(),
+    clock: Clock = Clock.systemUTC(),
+) = object : IotDataPlane {
+    private val signedHttp = signAwsRequests(region, credentialsProvider, clock, Signed, endpoint).then(http)
+
+    override fun <R> invoke(action: IotDataPlaneAction<R>) = action.toResult(signedHttp(action.toRequest()))
+}
+
+/**
+ * Convenience function to create a IotDataPlane from a System environment
+ */
+fun IotDataPlane.Companion.Http(
+    endpoint: Uri,
+    env: Map<String, String> = System.getenv(),
+    http: HttpHandler = JavaHttpClient(),
+    clock: Clock = Clock.systemUTC(),
+    credentialsProvider: CredentialsProvider = CredentialsProvider.Environment(env),
+) = Http(endpoint, Environment.from(env), http, clock, credentialsProvider)
+
+/**
+ * Convenience function to create a IotDataPlane from an http4k Environment
+ */
+fun IotDataPlane.Companion.Http(
+    endpoint: Uri,
+    env: Environment,
+    http: HttpHandler = JavaHttpClient(),
+    clock: Clock = Clock.systemUTC(),
+    credentialsProvider: CredentialsProvider = CredentialsProvider.Environment(env),
+) = Http(endpoint, AWS_REGION(env), credentialsProvider, http, clock)

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/IotDataPlane.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/IotDataPlane.kt
@@ -1,0 +1,16 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import dev.forkhandles.result4k.Result
+import org.http4k.connect.Http4kConnectApiClient
+import org.http4k.connect.RemoteFailure
+import org.http4k.connect.amazon.AwsServiceCompanion
+
+/**
+ * Docs: https://docs.aws.amazon.com/iot/latest/apireference/API_Operations_AWS_IoT_Data_Plane.html
+ */
+@Http4kConnectApiClient
+interface IotDataPlane {
+    operator fun <R> invoke(action: IotDataPlaneAction<R>): Result<R, RemoteFailure>
+
+    companion object : AwsServiceCompanion("iotdata")
+}

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/IotDataPlaneAction.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/IotDataPlaneAction.kt
@@ -1,0 +1,7 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import dev.forkhandles.result4k.Result
+import org.http4k.connect.Action
+import org.http4k.connect.RemoteFailure
+
+interface IotDataPlaneAction<R> : Action<Result<R, RemoteFailure>>

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/IotDataPlaneMoshi.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/IotDataPlaneMoshi.kt
@@ -1,0 +1,21 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import com.squareup.moshi.JsonAdapter
+import org.http4k.connect.amazon.iotdataplane.model.ShadowName
+import org.http4k.connect.amazon.iotdataplane.model.ThingName
+import org.http4k.connect.amazon.iotdataplane.model.TopicName
+import org.http4k.format.AwsMoshiBuilder
+import org.http4k.format.ConfigurableMoshi
+import org.http4k.format.value
+import se.ansman.kotshi.KotshiJsonAdapterFactory
+
+object IotDataPlaneMoshi : ConfigurableMoshi(
+    AwsMoshiBuilder(IotDataPlaneJsonAdapterFactory)
+        .value(ShadowName)
+        .value(ThingName)
+        .value(TopicName)
+        .done()
+)
+
+@KotshiJsonAdapterFactory
+object IotDataPlaneJsonAdapterFactory : JsonAdapter.Factory by KotshiIotDataPlaneJsonAdapterFactory

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/DeleteConnection.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/DeleteConnection.kt
@@ -1,0 +1,37 @@
+package org.http4k.connect.amazon.iotdataplane.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.iotdataplane.IotDataPlaneAction
+import org.http4k.connect.amazon.iotdataplane.model.ClientId
+import org.http4k.connect.asRemoteFailure
+import org.http4k.core.Method.DELETE
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Uri
+
+@Http4kConnectAction
+data class DeleteConnection(
+    val clientId: ClientId,
+    val cleanSession: Boolean? = null,
+    val preventWillMessage: Boolean? = null
+) : IotDataPlaneAction<Unit> {
+
+    override fun toRequest() = queryParameters()
+        .fold(Request(DELETE, uri())) { request, (name, value) -> request.query(name, value) }
+
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(Unit)
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+
+    private fun uri() = Uri.of("").path("/connections/${clientId.value}")
+
+    private fun queryParameters() = listOfNotNull(
+        cleanSession?.let { "cleanSession" to it.toString() },
+        preventWillMessage?.let { "preventWillMessage" to it.toString() }
+    )
+}

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/DeleteThingShadow.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/DeleteThingShadow.kt
@@ -1,0 +1,29 @@
+package org.http4k.connect.amazon.iotdataplane.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.iotdataplane.IotDataPlaneAction
+import org.http4k.connect.amazon.iotdataplane.model.ShadowName
+import org.http4k.connect.amazon.iotdataplane.model.ThingName
+import org.http4k.connect.asRemoteFailure
+import org.http4k.core.Method.DELETE
+import org.http4k.core.Response
+import java.io.InputStream
+
+/** AWS answers with the deleted shadow's version as opaque JSON, so it is returned as a stream. */
+@Http4kConnectAction
+data class DeleteThingShadow(
+    val thingName: ThingName,
+    val shadowName: ShadowName? = null
+) : IotDataPlaneAction<InputStream> {
+
+    override fun toRequest() = shadowRequest(DELETE, thingName, shadowName)
+
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(body.stream)
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+}

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/GetRetainedMessage.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/GetRetainedMessage.kt
@@ -1,0 +1,44 @@
+package org.http4k.connect.amazon.iotdataplane.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.iotdataplane.IotDataPlaneAction
+import org.http4k.connect.amazon.iotdataplane.IotDataPlaneMoshi
+import org.http4k.connect.amazon.iotdataplane.model.TopicName
+import org.http4k.connect.asRemoteFailure
+import org.http4k.connect.model.Base64Blob
+import org.http4k.connect.model.TimestampMillis
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Uri
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+data class GetRetainedMessage(val topic: TopicName) : IotDataPlaneAction<RetainedMessage> {
+
+    override fun toRequest() = Request(GET, uri())
+
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(IotDataPlaneMoshi.asA<RetainedMessage>(bodyString()))
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+
+    private fun uri() = Uri.of("").path("/retainedMessage/${topic.value}")
+}
+
+/**
+ * [userProperties] stays as the base64 JSON AWS sends. Decoding it here would turn a successful call
+ * into a parse failure if AWS ever shaped it differently.
+ */
+@JsonSerializable
+data class RetainedMessage(
+    val topic: TopicName,
+    val lastModifiedTime: TimestampMillis,
+    val qos: Int = 0,
+    val payload: Base64Blob? = null,
+    val userProperties: Base64Blob? = null
+)

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/GetThingShadow.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/GetThingShadow.kt
@@ -1,0 +1,29 @@
+package org.http4k.connect.amazon.iotdataplane.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.iotdataplane.IotDataPlaneAction
+import org.http4k.connect.amazon.iotdataplane.model.ShadowName
+import org.http4k.connect.amazon.iotdataplane.model.ThingName
+import org.http4k.connect.asRemoteFailure
+import org.http4k.core.Method.GET
+import org.http4k.core.Response
+import java.io.InputStream
+
+/** The shadow document is opaque JSON, so it is returned as a stream, as S3 GetObject does. */
+@Http4kConnectAction
+data class GetThingShadow(
+    val thingName: ThingName,
+    val shadowName: ShadowName? = null
+) : IotDataPlaneAction<InputStream> {
+
+    override fun toRequest() = shadowRequest(GET, thingName, shadowName)
+
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(body.stream)
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+}

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/ListNamedShadowsForThing.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/ListNamedShadowsForThing.kt
@@ -1,0 +1,48 @@
+package org.http4k.connect.amazon.iotdataplane.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.iotdataplane.IotDataPlaneAction
+import org.http4k.connect.amazon.iotdataplane.IotDataPlaneMoshi
+import org.http4k.connect.amazon.iotdataplane.model.ShadowName
+import org.http4k.connect.amazon.iotdataplane.model.ThingName
+import org.http4k.connect.asRemoteFailure
+import org.http4k.connect.model.Timestamp
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Uri
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+data class ListNamedShadowsForThing(
+    val thingName: ThingName,
+    val nextToken: String? = null,
+    val pageSize: Int? = null
+) : IotDataPlaneAction<NamedShadows> {
+
+    override fun toRequest() = queryParameters()
+        .fold(Request(GET, uri())) { request, (name, value) -> request.query(name, value) }
+
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(IotDataPlaneMoshi.asA<NamedShadows>(bodyString()))
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+
+    private fun uri() = Uri.of("").path("/api/things/shadow/ListNamedShadowsForThing/${thingName.value}")
+
+    private fun queryParameters() = listOfNotNull(
+        nextToken?.let { "nextToken" to it },
+        pageSize?.let { "pageSize" to it.toString() }
+    )
+}
+
+@JsonSerializable
+data class NamedShadows(
+    val results: List<ShadowName> = emptyList(),
+    val nextToken: String? = null,
+    val timestamp: Timestamp? = null
+)

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/ListRetainedMessages.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/ListRetainedMessages.kt
@@ -1,0 +1,52 @@
+package org.http4k.connect.amazon.iotdataplane.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.iotdataplane.IotDataPlaneAction
+import org.http4k.connect.amazon.iotdataplane.IotDataPlaneMoshi
+import org.http4k.connect.amazon.iotdataplane.model.TopicName
+import org.http4k.connect.asRemoteFailure
+import org.http4k.connect.model.TimestampMillis
+import org.http4k.core.Method.GET
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Uri
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+data class ListRetainedMessages(
+    val maxResults: Int? = null,
+    val nextToken: String? = null
+) : IotDataPlaneAction<RetainedMessages> {
+
+    override fun toRequest() = queryParameters()
+        .fold(Request(GET, Uri.of("").path("/retainedMessage"))) { request, (name, value) -> request.query(name, value) }
+
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(IotDataPlaneMoshi.asA<RetainedMessages>(bodyString()))
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+
+    private fun queryParameters() = listOfNotNull(
+        maxResults?.let { "maxResults" to it.toString() },
+        nextToken?.let { "nextToken" to it }
+    )
+}
+
+/** AWS names this field `retainedTopics`, though it holds whole summaries rather than topic names. */
+@JsonSerializable
+data class RetainedMessages(
+    val retainedTopics: List<RetainedMessageSummary> = emptyList(),
+    val nextToken: String? = null
+)
+
+@JsonSerializable
+data class RetainedMessageSummary(
+    val topic: TopicName,
+    val lastModifiedTime: TimestampMillis,
+    val payloadSize: Long = 0,
+    val qos: Int = 0
+)

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/Publish.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/Publish.kt
@@ -1,0 +1,89 @@
+package org.http4k.connect.amazon.iotdataplane.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.iotdataplane.IotDataPlaneAction
+import org.http4k.connect.amazon.iotdataplane.model.PayloadFormatIndicator
+import org.http4k.connect.amazon.iotdataplane.model.TopicName
+import org.http4k.connect.asRemoteFailure
+import org.http4k.connect.model.Base64Blob
+import org.http4k.core.ContentType.Companion.OCTET_STREAM
+import org.http4k.core.MemoryBody
+import org.http4k.core.Method.POST
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Uri
+import org.http4k.core.with
+import org.http4k.format.Moshi
+import org.http4k.lens.Header.CONTENT_TYPE
+
+@Http4kConnectAction
+data class Publish(
+    val topic: TopicName,
+    val payload: ByteArray,
+    val qos: Int? = null,
+    val retain: Boolean? = null,
+    val messageExpiry: Long? = null,
+    val responseTopic: String? = null,
+    val contentType: String? = null,
+    val correlationData: Base64Blob? = null,
+    val payloadFormatIndicator: PayloadFormatIndicator? = null,
+    val userProperties: List<Pair<String, String>>? = null,
+) : IotDataPlaneAction<Unit> {
+
+    override fun toRequest() = queryParameters()
+        .fold(topicRequest()) { request, (name, value) -> request.query(name, value) }
+        .headers(mqtt5Headers())
+        .with(CONTENT_TYPE of OCTET_STREAM)
+        .body(MemoryBody(payload))
+
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(Unit)
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+
+    /**
+     * The topic goes into the path exactly as given. The AWS auth filter percent-encodes the path
+     * afterwards, so encoding it here as well would put %252F on the wire and AWS would read the
+     * escape as part of the topic name.
+     */
+    private fun topicRequest() = Request(POST, Uri.of("").path("/topics/${topic.value}"))
+
+    private fun queryParameters() = listOf(
+        "contentType" to contentType,
+        "messageExpiry" to messageExpiry?.toString(),
+        "qos" to qos?.toString(),
+        "responseTopic" to responseTopic,
+        "retain" to retain?.toString()
+    ).present()
+
+    private fun mqtt5Headers() = listOf(
+        "x-amz-mqtt5-correlation-data" to correlationData?.value,
+        "x-amz-mqtt5-payload-format-indicator" to payloadFormatIndicator?.name,
+        "x-amz-mqtt5-user-properties" to userProperties?.toHeaderValue()
+    ).present()
+
+    /** ByteArray equality is by identity, so equals/hashCode have to compare the payload here. */
+    private fun fieldsOtherThanPayload() = listOf(
+        topic, qos, retain, messageExpiry, responseTopic,
+        contentType, correlationData, payloadFormatIndicator, userProperties
+    )
+
+    override fun equals(other: Any?) = other is Publish &&
+        payload.contentEquals(other.payload) &&
+        fieldsOtherThanPayload() == other.fieldsOtherThanPayload()
+
+    override fun hashCode() = 31 * fieldsOtherThanPayload().hashCode() + payload.contentHashCode()
+}
+
+private fun List<Pair<String, String?>>.present() = filterNot { (_, value) -> value == null }
+
+/**
+ * AWS expects the user properties as base64 of a JSON array of single-entry objects, eg.
+ * `[{"deviceName": "alpha"}, {"deviceCnt": "45"}]`.
+ */
+private fun List<Pair<String, String>>.toHeaderValue() =
+    Base64Blob.encode(Moshi.asFormatString(map { (key, value) -> mapOf(key to value) })).value

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/UpdateThingShadow.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/UpdateThingShadow.kt
@@ -1,0 +1,45 @@
+package org.http4k.connect.amazon.iotdataplane.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.iotdataplane.IotDataPlaneAction
+import org.http4k.connect.amazon.iotdataplane.model.ShadowName
+import org.http4k.connect.amazon.iotdataplane.model.ThingName
+import org.http4k.connect.asRemoteFailure
+import org.http4k.core.ContentType.Companion.OCTET_STREAM
+import org.http4k.core.MemoryBody
+import org.http4k.core.Method.POST
+import org.http4k.core.Response
+import org.http4k.core.with
+import org.http4k.lens.Header.CONTENT_TYPE
+import java.io.InputStream
+
+/** Both documents are opaque JSON, so they are carried as raw bytes in and a stream out. */
+@Http4kConnectAction
+data class UpdateThingShadow(
+    val thingName: ThingName,
+    val payload: ByteArray,
+    val shadowName: ShadowName? = null
+) : IotDataPlaneAction<InputStream> {
+
+    override fun toRequest() = shadowRequest(POST, thingName, shadowName)
+        .with(CONTENT_TYPE of OCTET_STREAM)
+        .body(MemoryBody(payload))
+
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(body.stream)
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+
+    /** ByteArray equality is by identity, so equals/hashCode have to compare the payload here. */
+    private fun fieldsOtherThanPayload() = listOf(thingName, shadowName)
+
+    override fun equals(other: Any?) = other is UpdateThingShadow &&
+        payload.contentEquals(other.payload) &&
+        fieldsOtherThanPayload() == other.fieldsOtherThanPayload()
+
+    override fun hashCode() = 31 * fieldsOtherThanPayload().hashCode() + payload.contentHashCode()
+}

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/shadowRequest.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/action/shadowRequest.kt
@@ -1,0 +1,13 @@
+package org.http4k.connect.amazon.iotdataplane.action
+
+import org.http4k.connect.amazon.iotdataplane.model.ShadowName
+import org.http4k.connect.amazon.iotdataplane.model.ThingName
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.Uri
+
+/** An absent [shadowName] addresses the unnamed ("classic") shadow. */
+internal fun shadowRequest(method: Method, thingName: ThingName, shadowName: ShadowName?): Request {
+    val request = Request(method, Uri.of("").path("/things/${thingName.value}/shadow"))
+    return shadowName?.let { request.query("name", it.value) } ?: request
+}

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model/ClientId.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model/ClientId.kt
@@ -1,0 +1,13 @@
+package org.http4k.connect.amazon.iotdataplane.model
+
+import dev.forkhandles.values.StringValue
+import dev.forkhandles.values.StringValueFactory
+import dev.forkhandles.values.regex
+
+/**
+ * The identifier of the MQTT client whose connection is being addressed. AWS caps it at 128
+ * characters and reserves the `$` prefix.
+ */
+class ClientId private constructor(value: String) : StringValue(value) {
+    companion object : StringValueFactory<ClientId>(::ClientId, "[^\$].{0,127}".regex)
+}

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model/PayloadFormatIndicator.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model/PayloadFormatIndicator.kt
@@ -1,0 +1,6 @@
+package org.http4k.connect.amazon.iotdataplane.model
+
+enum class PayloadFormatIndicator {
+    UNSPECIFIED_BYTES,
+    UTF8_DATA
+}

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model/ShadowName.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model/ShadowName.kt
@@ -1,0 +1,15 @@
+package org.http4k.connect.amazon.iotdataplane.model
+
+import dev.forkhandles.values.StringValue
+import dev.forkhandles.values.StringValueFactory
+import dev.forkhandles.values.and
+import dev.forkhandles.values.maxLength
+import dev.forkhandles.values.regex
+
+/**
+ * The name of a named shadow. Absence of a name addresses the unnamed ("classic") shadow.
+ * Constrained to the charset and length AWS documents for a shadow name.
+ */
+class ShadowName private constructor(value: String) : StringValue(value) {
+    companion object : StringValueFactory<ShadowName>(::ShadowName, 64.maxLength.and("[a-zA-Z0-9:_-]+".regex))
+}

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model/ThingName.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model/ThingName.kt
@@ -1,0 +1,15 @@
+package org.http4k.connect.amazon.iotdataplane.model
+
+import dev.forkhandles.values.StringValue
+import dev.forkhandles.values.StringValueFactory
+import dev.forkhandles.values.and
+import dev.forkhandles.values.maxLength
+import dev.forkhandles.values.regex
+
+/**
+ * AWS does not allow slashes in a thing name, which is what lets it be dropped straight into the
+ * `/things/{thingName}/shadow` path.
+ */
+class ThingName private constructor(value: String) : StringValue(value) {
+    companion object : StringValueFactory<ThingName>(::ThingName, 128.maxLength.and("[a-zA-Z0-9:_-]+".regex))
+}

--- a/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model/TopicName.kt
+++ b/connect/amazon/iotdataplane/client/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model/TopicName.kt
@@ -1,0 +1,13 @@
+package org.http4k.connect.amazon.iotdataplane.model
+
+import dev.forkhandles.values.NonBlankStringValueFactory
+import dev.forkhandles.values.StringValue
+
+/**
+ * Only checked for being non-blank. MQTT topics are slash-separated and can contain `$` (reserved
+ * topics) and spaces, so the stricter pattern used for thing and shadow names would reject valid
+ * topics.
+ */
+class TopicName private constructor(value: String) : StringValue(value) {
+    companion object : NonBlankStringValueFactory<TopicName>(::TopicName)
+}

--- a/connect/amazon/iotdataplane/client/src/test/kotlin/org/http4k/connect/amazon/iotdataplane/HttpIotDataPlaneTest.kt
+++ b/connect/amazon/iotdataplane/client/src/test/kotlin/org/http4k/connect/amazon/iotdataplane/HttpIotDataPlaneTest.kt
@@ -1,0 +1,415 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.connect.amazon.CredentialsProvider
+import org.http4k.connect.amazon.FakeAwsEnvironment
+import org.http4k.connect.amazon.core.model.Region
+import org.http4k.connect.amazon.iotdataplane.action.DeleteConnection
+import org.http4k.connect.amazon.iotdataplane.action.GetRetainedMessage
+import org.http4k.connect.amazon.iotdataplane.action.GetThingShadow
+import org.http4k.connect.amazon.iotdataplane.action.Publish
+import org.http4k.connect.amazon.iotdataplane.action.RetainedMessageSummary
+import org.http4k.connect.amazon.iotdataplane.action.UpdateThingShadow
+import org.http4k.connect.amazon.iotdataplane.model.ClientId
+import org.http4k.connect.amazon.iotdataplane.model.PayloadFormatIndicator.UNSPECIFIED_BYTES
+import org.http4k.connect.amazon.iotdataplane.model.PayloadFormatIndicator.UTF8_DATA
+import org.http4k.connect.amazon.iotdataplane.model.ShadowName
+import org.http4k.connect.amazon.iotdataplane.model.ThingName
+import org.http4k.connect.amazon.iotdataplane.model.TopicName
+import org.http4k.connect.model.Base64Blob
+import org.http4k.connect.model.Timestamp
+import org.http4k.connect.model.TimestampMillis
+import org.http4k.connect.successValue
+import org.http4k.core.Method.DELETE
+import org.http4k.core.Method.GET
+import org.http4k.core.Method.POST
+import org.http4k.core.MockHttp
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.OK
+import org.http4k.core.Uri
+import org.http4k.hamkrest.hasBody
+import org.http4k.hamkrest.hasHeader
+import org.http4k.hamkrest.hasMethod
+import org.http4k.hamkrest.hasUri
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
+
+class HttpIotDataPlaneTest {
+
+    companion object {
+        private val base = Publish(
+            topic = TopicName.of("topic"),
+            payload = "hi".toByteArray(),
+            qos = 1,
+            retain = true,
+            messageExpiry = 60,
+            responseTopic = "response/topic",
+            contentType = "text/plain",
+            correlationData = Base64Blob.encode("correlation"),
+            payloadFormatIndicator = UTF8_DATA,
+            userProperties = listOf("k1" to "v1")
+        )
+
+        @JvmStatic
+        fun publishesDifferingInOneField() = listOf(
+            Arguments.of("payload", base.copy(payload = "ho".toByteArray())),
+            Arguments.of("topic", base.copy(topic = TopicName.of("other"))),
+            Arguments.of("qos", base.copy(qos = 0)),
+            Arguments.of("retain", base.copy(retain = false)),
+            Arguments.of("messageExpiry", base.copy(messageExpiry = 61)),
+            Arguments.of("responseTopic", base.copy(responseTopic = "response/other")),
+            Arguments.of("contentType", base.copy(contentType = "application/json")),
+            Arguments.of("correlationData", base.copy(correlationData = Base64Blob.encode("other"))),
+            Arguments.of("payloadFormatIndicator", base.copy(payloadFormatIndicator = UNSPECIFIED_BYTES)),
+            Arguments.of("userProperties", base.copy(userProperties = listOf("k1" to "v2")))
+        )
+    }
+
+    private val endpoint = Uri.of("https://abc123-ats.iot.us-east-1.amazonaws.com")
+
+    private val thingName = ThingName.of("my-thing")
+
+    /** An empty JSON document is what AWS answers with when there is nothing to report. */
+    private val mockHttp = MockHttp(Response(OK).body("{}"))
+
+    private val iotDataPlane = IotDataPlane.Http(
+        endpoint,
+        Region.US_EAST_1,
+        CredentialsProvider.FakeAwsEnvironment(),
+        mockHttp
+    )
+
+    @Test
+    fun `publish builds the documented request`() {
+        iotDataPlane.publish(
+            topic = TopicName.of("a/b/c"),
+            payload = "hello world".toByteArray(),
+            qos = 1,
+            retain = true,
+            messageExpiry = 60,
+            responseTopic = "response/topic",
+            contentType = "text/plain",
+            correlationData = Base64Blob.encode("correlation"),
+            payloadFormatIndicator = UTF8_DATA,
+            userProperties = listOf("k1" to "v1", "k2" to "v2")
+        ).successValue()
+
+        val request = mockHttp.request!!
+
+        assertThat(request, hasMethod(POST))
+
+        assertThat(
+            request, hasUri(
+                Uri.of(
+                    "https://abc123-ats.iot.us-east-1.amazonaws.com/topics/a/b/c" +
+                        "?contentType=text%2Fplain&messageExpiry=60&qos=1" +
+                        "&responseTopic=response%2Ftopic&retain=true"
+                )
+            )
+        )
+
+        assertThat(request, hasHeader("Content-Type", "application/octet-stream"))
+        assertThat(request, hasHeader("x-amz-mqtt5-correlation-data", Base64Blob.encode("correlation").value))
+        assertThat(request, hasHeader("x-amz-mqtt5-payload-format-indicator", "UTF8_DATA"))
+        assertThat(
+            request,
+            hasHeader("x-amz-mqtt5-user-properties", Base64Blob.encode("""[{"k1":"v1"},{"k2":"v2"}]""").value)
+        )
+
+        assertThat(request, hasBody("hello world"))
+        assertThat(request.body.payload.array().toList(), equalTo("hello world".toByteArray().toList()))
+    }
+
+    @Test
+    fun `publish omits every optional field when not set`() {
+        iotDataPlane.publish(
+            topic = TopicName.of("simple"),
+            payload = byteArrayOf(1, 2, 3)
+        ).successValue()
+
+        val request = mockHttp.request!!
+
+        assertThat(request, hasUri(Uri.of("https://abc123-ats.iot.us-east-1.amazonaws.com/topics/simple")))
+        assertThat(request.header("x-amz-mqtt5-correlation-data"), equalTo(null))
+        assertThat(request.header("x-amz-mqtt5-payload-format-indicator"), equalTo(null))
+        assertThat(request.header("x-amz-mqtt5-user-properties"), equalTo(null))
+        assertThat(request.body.payload.array().toList(), equalTo(listOf<Byte>(1, 2, 3)))
+    }
+
+    /** The action leaves the topic unencoded, because the AWS auth filter encodes the path later. */
+    @Test
+    fun `action leaves percent-encoding of the topic to the signing filter`() {
+        assertThat(
+            Publish(TopicName.of("\$aws/rules/rule/a b"), "hi".toByteArray()).toRequest().uri.path,
+            equalTo("/topics/\$aws/rules/rule/a b")
+        )
+
+        iotDataPlane.publish(TopicName.of("\$aws/rules/rule/a b"), "hi".toByteArray()).successValue()
+
+        assertThat(mockHttp.request!!.uri.path, equalTo("/topics/%24aws/rules/rule/a%20b"))
+    }
+
+    /** Two publishes carrying the same bytes must compare equal. */
+    @Test
+    fun `equality is by payload content`() {
+        val same = base.copy(payload = "hi".toByteArray())
+
+        assertThat(same, equalTo(base))
+        assertThat(same.hashCode(), equalTo(base.hashCode()))
+    }
+
+    /** One variant per field, so a field dropped from the comparison fails its case. */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("publishesDifferingInOneField")
+    fun `publishes differing in a single field are not equal`(field: String, other: Publish) {
+        assertThat(field, other, !equalTo(base))
+    }
+
+    @Test
+    fun `get thing shadow builds the documented request`() {
+        iotDataPlane.getThingShadow(thingName).successValue()
+
+        assertThat(mockHttp.request!!, hasMethod(GET))
+        assertThat(mockHttp.request!!, hasUri(uri("/things/my-thing/shadow")))
+    }
+
+    @Test
+    fun `get named thing shadow builds the documented request`() {
+        iotDataPlane.getThingShadow(thingName, ShadowName.of("config")).successValue()
+
+        assertThat(mockHttp.request!!, hasUri(uri("/things/my-thing/shadow?name=config")))
+    }
+
+    @Test
+    fun `update thing shadow builds the documented request`() {
+        iotDataPlane.updateThingShadow(
+            thingName,
+            """{"state":{"reported":{"on":true}}}""".toByteArray(),
+            ShadowName.of("config")
+        ).successValue()
+
+        val request = mockHttp.request!!
+
+        assertThat(request, hasMethod(POST))
+        assertThat(request, hasUri(uri("/things/my-thing/shadow?name=config")))
+        assertThat(request, hasHeader("Content-Type", "application/octet-stream"))
+        assertThat(request, hasBody("""{"state":{"reported":{"on":true}}}"""))
+    }
+
+    @Test
+    fun `delete thing shadow builds the documented request`() {
+        iotDataPlane.deleteThingShadow(thingName).successValue()
+
+        assertThat(mockHttp.request!!, hasMethod(DELETE))
+        assertThat(mockHttp.request!!, hasUri(uri("/things/my-thing/shadow")))
+    }
+
+    @Test
+    fun `list named shadows builds the documented request`() {
+        iotDataPlane.listNamedShadowsForThing(thingName, nextToken = "token", pageSize = 2).successValue()
+
+        assertThat(mockHttp.request!!, hasMethod(GET))
+        assertThat(
+            mockHttp.request!!,
+            hasUri(uri("/api/things/shadow/ListNamedShadowsForThing/my-thing?nextToken=token&pageSize=2"))
+        )
+    }
+
+    @Test
+    fun `list named shadows omits both optional query parameters when not set`() {
+        iotDataPlane.listNamedShadowsForThing(thingName).successValue()
+
+        assertThat(mockHttp.request!!, hasUri(uri("/api/things/shadow/ListNamedShadowsForThing/my-thing")))
+    }
+
+    @Test
+    fun `list named shadows unmarshals the response document`() {
+        val listing = IotDataPlane.Http(
+            endpoint,
+            Region.US_EAST_1,
+            CredentialsProvider.FakeAwsEnvironment(),
+            MockHttp(Response(OK).body("""{"results":["alpha","beta"],"nextToken":"token","timestamp":1614355593}"""))
+        ).listNamedShadowsForThing(thingName).successValue()
+
+        assertThat(listing.results, equalTo(listOf(ShadowName.of("alpha"), ShadowName.of("beta"))))
+        assertThat(listing.nextToken, equalTo("token"))
+        assertThat(listing.timestamp, equalTo(Timestamp.of(1614355593)))
+    }
+
+    /** A colon is the one character the thing-name charset allows which a path must still escape. */
+    @Test
+    fun `action leaves percent-encoding of the thing name to the signing filter`() {
+        assertThat(
+            GetThingShadow(ThingName.of("thing:one")).toRequest().uri.path,
+            equalTo("/things/thing:one/shadow")
+        )
+
+        iotDataPlane.getThingShadow(ThingName.of("thing:one")).successValue()
+
+        assertThat(mockHttp.request!!.uri.path, equalTo("/things/thing%3Aone/shadow"))
+    }
+
+    /** A slashed or spaced name would build a path AWS rejects and the fake cannot route. */
+    @ParameterizedTest(name = "{0}")
+    @ValueSource(strings = ["", " ", "thing one", "thing/one", "thing.one", "thing+one"])
+    fun `thing and shadow names outside the AWS charset are rejected`(name: String) {
+        assertThrows<IllegalArgumentException> { ThingName.of(name) }
+        assertThrows<IllegalArgumentException> { ShadowName.of(name) }
+    }
+
+    @Test
+    fun `thing and shadow names over the AWS length limit are rejected`() {
+        ThingName.of("t".repeat(128))
+        ShadowName.of("s".repeat(64))
+
+        assertThrows<IllegalArgumentException> { ThingName.of("t".repeat(129)) }
+        assertThrows<IllegalArgumentException> { ShadowName.of("s".repeat(65)) }
+    }
+
+    /** "The client ID can't start with a dollar sign ($)" - and nothing else is constrained. */
+    @Test
+    fun `client ids starting with a dollar sign are rejected`() {
+        ClientId.of("client\$id")
+
+        assertThrows<IllegalArgumentException> { ClientId.of("") }
+        assertThrows<IllegalArgumentException> { ClientId.of("\$aws-client") }
+    }
+
+    /** Two updates carrying the same bytes must compare equal. */
+    @Test
+    fun `update equality is by payload content`() {
+        val update = UpdateThingShadow(thingName, "hi".toByteArray(), ShadowName.of("config"))
+
+        assertThat(update.copy(payload = "hi".toByteArray()), equalTo(update))
+        assertThat(update.copy(payload = "hi".toByteArray()).hashCode(), equalTo(update.hashCode()))
+        assertThat(update.copy(payload = "ho".toByteArray()), !equalTo(update))
+        assertThat(update.copy(thingName = ThingName.of("other")), !equalTo(update))
+        assertThat(update.copy(shadowName = null), !equalTo(update))
+    }
+
+    @Test
+    fun `get retained message builds the documented request`() {
+        val mock = MockHttp(Response(OK).body(RETAINED_MESSAGE))
+
+        clientFor(mock).getRetainedMessage(TopicName.of("a/b")).successValue()
+
+        assertThat(mock.request!!, hasMethod(GET))
+        assertThat(mock.request!!, hasUri(uri("/retainedMessage/a/b")))
+    }
+
+    @Test
+    fun `get retained message unmarshals the response document`() {
+        val retained = clientFor(MockHttp(Response(OK).body(RETAINED_MESSAGE)))
+            .getRetainedMessage(TopicName.of("a/b"))
+            .successValue()
+
+        assertThat(retained.topic, equalTo(TopicName.of("a/b")))
+        assertThat(retained.lastModifiedTime, equalTo(TimestampMillis.of(1614355593000)))
+        assertThat(retained.qos, equalTo(1))
+        assertThat(retained.payload?.decoded(), equalTo("hello world"))
+        assertThat(retained.userProperties?.decoded(), equalTo("""[{"deviceName":"alpha"},{"deviceCnt":"45"}]"""))
+    }
+
+    @Test
+    fun `action leaves percent-encoding of the retained topic to the signing filter`() {
+        assertThat(
+            GetRetainedMessage(TopicName.of("\$aws/rules/rule/a b")).toRequest().uri.path,
+            equalTo("/retainedMessage/\$aws/rules/rule/a b")
+        )
+
+        val mock = MockHttp(Response(OK).body(RETAINED_MESSAGE))
+
+        clientFor(mock).getRetainedMessage(TopicName.of("\$aws/rules/rule/a b")).successValue()
+
+        assertThat(mock.request!!.uri.path, equalTo("/retainedMessage/%24aws/rules/rule/a%20b"))
+    }
+
+    @Test
+    fun `list retained messages builds the documented request`() {
+        iotDataPlane.listRetainedMessages(maxResults = 2, nextToken = "token").successValue()
+
+        assertThat(mockHttp.request!!, hasMethod(GET))
+        assertThat(mockHttp.request!!, hasUri(uri("/retainedMessage?maxResults=2&nextToken=token")))
+    }
+
+    @Test
+    fun `list retained messages omits both optional query parameters when not set`() {
+        iotDataPlane.listRetainedMessages().successValue()
+
+        assertThat(mockHttp.request!!, hasUri(uri("/retainedMessage")))
+    }
+
+    @Test
+    fun `list retained messages unmarshals the response document`() {
+        val listing = clientFor(
+            MockHttp(
+                Response(OK).body(
+                    """{"retainedTopics":[{"topic":"a/b","lastModifiedTime":1614355593000,""" +
+                        """"payloadSize":11,"qos":1}],"nextToken":"token"}"""
+                )
+            )
+        ).listRetainedMessages().successValue()
+
+        assertThat(listing.nextToken, equalTo("token"))
+        assertThat(
+            listing.retainedTopics, equalTo(
+                listOf(
+                    RetainedMessageSummary(
+                        topic = TopicName.of("a/b"),
+                        lastModifiedTime = TimestampMillis.of(1614355593000),
+                        payloadSize = 11,
+                        qos = 1
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `delete connection builds the documented request`() {
+        iotDataPlane.deleteConnection(
+            clientId = ClientId.of("my-client"),
+            cleanSession = true,
+            preventWillMessage = false
+        ).successValue()
+
+        assertThat(mockHttp.request!!, hasMethod(DELETE))
+        assertThat(
+            mockHttp.request!!,
+            hasUri(uri("/connections/my-client?cleanSession=true&preventWillMessage=false"))
+        )
+    }
+
+    @Test
+    fun `delete connection omits both optional query parameters when not set`() {
+        iotDataPlane.deleteConnection(ClientId.of("my-client")).successValue()
+
+        assertThat(mockHttp.request!!, hasUri(uri("/connections/my-client")))
+    }
+
+    @Test
+    fun `action leaves percent-encoding of the client id to the signing filter`() {
+        assertThat(
+            DeleteConnection(ClientId.of("client:one")).toRequest().uri.path,
+            equalTo("/connections/client:one")
+        )
+
+        iotDataPlane.deleteConnection(ClientId.of("client:one")).successValue()
+
+        assertThat(mockHttp.request!!.uri.path, equalTo("/connections/client%3Aone"))
+    }
+
+    private fun clientFor(http: MockHttp) =
+        IotDataPlane.Http(endpoint, Region.US_EAST_1, CredentialsProvider.FakeAwsEnvironment(), http)
+
+    private fun uri(path: String) = Uri.of("$endpoint$path")
+}
+
+private val RETAINED_MESSAGE = """{"topic":"a/b","lastModifiedTime":1614355593000,"qos":1,""" +
+    """"payload":"${Base64Blob.encode("hello world").value}",""" +
+    """"userProperties":"${Base64Blob.encode("""[{"deviceName":"alpha"},{"deviceCnt":"45"}]""").value}"}"""

--- a/connect/amazon/iotdataplane/client/src/test/kotlin/org/http4k/connect/amazon/iotdataplane/RealIotDataPlaneTest.kt
+++ b/connect/amazon/iotdataplane/client/src/test/kotlin/org/http4k/connect/amazon/iotdataplane/RealIotDataPlaneTest.kt
@@ -1,0 +1,20 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import org.http4k.client.JavaHttpClient
+import org.http4k.connect.amazon.RealAwsContract
+import org.http4k.core.Uri
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import java.lang.System.getenv
+
+/**
+ * Unlike other AWS services the IoT data endpoint is account-specific, so it has to be supplied.
+ * Set HTTP4K_IOT_DATA_PLANE_ENDPOINT to run this against a real account.
+ */
+class RealIotDataPlaneTest : IotDataPlaneContract, RealAwsContract {
+    override val http = JavaHttpClient()
+
+    override val endpoint: Uri
+        get() = getenv("HTTP4K_IOT_DATA_PLANE_ENDPOINT")
+            .also { assumeTrue(it != null, "HTTP4K_IOT_DATA_PLANE_ENDPOINT not set") }
+            .let(Uri::of)
+}

--- a/connect/amazon/iotdataplane/client/src/testFixtures/kotlin/org/http4k/connect/amazon/iotdataplane/IotDataPlaneContract.kt
+++ b/connect/amazon/iotdataplane/client/src/testFixtures/kotlin/org/http4k/connect/amazon/iotdataplane/IotDataPlaneContract.kt
@@ -1,0 +1,373 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.http4k.connect.amazon.AwsContract
+import org.http4k.connect.amazon.iotdataplane.action.RetainedMessages
+import org.http4k.connect.amazon.iotdataplane.model.ClientId
+import org.http4k.connect.amazon.iotdataplane.model.PayloadFormatIndicator.UTF8_DATA
+import org.http4k.connect.amazon.iotdataplane.model.ShadowName
+import org.http4k.connect.amazon.iotdataplane.model.ThingName
+import org.http4k.connect.amazon.iotdataplane.model.TopicName
+import org.http4k.connect.failureValue
+import org.http4k.connect.model.Base64Blob
+import org.http4k.connect.successValue
+import org.http4k.core.Status.Companion.NOT_FOUND
+import org.http4k.core.Uri
+import org.http4k.format.MoshiNode
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Test
+import java.io.InputStream
+import java.util.concurrent.TimeUnit.SECONDS
+
+interface IotDataPlaneContract : AwsContract {
+    /** The account-specific endpoint, eg. https://xxxxxxxx-ats.iot.<region>.amazonaws.com */
+    val endpoint: Uri
+
+    val iotDataPlane get() = IotDataPlane.Http(endpoint, aws.region, { aws.credentials }, http)
+
+    val topicPrefix get() = "http4k/${uuid()}"
+
+    /** Shadows outlive the request which created them, so every case gets its own thing. */
+    fun thing(name: String) = ThingName.of("http4k-${uuid()}-$name")
+
+    @Test
+    fun `publish message to topic`() {
+        iotDataPlane.publish(
+            topic = TopicName.of("$topicPrefix/simple"),
+            payload = "hello world".toByteArray()
+        ).successValue()
+    }
+
+    @Test
+    fun `publish with all options`() {
+        iotDataPlane.publish(
+            topic = TopicName.of("$topicPrefix/options"),
+            payload = "hello world".toByteArray(),
+            qos = 1,
+            retain = false,
+            messageExpiry = 60,
+            responseTopic = "$topicPrefix/response",
+            contentType = "text/plain",
+            correlationData = Base64Blob.encode("correlation"),
+            payloadFormatIndicator = UTF8_DATA,
+            userProperties = listOf("k1" to "v1", "k2" to "v2")
+        ).successValue()
+    }
+
+    /** Proves AWS accepts a topic containing slashes sent as plain path segments, as `Publish` sends it. */
+    @Test
+    fun `publish to topic containing slashes`() {
+        iotDataPlane.publish(
+            topic = TopicName.of("$topicPrefix/a/b/c"),
+            payload = "nested".toByteArray()
+        ).successValue()
+    }
+
+    @Test
+    fun `update then get round-trips the shadow state`() {
+        val thing = thing("roundtrip")
+
+        try {
+            val accepted = iotDataPlane
+                .updateThingShadow(thing, """{"state":{"reported":{"level":3,"on":true}}}""".toByteArray())
+                .successValue()
+                .asShadowDocument()
+
+            assertThat(accepted.at("version"), equalTo("1"))
+
+            val stored = iotDataPlane.getThingShadow(thing).successValue().asShadowDocument()
+
+            assertThat(stored.at("state", "reported", "level"), equalTo("3"))
+            assertThat(stored.at("state", "reported", "on"), equalTo("true"))
+            assertThat(stored.at("version"), equalTo("1"))
+        } finally {
+            iotDataPlane.deleteShadow(thing)
+        }
+    }
+
+    @Test
+    fun `update merges into the stored state`() {
+        val thing = thing("merge")
+
+        try {
+            iotDataPlane
+                .updateThingShadow(thing, """{"state":{"reported":{"on":true,"nested":{"a":1}}}}""".toByteArray())
+                .successValue()
+            iotDataPlane
+                .updateThingShadow(thing, """{"state":{"reported":{"nested":{"b":2}}}}""".toByteArray())
+                .successValue()
+            iotDataPlane
+                .updateThingShadow(thing, """{"state":{"reported":{"on":null}}}""".toByteArray())
+                .successValue()
+
+            val stored = iotDataPlane.getThingShadow(thing).successValue().asShadowDocument()
+
+            assertThat(stored.at("state", "reported", "nested", "a"), equalTo("1"))
+            assertThat(stored.at("state", "reported", "nested", "b"), equalTo("2"))
+            assertThat(stored.at("state", "reported", "on"), equalTo(null))
+            assertThat(stored.at("version"), equalTo("3"))
+        } finally {
+            iotDataPlane.deleteShadow(thing)
+        }
+    }
+
+    @Test
+    fun `named shadows are independent of the classic shadow`() {
+        val thing = thing("named")
+        val shadowName = ShadowName.of("config")
+
+        try {
+            iotDataPlane.updateThingShadow(thing, """{"state":{"reported":{"which":"classic"}}}""".toByteArray())
+                .successValue()
+            iotDataPlane
+                .updateThingShadow(thing, """{"state":{"reported":{"which":"named"}}}""".toByteArray(), shadowName)
+                .successValue()
+
+            val classic = iotDataPlane.getThingShadow(thing).successValue().asShadowDocument()
+            val named = iotDataPlane.getThingShadow(thing, shadowName).successValue().asShadowDocument()
+
+            assertThat(classic.at("state", "reported", "which"), equalTo(""""classic""""))
+            assertThat(named.at("state", "reported", "which"), equalTo(""""named""""))
+        } finally {
+            iotDataPlane.deleteShadow(thing)
+            iotDataPlane.deleteShadow(thing, shadowName)
+        }
+    }
+
+    @Test
+    fun `list named shadows`() {
+        val thing = thing("list")
+        val names = listOf("alpha", "beta").map(ShadowName::of)
+
+        try {
+            iotDataPlane.updateThingShadow(thing, SOME_STATE).successValue()
+            names.forEach { iotDataPlane.updateThingShadow(thing, SOME_STATE, it).successValue() }
+
+            assertThat(iotDataPlane.listNamedShadowsForThing(thing).successValue().results.sortedBy { it.value },
+                equalTo(names))
+        } finally {
+            iotDataPlane.deleteShadow(thing)
+            names.forEach { iotDataPlane.deleteShadow(thing, it) }
+        }
+    }
+
+    @Test
+    fun `list named shadows a page at a time`() {
+        val thing = thing("paged")
+        val names = listOf("one", "three", "two").map(ShadowName::of)
+
+        try {
+            names.forEach { iotDataPlane.updateThingShadow(thing, SOME_STATE, it).successValue() }
+
+            val first = iotDataPlane.listNamedShadowsForThing(thing, pageSize = 2).successValue()
+
+            assertThat(first.results.size, equalTo(2))
+            assertThat(first.nextToken != null, equalTo(true))
+
+            val second = iotDataPlane.listNamedShadowsForThing(thing, first.nextToken, pageSize = 2).successValue()
+
+            assertThat((first.results + second.results).sortedBy { it.value }, equalTo(names.sortedBy { it.value }))
+            assertThat(second.nextToken, equalTo(null))
+        } finally {
+            names.forEach { iotDataPlane.deleteShadow(thing, it) }
+        }
+    }
+
+    @Test
+    fun `get a shadow which does not exist`() {
+        assertThat(iotDataPlane.getThingShadow(thing("missing")).failureValue().status, equalTo(NOT_FOUND))
+    }
+
+    @Test
+    fun `delete a shadow then get it`() {
+        val thing = thing("deleted")
+
+        iotDataPlane.updateThingShadow(thing, SOME_STATE).successValue()
+        iotDataPlane.deleteThingShadow(thing).successValue()
+
+        assertThat(iotDataPlane.getThingShadow(thing).failureValue().status, equalTo(NOT_FOUND))
+        assertThat(iotDataPlane.deleteThingShadow(thing).failureValue().status, equalTo(NOT_FOUND))
+    }
+
+    @Test
+    fun `publish a retained message then get it`() {
+        val topic = TopicName.of("$topicPrefix/retained")
+
+        try {
+            iotDataPlane.publish(
+                topic = topic,
+                payload = "retained payload".toByteArray(),
+                qos = 1,
+                retain = true,
+                userProperties = listOf("deviceName" to "alpha")
+            ).successValue()
+
+            val retained = iotDataPlane.getRetainedMessage(topic).successValue()
+
+            assertThat(retained.topic, equalTo(topic))
+            assertThat(retained.payload?.decoded(), equalTo("retained payload"))
+            assertThat(retained.qos, equalTo(1))
+            assertThat(retained.lastModifiedTime.value > 0, equalTo(true))
+
+            // content only - AWS is free to re-serialize the JSON it echoes back
+            val userProperties = retained.userProperties?.decoded().orEmpty()
+            assertThat(userProperties.contains("deviceName") && userProperties.contains("alpha"), equalTo(true))
+        } finally {
+            iotDataPlane.clearRetainedMessage(topic)
+        }
+    }
+
+    @Test
+    fun `publish a retained message to a topic containing slashes then get it`() {
+        val topic = TopicName.of("$topicPrefix/a/b/c")
+
+        try {
+            iotDataPlane.publish(topic, "nested".toByteArray(), retain = true).successValue()
+
+            assertThat(iotDataPlane.getRetainedMessage(topic).successValue().payload?.decoded(), equalTo("nested"))
+        } finally {
+            iotDataPlane.clearRetainedMessage(topic)
+        }
+    }
+
+    @Test
+    fun `a second retained publish replaces the first`() {
+        val topic = TopicName.of("$topicPrefix/replaced")
+
+        try {
+            iotDataPlane.publish(topic, "first".toByteArray(), retain = true).successValue()
+            iotDataPlane.publish(topic, "second".toByteArray(), retain = true).successValue()
+
+            assertThat(iotDataPlane.getRetainedMessage(topic).successValue().payload?.decoded(), equalTo("second"))
+        } finally {
+            iotDataPlane.clearRetainedMessage(topic)
+        }
+    }
+
+    @Test
+    fun `a retained publish with an empty payload clears the retained message`() {
+        val topic = TopicName.of("$topicPrefix/cleared")
+
+        iotDataPlane.publish(topic, "value".toByteArray(), retain = true).successValue()
+        iotDataPlane.getRetainedMessage(topic).successValue()
+
+        iotDataPlane.publish(topic, ByteArray(0), retain = true).successValue()
+
+        assertThat(iotDataPlane.getRetainedMessage(topic).failureValue().status, equalTo(NOT_FOUND))
+    }
+
+    /**
+     * The retained store is account-wide and unbounded, so this proves content by point read and
+     * only checks the listing's structure. FakeIotDataPlaneTest asserts the listing's contents.
+     */
+    @Test
+    fun `list retained messages`() {
+        val topics = listOf("one", "two").map { TopicName.of("$topicPrefix/list/$it") }
+
+        try {
+            topics.forEach { iotDataPlane.publish(it, "listed".toByteArray(), qos = 1, retain = true).successValue() }
+
+            topics.forEach { topic ->
+                val retained = iotDataPlane.getRetainedMessage(topic).successValue()
+
+                assertThat(retained.topic, equalTo(topic))
+                assertThat(retained.payload?.decoded(), equalTo("listed"))
+                assertThat(retained.qos, equalTo(1))
+                assertThat(retained.lastModifiedTime.value > 0, equalTo(true))
+            }
+
+            val page = iotDataPlane.listRetainedMessages().successValue()
+
+            assertThat(page.retainedTopics.all { it.lastModifiedTime.value > 0 }, equalTo(true))
+        } finally {
+            topics.forEach(iotDataPlane::clearRetainedMessage)
+        }
+    }
+
+    /**
+     * maxResults is a maximum, not an exact page size. Pagination is proved by following one token
+     * rather than walking to the last page, which an account-wide store does not bound.
+     */
+    @Test
+    fun `list retained messages a page at a time`() {
+        val topics = listOf("one", "two").map { TopicName.of("$topicPrefix/paged/$it") }
+
+        try {
+            topics.forEach { iotDataPlane.publish(it, "paged".toByteArray(), retain = true).successValue() }
+
+            val first = iotDataPlane.awaitPaginableRetainedMessages()
+
+            assertThat(first.retainedTopics.size <= 1, equalTo(true))
+
+            assumeTrue(first.nextToken != null, "the account holds too few retained messages to paginate")
+
+            val second = iotDataPlane.listRetainedMessages(maxResults = 1, nextToken = first.nextToken).successValue()
+
+            assertThat(second.retainedTopics.size <= 1, equalTo(true))
+        } finally {
+            topics.forEach(iotDataPlane::clearRetainedMessage)
+        }
+    }
+
+    @Test
+    fun `get a retained message for a topic with nothing retained`() {
+        val topic = TopicName.of("$topicPrefix/nothing-retained")
+
+        assertThat(iotDataPlane.getRetainedMessage(topic).failureValue().status, equalTo(NOT_FOUND))
+    }
+
+    /**
+     * A freshly named client is connected to nothing, in a real account as in the fake, so both
+     * answer with what the AWS SDK's deserializer maps to ResourceNotFoundException. Disconnecting
+     * a live client cannot be asserted without one, so the failure path is what the contract holds
+     * both implementations to.
+     */
+    @Test
+    fun `delete a connection which does not exist`() {
+        val clientId = ClientId.of("http4k-${uuid()}")
+
+        assertThat(iotDataPlane.deleteConnection(clientId).failureValue().status, equalTo(NOT_FOUND))
+    }
+}
+
+private val SOME_STATE = """{"state":{"reported":{"created":true}}}""".toByteArray()
+
+/**
+ * The result is ignored on purpose. This runs in a finally block, so a failure here would hide the
+ * assertion failure that got us there.
+ */
+private fun IotDataPlane.deleteShadow(thingName: ThingName, shadowName: ShadowName? = null) {
+    deleteThingShadow(thingName, shadowName)
+}
+
+/**
+ * Publishing an empty payload with retain=true is how AWS deletes a retained message. The result is
+ * ignored for the same reason as [deleteShadow].
+ */
+private fun IotDataPlane.clearRetainedMessage(topic: TopicName) {
+    publish(topic, ByteArray(0), retain = true)
+}
+
+/**
+ * Retried, because AWS does not promise that a message which was just retained appears in this
+ * listing straight away.
+ */
+private fun IotDataPlane.awaitPaginableRetainedMessages(): RetainedMessages {
+    val deadline = System.currentTimeMillis() + SECONDS.toMillis(20)
+    var page = listRetainedMessages(maxResults = 1).successValue()
+
+    while (page.nextToken == null && System.currentTimeMillis() < deadline) {
+        Thread.sleep(SECONDS.toMillis(1))
+        page = listRetainedMessages(maxResults = 1).successValue()
+    }
+
+    return page
+}
+
+private fun InputStream.asShadowDocument() = IotDataPlaneMoshi.parse(reader().readText())
+
+/** Comparing leaves keeps assertions independent of attribute order and the sections only AWS returns. */
+private fun MoshiNode.at(vararg path: String) = path
+    .fold<String, MoshiNode?>(this) { node, name -> node?.let { IotDataPlaneMoshi.fields(it).toMap()[name] } }
+    ?.let(IotDataPlaneMoshi::compact)

--- a/connect/amazon/iotdataplane/fake/build.gradle.kts
+++ b/connect/amazon/iotdataplane/fake/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("org.http4k.community")
+    id("org.http4k.connect.module")
+    id("org.http4k.connect.fake")
+}
+
+dependencies {
+    testFixturesApi(testFixtures(project(":http4k-connect-amazon-core")))
+}

--- a/connect/amazon/iotdataplane/fake/src/examples/kotlin/using_connect_client.kt
+++ b/connect/amazon/iotdataplane/fake/src/examples/kotlin/using_connect_client.kt
@@ -1,0 +1,46 @@
+import dev.forkhandles.result4k.Result
+import org.http4k.aws.AwsCredentials
+import org.http4k.client.JavaHttpClient
+import org.http4k.connect.RemoteFailure
+import org.http4k.connect.amazon.core.model.Region
+import org.http4k.connect.amazon.iotdataplane.FakeIotDataPlane
+import org.http4k.connect.amazon.iotdataplane.Http
+import org.http4k.connect.amazon.iotdataplane.IotDataPlane
+import org.http4k.connect.amazon.iotdataplane.model.PayloadFormatIndicator.UTF8_DATA
+import org.http4k.connect.amazon.iotdataplane.model.TopicName
+import org.http4k.connect.amazon.iotdataplane.publish
+import org.http4k.core.HttpHandler
+import org.http4k.core.Uri
+import org.http4k.filter.debug
+
+const val USE_REAL_CLIENT = false
+
+fun main() {
+    val region = Region.of("us-east-1")
+    val topic = TopicName.of("http4k/example/topic")
+
+    // unlike other AWS services the IoT data endpoint is account-specific
+    val endpoint = Uri.of("https://000000000-ats.iot.us-east-1.amazonaws.com")
+
+    // we can connect to the real service or the fake (drop in replacement)
+    val http: HttpHandler = if (USE_REAL_CLIENT) JavaHttpClient() else FakeIotDataPlane()
+
+    // create a client
+    val client = IotDataPlane.Http(endpoint, region, { AwsCredentials("accessKeyId", "secretKey") }, http.debug())
+
+    // all operations return a Result monad of the API type
+    val published: Result<Unit, RemoteFailure> = client.publish(topic, """{"message":"hello"}""".toByteArray())
+    println(published)
+
+    // ... and the MQTT5 options are all available
+    println(
+        client.publish(
+            topic = topic,
+            payload = """{"message":"hello again"}""".toByteArray(),
+            qos = 1,
+            contentType = "application/json",
+            payloadFormatIndicator = UTF8_DATA,
+            userProperties = listOf("source" to "http4k")
+        )
+    )
+}

--- a/connect/amazon/iotdataplane/fake/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/FakeIotDataPlane.kt
+++ b/connect/amazon/iotdataplane/fake/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/FakeIotDataPlane.kt
@@ -1,0 +1,158 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import org.http4k.aws.AwsCredentials
+import org.http4k.chaos.ChaoticHttpHandler
+import org.http4k.chaos.start
+import org.http4k.connect.amazon.core.model.Region
+import org.http4k.connect.amazon.iotdataplane.action.NamedShadows
+import org.http4k.connect.amazon.iotdataplane.action.RetainedMessage
+import org.http4k.connect.amazon.iotdataplane.action.RetainedMessages
+import org.http4k.connect.amazon.iotdataplane.model.ShadowName
+import org.http4k.connect.amazon.iotdataplane.model.ThingName
+import org.http4k.connect.amazon.iotdataplane.model.TopicName
+import org.http4k.connect.model.Base64Blob
+import org.http4k.connect.storage.InMemory
+import org.http4k.connect.storage.Storage
+import org.http4k.core.Method.DELETE
+import org.http4k.core.Method.GET
+import org.http4k.core.Method.POST
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.OK
+import org.http4k.core.Uri
+import org.http4k.routing.bind
+import org.http4k.routing.path
+import org.http4k.routing.routes
+import java.time.Clock
+
+class FakeIotDataPlane(
+    private val messages: Storage<List<PublishedMessage>> = Storage.InMemory(),
+    private val shadows: Storage<String> = Storage.InMemory(),
+    private val retainedMessages: Storage<RetainedMessage> = Storage.InMemory(),
+    private val region: Region = Region.of("ldn-north-1"),
+    private val endpoint: Uri = Uri.of("https://http4k-ats.iot.$region.amazonaws.com"),
+    private val clock: Clock = Clock.systemUTC()
+) : ChaoticHttpHandler() {
+
+    // {topic:.+} because a topic may contain slashes
+    override val app = routes(
+        "/topics/{topic:.+}" bind POST to ::publish,
+        "/api/things/shadow/ListNamedShadowsForThing/{thingName}" bind GET to ::listNamedShadowsForThing,
+        "/things/{thingName}/shadow" bind GET to ::getThingShadow,
+        "/things/{thingName}/shadow" bind POST to ::updateThingShadow,
+        "/things/{thingName}/shadow" bind DELETE to ::deleteThingShadow,
+        "/retainedMessage" bind GET to ::listRetainedMessages,
+        "/retainedMessage/{topic:.+}" bind GET to ::getRetainedMessage,
+        "/connections/{clientId}" bind DELETE to ::deleteConnection
+    )
+
+    /** Nothing is ever connected to the fake, so there is never a connection to delete. */
+    private fun deleteConnection(request: Request) = connectionNotFound(request.clientId())
+
+    private fun publish(request: Request): Response {
+        val topic = TopicName.of(request.path("topic")!!)
+        val payload = Base64Blob.encode(request.body.stream)
+
+        messages[topic.value] = messages[topic.value].orEmpty() + PublishedMessage(
+            topic = topic,
+            payload = payload,
+            qos = request.query("qos")?.toInt(),
+            retain = request.query("retain")?.toBoolean(),
+            contentType = request.query("contentType"),
+            messageExpiry = request.query("messageExpiry")?.toLong(),
+            responseTopic = request.query("responseTopic"),
+            correlationData = request.header("x-amz-mqtt5-correlation-data"),
+            payloadFormatIndicator = request.header("x-amz-mqtt5-payload-format-indicator"),
+            userProperties = request.header("x-amz-mqtt5-user-properties")
+        )
+
+        if (request.query("retain")?.toBoolean() == true) {
+            retainedMessages.retain(topic, payload, request, clock)
+        }
+
+        return Response(OK).body("{}")
+    }
+
+    private fun getThingShadow(request: Request) = shadows[request.storageKey()]
+        ?.let { Response(OK).body(it) }
+        ?: request.shadowNotFound()
+
+    private fun updateThingShadow(request: Request): Response {
+        val key = request.storageKey()
+        val delta = IotDataPlaneMoshi.parse(request.bodyString())
+        val updated = updatedShadow(shadows[key]?.let(IotDataPlaneMoshi::parse), delta)
+
+        shadows[key] = IotDataPlaneMoshi.compact(updated)
+
+        return Response(OK).body(IotDataPlaneMoshi.compact(acceptedShadow(delta, updated.version())))
+    }
+
+    private fun deleteThingShadow(request: Request): Response {
+        val key = request.storageKey()
+        val existing = shadows[key] ?: return request.shadowNotFound()
+
+        shadows.remove(key)
+
+        return Response(OK)
+            .body(IotDataPlaneMoshi.compact(deletedShadow(IotDataPlaneMoshi.parse(existing).version())))
+    }
+
+    private fun listNamedShadowsForThing(request: Request): Response {
+        val names = namedShadowsOf(request.thingName())
+        val from = request.query("nextToken")?.toInt() ?: 0
+        val page = names.drop(from).take(request.query("pageSize")?.toInt() ?: names.size)
+
+        return Response(OK).body(
+            IotDataPlaneMoshi.asFormatString(
+                NamedShadows(
+                    results = page.map(ShadowName::of),
+                    nextToken = (from + page.size).takeIf { it < names.size }?.toString()
+                )
+            )
+        )
+    }
+
+    private fun getRetainedMessage(request: Request): Response {
+        val topic = TopicName.of(request.path("topic")!!)
+
+        return retainedMessages[topic.value]
+            ?.let { Response(OK).body(IotDataPlaneMoshi.asFormatString(it)) }
+            ?: retainedMessageNotFound(topic)
+    }
+
+    private fun listRetainedMessages(request: Request): Response {
+        val topics = retainedMessages.keySet().sorted()
+        val from = request.query("nextToken")?.toInt() ?: 0
+        val page = topics.drop(from).take(request.query("maxResults")?.toInt() ?: topics.size)
+
+        return Response(OK).body(
+            IotDataPlaneMoshi.asFormatString(
+                RetainedMessages(
+                    retainedTopics = page.mapNotNull { retainedMessages[it]?.summary() },
+                    nextToken = (from + page.size).takeIf { it < topics.size }?.toString()
+                )
+            )
+        )
+    }
+
+    private fun namedShadowsOf(thingName: ThingName) = shadows
+        .keySet(storageKey(thingName))
+        .map { it.substringAfter("/") }
+        .filter(String::isNotEmpty)
+        .sorted()
+
+    /**
+     * Convenience function to get an IotDataPlane client
+     */
+    fun client() = IotDataPlane.Http(endpoint, region, { AwsCredentials("accessKey", "secret") }, this)
+
+    fun publishedMessages(topic: TopicName) = messages[topic.value].orEmpty()
+
+    fun shadow(thingName: ThingName, shadowName: ShadowName? = null) = shadows[storageKey(thingName, shadowName)]
+
+    fun retainedMessage(topic: TopicName) = retainedMessages[topic.value]
+}
+
+fun main() {
+    FakeIotDataPlane().start()
+}

--- a/connect/amazon/iotdataplane/fake/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/connections.kt
+++ b/connect/amazon/iotdataplane/fake/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/connections.kt
@@ -1,0 +1,17 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import org.http4k.connect.amazon.iotdataplane.model.ClientId
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.NOT_FOUND
+import org.http4k.routing.path
+
+internal fun Request.clientId() = ClientId.of(path("clientId")!!)
+
+/**
+ * The fake holds no MQTT connections, so every client is an unknown one. The AWS SDK turns this
+ * status and error header into a ResourceNotFoundException.
+ */
+internal fun connectionNotFound(clientId: ClientId) = Response(NOT_FOUND)
+    .header("x-amzn-ErrorType", "ResourceNotFoundException")
+    .body("""{"message":"No connection found for client: '${clientId.value}'"}""")

--- a/connect/amazon/iotdataplane/fake/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model.kt
+++ b/connect/amazon/iotdataplane/fake/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/model.kt
@@ -1,0 +1,21 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import org.http4k.connect.amazon.iotdataplane.model.TopicName
+import org.http4k.connect.model.Base64Blob
+
+/**
+ * A message recorded by FakeIotDataPlane. The header fields are kept in their raw wire form so
+ * tests can assert on exactly what was transmitted.
+ */
+data class PublishedMessage(
+    val topic: TopicName,
+    val payload: Base64Blob,
+    val qos: Int? = null,
+    val retain: Boolean? = null,
+    val contentType: String? = null,
+    val messageExpiry: Long? = null,
+    val responseTopic: String? = null,
+    val correlationData: String? = null,
+    val payloadFormatIndicator: String? = null,
+    val userProperties: String? = null
+)

--- a/connect/amazon/iotdataplane/fake/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/retained.kt
+++ b/connect/amazon/iotdataplane/fake/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/retained.kt
@@ -1,0 +1,44 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import org.http4k.connect.amazon.iotdataplane.action.RetainedMessage
+import org.http4k.connect.amazon.iotdataplane.action.RetainedMessageSummary
+import org.http4k.connect.amazon.iotdataplane.model.TopicName
+import org.http4k.connect.model.Base64Blob
+import org.http4k.connect.model.TimestampMillis
+import org.http4k.connect.storage.Storage
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.NOT_FOUND
+import java.time.Clock
+
+/** AWS retains one message per topic, and treats a publish with an empty payload as a delete. */
+internal fun Storage<RetainedMessage>.retain(
+    topic: TopicName,
+    payload: Base64Blob,
+    request: Request,
+    clock: Clock
+) {
+    when {
+        payload.value.isEmpty() -> remove(topic.value)
+
+        else -> this[topic.value] = RetainedMessage(
+            topic = topic,
+            lastModifiedTime = TimestampMillis.of(clock.instant()),
+            qos = request.query("qos")?.toInt() ?: 0,
+            payload = payload,
+            userProperties = request.header("x-amz-mqtt5-user-properties")?.let(Base64Blob::of)
+        )
+    }
+}
+
+internal fun RetainedMessage.summary() = RetainedMessageSummary(
+    topic = topic,
+    lastModifiedTime = lastModifiedTime,
+    payloadSize = payload?.decodedBytes()?.size?.toLong() ?: 0,
+    qos = qos
+)
+
+/** The AWS SDK turns this status and error header into a ResourceNotFoundException. */
+internal fun retainedMessageNotFound(topic: TopicName) = Response(NOT_FOUND)
+    .header("x-amzn-ErrorType", "ResourceNotFoundException")
+    .body("""{"message":"No retained message found for topic: '${topic.value}'"}""")

--- a/connect/amazon/iotdataplane/fake/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/shadows.kt
+++ b/connect/amazon/iotdataplane/fake/src/main/kotlin/org/http4k/connect/amazon/iotdataplane/shadows.kt
@@ -1,0 +1,60 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import org.http4k.connect.amazon.iotdataplane.model.ShadowName
+import org.http4k.connect.amazon.iotdataplane.model.ThingName
+import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status.Companion.NOT_FOUND
+import org.http4k.format.MoshiInteger
+import org.http4k.format.MoshiNode
+import org.http4k.format.MoshiNull
+import org.http4k.format.MoshiObject
+import org.http4k.routing.path
+
+private const val STATE = "state"
+private const val VERSION = "version"
+
+/** Public so that a Storage passed to the fake can be pre-seeded with shadows. */
+fun storageKey(thingName: ThingName, shadowName: ShadowName? = null) =
+    "${thingName.value}/${shadowName?.value.orEmpty()}"
+
+/** Nested objects merge rather than replace, and an attribute submitted as null is deleted. */
+internal fun merge(existing: MoshiNode?, delta: MoshiNode): MoshiNode = when {
+    existing is MoshiObject && delta is MoshiObject -> MoshiObject(
+        (existing.attributes + delta.attributes)
+            .filterValues { it != MoshiNull }
+            .mapValues { (name, value) -> merge(existing[name], value) }
+            .toMutableMap()
+    )
+
+    else -> delta
+}
+
+internal fun updatedShadow(existing: MoshiNode?, delta: MoshiNode) = MoshiObject(
+    STATE to merge(existing.attribute(STATE), delta.state()),
+    VERSION to MoshiInteger(existing.version() + 1)
+)
+
+internal fun acceptedShadow(delta: MoshiNode, version: Int) = MoshiObject(
+    STATE to delta.state(),
+    VERSION to MoshiInteger(version)
+)
+
+internal fun deletedShadow(version: Int) = MoshiObject(VERSION to MoshiInteger(version))
+
+internal fun MoshiNode?.version() = (attribute(VERSION) as? MoshiInteger)?.value ?: 0
+
+private fun MoshiNode?.state() = attribute(STATE) ?: MoshiObject()
+
+private fun MoshiNode?.attribute(name: String) = (this as? MoshiObject)?.get(name)
+
+internal fun Request.thingName() = ThingName.of(path("thingName")!!)
+
+internal fun Request.shadowName() = query("name")?.let(ShadowName::of)
+
+internal fun Request.storageKey() = storageKey(thingName(), shadowName())
+
+/** The AWS SDK turns this status and error header into a ResourceNotFoundException. */
+internal fun Request.shadowNotFound() = Response(NOT_FOUND)
+    .header("x-amzn-ErrorType", "ResourceNotFoundException")
+    .body("""{"message":"No shadow exists with name: '${shadowName()?.value ?: "classic"}'"}""")

--- a/connect/amazon/iotdataplane/fake/src/test/kotlin/org/http4k/connect/amazon/iotdataplane/FakeIotDataPlaneChaosTest.kt
+++ b/connect/amazon/iotdataplane/fake/src/test/kotlin/org/http4k/connect/amazon/iotdataplane/FakeIotDataPlaneChaosTest.kt
@@ -1,0 +1,9 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import org.http4k.connect.FakeSystemContract
+import org.http4k.core.Method.POST
+import org.http4k.core.Request
+
+class FakeIotDataPlaneChaosTest : FakeSystemContract(FakeIotDataPlane()) {
+    override val anyValid = Request(POST, "/topics/foo")
+}

--- a/connect/amazon/iotdataplane/fake/src/test/kotlin/org/http4k/connect/amazon/iotdataplane/FakeIotDataPlaneTest.kt
+++ b/connect/amazon/iotdataplane/fake/src/test/kotlin/org/http4k/connect/amazon/iotdataplane/FakeIotDataPlaneTest.kt
@@ -1,0 +1,245 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.hasSize
+import com.natpryce.hamkrest.present
+import org.http4k.connect.amazon.FakeAwsContract
+import org.http4k.connect.amazon.iotdataplane.action.RetainedMessage
+import org.http4k.connect.amazon.iotdataplane.model.PayloadFormatIndicator.UTF8_DATA
+import org.http4k.connect.amazon.iotdataplane.model.ShadowName
+import org.http4k.connect.amazon.iotdataplane.model.ThingName
+import org.http4k.connect.amazon.iotdataplane.model.TopicName
+import org.http4k.connect.model.Base64Blob
+import org.http4k.connect.model.TimestampMillis
+import org.http4k.connect.storage.InMemory
+import org.http4k.connect.storage.Storage
+import org.http4k.connect.successValue
+import org.http4k.core.Uri
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset.UTC
+
+class FakeIotDataPlaneTest : IotDataPlaneContract, FakeAwsContract {
+    override val http = FakeIotDataPlane()
+
+    override val endpoint = Uri.of("https://http4k-ats.iot.ldn-north-1.amazonaws.com")
+
+    @Test
+    fun `records the payload of a published message`() {
+        val topic = TopicName.of("$topicPrefix/recorded")
+
+        iotDataPlane.publish(topic, "hello world".toByteArray()).successValue()
+
+        val messages = http.publishedMessages(topic)
+        assertThat(messages, hasSize(equalTo(1)))
+        assertThat(messages[0].topic, equalTo(topic))
+        assertThat(messages[0].payload, equalTo(Base64Blob.encode("hello world")))
+        assertThat(messages[0].payload.decoded(), equalTo("hello world"))
+        assertThat(messages[0].qos, equalTo(null))
+        assertThat(messages[0].correlationData, equalTo(null))
+    }
+
+    @Test
+    fun `records every parameter and header`() {
+        val topic = TopicName.of("$topicPrefix/full")
+
+        iotDataPlane.publish(
+            topic = topic,
+            payload = byteArrayOf(1, 2, 3),
+            qos = 1,
+            retain = true,
+            messageExpiry = 60,
+            responseTopic = "$topicPrefix/response",
+            contentType = "text/plain",
+            correlationData = Base64Blob.encode("correlation"),
+            payloadFormatIndicator = UTF8_DATA,
+            userProperties = listOf("k1" to "v1", "k2" to "v2")
+        ).successValue()
+
+        assertThat(
+            http.publishedMessages(topic), equalTo(
+                listOf(
+                    PublishedMessage(
+                        topic = topic,
+                        payload = Base64Blob.encode(byteArrayOf(1, 2, 3)),
+                        qos = 1,
+                        retain = true,
+                        contentType = "text/plain",
+                        messageExpiry = 60,
+                        responseTopic = "$topicPrefix/response",
+                        correlationData = Base64Blob.encode("correlation").value,
+                        payloadFormatIndicator = "UTF8_DATA",
+                        userProperties = Base64Blob.encode("""[{"k1":"v1"},{"k2":"v2"}]""").value
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `records a slashed topic under its full decoded name`() {
+        val topic = TopicName.of("$topicPrefix/a/b/c")
+
+        iotDataPlane.publish(topic, "nested".toByteArray()).successValue()
+
+        assertThat(http.publishedMessages(topic).map { it.topic }, equalTo(listOf(topic)))
+        assertThat(http.publishedMessages(TopicName.of("$topicPrefix/a")), hasSize(equalTo(0)))
+    }
+
+    @Test
+    fun `records repeated publishes to the same topic in order`() {
+        val topic = TopicName.of("$topicPrefix/repeat")
+
+        iotDataPlane.publish(topic, "one".toByteArray()).successValue()
+        iotDataPlane.publish(topic, "two".toByteArray()).successValue()
+
+        assertThat(
+            http.publishedMessages(topic).map { it.payload.decoded() },
+            equalTo(listOf("one", "two"))
+        )
+    }
+
+    @Test
+    fun `client convenience function targets the fake`() {
+        val topic = TopicName.of("$topicPrefix/client")
+
+        http.client().publish(topic, "via client".toByteArray()).successValue()
+
+        assertThat(http.publishedMessages(topic).map { it.payload.decoded() }, equalTo(listOf("via client")))
+    }
+
+    @Test
+    fun `stores the merged shadow document under the thing and shadow name`() {
+        val thing = thing("stored")
+        val shadowName = ShadowName.of("config")
+
+        iotDataPlane.updateThingShadow(thing, """{"state":{"reported":{"on":true}}}""".toByteArray(), shadowName)
+            .successValue()
+        iotDataPlane.updateThingShadow(thing, """{"state":{"desired":{"on":false}}}""".toByteArray(), shadowName)
+            .successValue()
+
+        assertThat(
+            http.shadow(thing, shadowName),
+            equalTo("""{"state":{"reported":{"on":true},"desired":{"on":false}},"version":2}""")
+        )
+        assertThat(http.shadow(thing), equalTo(null))
+    }
+
+    @Test
+    fun `removes the stored document on delete`() {
+        val thing = thing("removed")
+
+        iotDataPlane.updateThingShadow(thing, """{"state":{"reported":{"on":true}}}""".toByteArray()).successValue()
+        assertThat(http.shadow(thing), present())
+
+        iotDataPlane.deleteThingShadow(thing).successValue()
+        assertThat(http.shadow(thing), equalTo(null))
+    }
+
+    @Test
+    fun `answers a delete with the version of the deleted shadow`() {
+        val thing = thing("deletedVersion")
+
+        iotDataPlane.updateThingShadow(thing, """{"state":{"reported":{"on":true}}}""".toByteArray()).successValue()
+
+        assertThat(
+            iotDataPlane.deleteThingShadow(thing).successValue().reader().readText(),
+            equalTo("""{"version":1}""")
+        )
+    }
+
+    @Test
+    fun `shadows are seeded from the storage the fake is given`() {
+        val thing = ThingName.of("seeded")
+        val seeded = Storage.InMemory<String>()
+        seeded[storageKey(thing)] = """{"state":{"reported":{"on":true}},"version":7}"""
+
+        val document = FakeIotDataPlane(shadows = seeded).client()
+            .getThingShadow(thing)
+            .successValue()
+            .reader()
+            .readText()
+
+        assertThat(document, equalTo("""{"state":{"reported":{"on":true}},"version":7}"""))
+    }
+
+    @Test
+    fun `records a retained publish in both the message log and the retained store`() {
+        val topic = TopicName.of("$topicPrefix/retained")
+
+        iotDataPlane.publish(topic, "kept".toByteArray(), qos = 1, retain = true).successValue()
+
+        assertThat(http.publishedMessages(topic).map { it.payload.decoded() }, equalTo(listOf("kept")))
+        assertThat(http.retainedMessage(topic)?.payload, equalTo(Base64Blob.encode("kept")))
+        assertThat(http.retainedMessage(topic)?.qos, equalTo(1))
+    }
+
+    @Test
+    fun `a publish without the retain flag retains nothing`() {
+        val topic = TopicName.of("$topicPrefix/unretained")
+
+        iotDataPlane.publish(topic, "transient".toByteArray()).successValue()
+        iotDataPlane.publish(topic, "also transient".toByteArray(), retain = false).successValue()
+
+        assertThat(http.publishedMessages(topic), hasSize(equalTo(2)))
+        assertThat(http.retainedMessage(topic), equalTo(null))
+    }
+
+    @Test
+    fun `a retained publish replaces the stored message and an empty one removes it`() {
+        val topic = TopicName.of("$topicPrefix/replaced")
+
+        iotDataPlane.publish(topic, "first".toByteArray(), retain = true).successValue()
+        iotDataPlane.publish(topic, "second".toByteArray(), retain = true).successValue()
+
+        assertThat(http.retainedMessage(topic)?.payload, equalTo(Base64Blob.encode("second")))
+
+        iotDataPlane.publish(topic, ByteArray(0), retain = true).successValue()
+
+        assertThat(http.retainedMessage(topic), equalTo(null))
+        // clearing the retained message does not un-record the publishes
+        assertThat(http.publishedMessages(topic), hasSize(equalTo(3)))
+    }
+
+    /**
+     * The contract only checks the shape of a listing, because a real account's retained store is
+     * unbounded and shared. The full semantics - every retained message listed, with its payload
+     * size, reachable by following nextToken - are proved here, against a store which is closed.
+     */
+    @Test
+    fun `lists every message in the retained store, a page at a time`() {
+        val client = FakeIotDataPlane().client()
+        val topics = listOf("one", "three", "two").map { TopicName.of("listed/$it") }
+
+        topics.forEach { client.publish(it, "listed".toByteArray(), qos = 1, retain = true).successValue() }
+
+        val summaries = generateSequence(client.listRetainedMessages(maxResults = 2).successValue()) { page ->
+            page.nextToken?.let { client.listRetainedMessages(maxResults = 2, nextToken = it).successValue() }
+        }.flatMap { it.retainedTopics }.toList()
+
+        assertThat(summaries.map { it.topic }, equalTo(topics))
+        assertThat(summaries.map { it.payloadSize }.distinct(), equalTo(listOf("listed".length.toLong())))
+        assertThat(summaries.map { it.qos }.distinct(), equalTo(listOf(1)))
+    }
+
+    @Test
+    fun `retained messages are seeded from the storage the fake is given and timed by its clock`() {
+        val seeded = TopicName.of("seeded/topic")
+        val published = TopicName.of("published/topic")
+        val clock = Clock.fixed(Instant.parse("2021-02-26T15:26:33Z"), UTC)
+        val store = Storage.InMemory<RetainedMessage>()
+        store[seeded.value] = RetainedMessage(seeded, TimestampMillis.of(1L), 1, Base64Blob.encode("seeded"))
+
+        val fake = FakeIotDataPlane(retainedMessages = store, clock = clock)
+
+        fake.client().publish(published, "now".toByteArray(), retain = true).successValue()
+
+        assertThat(fake.client().getRetainedMessage(seeded).successValue().payload?.decoded(), equalTo("seeded"))
+        assertThat(
+            fake.client().getRetainedMessage(published).successValue().lastModifiedTime,
+            equalTo(TimestampMillis.of(clock.instant()))
+        )
+    }
+}

--- a/connect/amazon/iotdataplane/fake/src/test/kotlin/org/http4k/connect/amazon/iotdataplane/RunningFakeIotDataPlaneTest.kt
+++ b/connect/amazon/iotdataplane/fake/src/test/kotlin/org/http4k/connect/amazon/iotdataplane/RunningFakeIotDataPlaneTest.kt
@@ -1,0 +1,9 @@
+package org.http4k.connect.amazon.iotdataplane
+
+import org.http4k.connect.WithRunningFake
+import org.http4k.connect.amazon.FakeAwsContract
+import org.http4k.core.Uri
+
+class RunningFakeIotDataPlaneTest : IotDataPlaneContract, FakeAwsContract, WithRunningFake(::FakeIotDataPlane) {
+    override val endpoint = Uri.of("https://http4k-ats.iot.ldn-north-1.amazonaws.com")
+}


### PR DESCRIPTION
Adds `http4k-connect-amazon-iotdataplane` and its fake: Publish, GetThingShadow,
UpdateThingShadow, DeleteThingShadow, ListNamedShadowsForThing, GetRetainedMessage,
ListRetainedMessages, DeleteConnection.

Unlike most AWS services the endpoint is account-specific, so it is a required constructor argument.

Verified against a real AWS account: `RealIotDataPlaneTest` 18/18.
