### PR TITLE
Add SetUserMFAPreference and AdminSetUserMFAPreference to Cognito

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ changes with their rationale when appropriate.
 
 Given version `A.B.C.D`, breaking changes are to be expected in version number increments where changes in the `A` or `B` sections. Note that breaking changes could be via direct code or indirectly via dependencies.
 
+### v6.57.2.0 (uncut)
+- **http4k-connect-amazon-cognito**: Added `AdminSetUserMFAPreference` and `SetUserMFAPreference` actions (with `SMSMfaSettingsType`/`SoftwareTokenMfaSettingsType`/`EmailMfaSettingsType`/`WebAuthnMfaSettingsType` models), so a user's MFA factors can be enabled and a preferred factor chosen. The fake supports both.
+
 ### v6.57.1.0
 - **http4k-***: Republish 6.57.0.0 due to broken release
 

--- a/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/AdminSetUserMFAPreference.kt
+++ b/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/AdminSetUserMFAPreference.kt
@@ -1,0 +1,33 @@
+package org.http4k.connect.amazon.cognito.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.cognito.CognitoAction
+import org.http4k.connect.amazon.cognito.model.EmailMfaSettingsType
+import org.http4k.connect.amazon.cognito.model.SMSMfaSettingsType
+import org.http4k.connect.amazon.cognito.model.SoftwareTokenMfaSettingsType
+import org.http4k.connect.amazon.cognito.model.UserPoolId
+import org.http4k.connect.amazon.cognito.model.WebAuthnMfaSettingsType
+import org.http4k.connect.amazon.core.model.Username
+import org.http4k.connect.asRemoteFailure
+import org.http4k.core.Response
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+@JsonSerializable
+data class AdminSetUserMFAPreference(
+    val Username: Username,
+    val UserPoolId: UserPoolId,
+    val EmailMfaSettings: EmailMfaSettingsType? = null,
+    val SMSMfaSettings: SMSMfaSettingsType? = null,
+    val SoftwareTokenMfaSettings: SoftwareTokenMfaSettingsType? = null,
+    val WebAuthnMfaSettings: WebAuthnMfaSettingsType? = null
+) : CognitoAction<Unit>(Unit::class) {
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(Unit)
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+}

--- a/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/SetUserMFAPreference.kt
+++ b/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/action/SetUserMFAPreference.kt
@@ -1,0 +1,31 @@
+package org.http4k.connect.amazon.cognito.action
+
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Success
+import org.http4k.connect.Http4kConnectAction
+import org.http4k.connect.amazon.cognito.CognitoAction
+import org.http4k.connect.amazon.cognito.model.AccessToken
+import org.http4k.connect.amazon.cognito.model.EmailMfaSettingsType
+import org.http4k.connect.amazon.cognito.model.SMSMfaSettingsType
+import org.http4k.connect.amazon.cognito.model.SoftwareTokenMfaSettingsType
+import org.http4k.connect.amazon.cognito.model.WebAuthnMfaSettingsType
+import org.http4k.connect.asRemoteFailure
+import org.http4k.core.Response
+import se.ansman.kotshi.JsonSerializable
+
+@Http4kConnectAction
+@JsonSerializable
+data class SetUserMFAPreference(
+    val AccessToken: AccessToken,
+    val EmailMfaSettings: EmailMfaSettingsType? = null,
+    val SMSMfaSettings: SMSMfaSettingsType? = null,
+    val SoftwareTokenMfaSettings: SoftwareTokenMfaSettingsType? = null,
+    val WebAuthnMfaSettings: WebAuthnMfaSettingsType? = null
+) : CognitoAction<Unit>(Unit::class) {
+    override fun toResult(response: Response) = with(response) {
+        when {
+            status.successful -> Success(Unit)
+            else -> Failure(asRemoteFailure(this))
+        }
+    }
+}

--- a/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/model/cognito.kt
+++ b/connect/amazon/cognito/client/src/main/kotlin/org/http4k/connect/amazon/cognito/model/cognito.kt
@@ -142,7 +142,7 @@ enum class UsernameAttribute {
 }
 
 enum class UserMFASetting {
-    SMS_MFA, SOFTWARE_TOKEN_MFA
+    SMS_MFA, SOFTWARE_TOKEN_MFA, EMAIL_OTP
 }
 
 enum class OAuthFlow {
@@ -159,6 +159,29 @@ data class AttributeType(
 data class MFAOptions(
     val AttributeName: String? = null,
     val DeliveryMedium: DeliveryMedium? = null
+)
+
+@JsonSerializable
+data class SMSMfaSettingsType(
+    val Enabled: Boolean? = null,
+    val PreferredMfa: Boolean? = null
+)
+
+@JsonSerializable
+data class SoftwareTokenMfaSettingsType(
+    val Enabled: Boolean? = null,
+    val PreferredMfa: Boolean? = null
+)
+
+@JsonSerializable
+data class EmailMfaSettingsType(
+    val Enabled: Boolean? = null,
+    val PreferredMfa: Boolean? = null
+)
+
+@JsonSerializable
+data class WebAuthnMfaSettingsType(
+    val Enabled: Boolean? = null
 )
 
 @JsonSerializable

--- a/connect/amazon/cognito/fake/src/main/kotlin/org/http4k/connect/amazon/cognito/FakeCognito.kt
+++ b/connect/amazon/cognito/fake/src/main/kotlin/org/http4k/connect/amazon/cognito/FakeCognito.kt
@@ -4,6 +4,7 @@ import org.http4k.aws.AwsCredentials
 import org.http4k.chaos.ChaoticHttpHandler
 import org.http4k.chaos.start
 import org.http4k.connect.amazon.AwsJsonFake
+import org.http4k.connect.amazon.cognito.endpoints.adminSetUserMFAPreference
 import org.http4k.connect.amazon.cognito.endpoints.createResourceServer
 import org.http4k.connect.amazon.cognito.endpoints.createUserPool
 import org.http4k.connect.amazon.cognito.endpoints.createUserPoolClient
@@ -13,6 +14,7 @@ import org.http4k.connect.amazon.cognito.endpoints.deleteUserPoolDomain
 import org.http4k.connect.amazon.cognito.endpoints.getTokensFromRefreshToken
 import org.http4k.connect.amazon.cognito.endpoints.resendConfirmationCode
 import org.http4k.connect.amazon.cognito.endpoints.revokeToken
+import org.http4k.connect.amazon.cognito.endpoints.setUserMFAPreference
 import org.http4k.connect.amazon.cognito.endpoints.wellKnown
 import org.http4k.connect.amazon.cognito.oauth.CognitoOAuth
 import org.http4k.connect.amazon.core.model.AwsService
@@ -34,6 +36,7 @@ class FakeCognito(
     override val app = routes(
         CognitoOAuth(pools, clock, expiry),
         wellKnown(pools),
+        api.adminSetUserMFAPreference(pools),
         api.createUserPool(pools),
         api.createResourceServer(pools),
         api.createUserPoolDomain(pools),
@@ -42,7 +45,8 @@ class FakeCognito(
         api.deleteUserPool(pools),
         api.getTokensFromRefreshToken(pools),
         api.resendConfirmationCode(pools),
-        api.revokeToken(pools)
+        api.revokeToken(pools),
+        api.setUserMFAPreference()
     )
 
     /**

--- a/connect/amazon/cognito/fake/src/main/kotlin/org/http4k/connect/amazon/cognito/endpoints/AdminSetUserMFAPreference.kt
+++ b/connect/amazon/cognito/fake/src/main/kotlin/org/http4k/connect/amazon/cognito/endpoints/AdminSetUserMFAPreference.kt
@@ -1,0 +1,10 @@
+package org.http4k.connect.amazon.cognito.endpoints
+
+import org.http4k.connect.amazon.AwsJsonFake
+import org.http4k.connect.amazon.cognito.CognitoPool
+import org.http4k.connect.amazon.cognito.action.AdminSetUserMFAPreference
+import org.http4k.connect.storage.Storage
+
+fun AwsJsonFake.adminSetUserMFAPreference(pools: Storage<CognitoPool>) = route<AdminSetUserMFAPreference> {
+    pools[it.UserPoolId.value]?.let { Unit }
+}

--- a/connect/amazon/cognito/fake/src/main/kotlin/org/http4k/connect/amazon/cognito/endpoints/SetUserMFAPreference.kt
+++ b/connect/amazon/cognito/fake/src/main/kotlin/org/http4k/connect/amazon/cognito/endpoints/SetUserMFAPreference.kt
@@ -1,0 +1,9 @@
+package org.http4k.connect.amazon.cognito.endpoints
+
+import org.http4k.connect.amazon.AwsJsonFake
+import org.http4k.connect.amazon.cognito.action.SetUserMFAPreference
+
+/** The caller is identified by an access token, which the fake does not model - so there is nothing to check. */
+fun AwsJsonFake.setUserMFAPreference() = route<SetUserMFAPreference> {
+    Unit
+}

--- a/connect/amazon/cognito/fake/src/test/kotlin/org/http4k/connect/amazon/cognito/FakeCognitoMFAPreferenceTest.kt
+++ b/connect/amazon/cognito/fake/src/test/kotlin/org/http4k/connect/amazon/cognito/FakeCognitoMFAPreferenceTest.kt
@@ -1,0 +1,39 @@
+package org.http4k.connect.amazon.cognito
+
+import org.http4k.connect.amazon.cognito.model.AccessToken
+import org.http4k.connect.amazon.cognito.model.PoolName
+import org.http4k.connect.amazon.cognito.model.SMSMfaSettingsType
+import org.http4k.connect.amazon.cognito.model.SoftwareTokenMfaSettingsType
+import org.http4k.connect.amazon.core.model.Username
+import org.http4k.connect.successValue
+import org.junit.jupiter.api.Test
+import java.util.UUID.randomUUID
+
+/**
+ * Fake-only rather than part of [CognitoContract]: the admin call needs a user which the pool APIs
+ * cannot create here, and the access-token call needs a genuinely signed-in user, so neither would
+ * pass against real Cognito.
+ */
+class FakeCognitoMFAPreferenceTest {
+
+    private val cognito = FakeCognito().client()
+
+    @Test
+    fun `can set user MFA preference as admin`() {
+        val pool = cognito.createUserPool(PoolName.of(randomUUID().toString())).successValue().UserPool.Id!!
+
+        cognito.adminSetUserMFAPreference(
+            Username = Username.of("test@example.com"),
+            UserPoolId = pool,
+            SMSMfaSettings = SMSMfaSettingsType(Enabled = true, PreferredMfa = true)
+        ).successValue()
+    }
+
+    @Test
+    fun `can set user MFA preference with an access token`() {
+        cognito.setUserMFAPreference(
+            AccessToken = AccessToken.of("fake-access-token"),
+            SoftwareTokenMfaSettings = SoftwareTokenMfaSettingsType(Enabled = true, PreferredMfa = true)
+        ).successValue()
+    }
+}


### PR DESCRIPTION
Both actions, with the `SMSMfaSettingsType`, `SoftwareTokenMfaSettingsType`, `EmailMfaSettingsType` and `WebAuthnMfaSettingsType` models, so a user's MFA factors can be enabled and a preferred factor chosen. The fake supports both.
