### PR TITLE
Accept comma-separated targets in the FakeDynamoDb REMOVE clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Given version `A.B.C.D`, breaking changes are to be expected in version number i
 - **http4k-***: Upgrade versions, including Swagger UI upgrade (path change)
 - **http4k-serverless-tencent**: [Possible break] Removed the dependency on `com.tencentcloudapi:scf-java-events`, which has been abandoned since its last release in June 2021 and has no replacement artifact. Vendored dependent classes. The module has no third-party runtime dependencies at all.
 - **http4k-format-fory**: [New module!] Support for Apache Fory binary serializationn.
+- **http4k-connect-amazon-dynamodb-fake**: [Fix] `REMOVE #a, #b` now parses. Targets could previously only be separated by whitespace, so an update removing two attributes failed.
 
 ### v6.57.2.0
 - **http4k-***: Upgrade versions

--- a/connect/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbUpdateGrammar.kt
+++ b/connect/amazon/dynamodb/fake/src/main/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbUpdateGrammar.kt
@@ -151,7 +151,7 @@ private val Remove = inOrder(
     oneOf(token("REMOVE"), token("remove")), // fixme possible to be case insensitive?
     oneOrMore(
         inOrder(
-            optional(Tokens.whitespace),
+            optional(oneOf(token(","), Tokens.whitespace)),
             Name,
             optional(index)
         ).skipFirst()

--- a/connect/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbUpdateGrammarTest.kt
+++ b/connect/amazon/dynamodb/fake/src/test/kotlin/org/http4k/connect/amazon/dynamodb/grammar/DynamoDbUpdateGrammarTest.kt
@@ -30,6 +30,21 @@ class DynamoDbUpdateGrammarTest {
     )
 
     @Test
+    fun `remove - multiple, comma separated`() = assert(
+        expression = "REMOVE $attrN, $attrS",
+        item = Item(attrS of "a", attrN of 1, attrBool of true),
+        expected = Item(attrBool of true)
+    )
+
+    @Test
+    fun `remove - multiple named, comma separated`() = assert(
+        expression = "REMOVE #key1, #key2",
+        item = Item(attrS of "a", attrN of 1, attrBool of true),
+        expected = Item(attrBool of true),
+        names = mapOf("#key1" to attrN.name, "#key2" to attrS.name)
+    )
+
+    @Test
     fun `remove - named`() = assert(
         expression = "REMOVE #key1",
         item = Item(attrS of "a", attrN of 1),


### PR DESCRIPTION
`REMOVE #a, #b` now parses. Targets could previously only be separated by whitespace, so an update removing two attributes failed