### PR TITLE
Fix CSV deserialization column ordering and unknown columns handling in http4k-format-jackson-csv

### DIFF
--- a/core/format/jackson-csv/src/main/kotlin/org/http4k/format/ConfigurableJacksonCsv.kt
+++ b/core/format/jackson-csv/src/main/kotlin/org/http4k/format/ConfigurableJacksonCsv.kt
@@ -18,7 +18,8 @@ import kotlin.reflect.KClass
 
 open class ConfigurableJacksonCsv(val mapper: CsvMapper, val defaultContentType: ContentType = ContentType.TEXT_CSV) {
 
-    inline fun <reified T> defaultSchema(): CsvSchema = mapper.schemaFor(T::class.java).withHeader()
+    inline fun <reified T> defaultWriteSchema(): CsvSchema = mapper.schemaFor(T::class.java).withHeader()
+    fun defaultReadSchema(): CsvSchema = CsvSchema.emptySchema().withHeader()
 
     fun <T : Any> writerFor(type: KClass<T>, schema: CsvSchema): (List<T>) -> String = { body: List<T> ->
         StringWriter().use { stringWriter ->
@@ -36,12 +37,12 @@ open class ConfigurableJacksonCsv(val mapper: CsvMapper, val defaultContentType:
         }
     }
 
-    inline fun <reified T : Any> writeCsv(input: List<T>, schema: CsvSchema = defaultSchema<T>()): String {
+    inline fun <reified T : Any> writeCsv(input: List<T>, schema: CsvSchema = defaultWriteSchema<T>()): String {
         val writer = writerFor(T::class, schema)
         return writer(input)
     }
 
-    inline fun <reified T : Any> readCsv(input: String, schema: CsvSchema = defaultSchema<T>()): List<T> {
+    inline fun <reified T : Any> readCsv(input: String, schema: CsvSchema = defaultReadSchema()): List<T> {
         val reader = readerFor(T::class, schema)
         return reader(input)
     }
@@ -56,8 +57,11 @@ open class ConfigurableJacksonCsv(val mapper: CsvMapper, val defaultContentType:
      */
     inline fun <reified T : Any> HttpMessage.csv(): List<T> = Body.auto<T>().toLens()(this)
 
-    inline fun <reified T : Any> asBiDiMapping(schema: CsvSchema = defaultSchema<T>()) =
-        BiDiMapping<String, List<T>>(readerFor(T::class, schema), writerFor(T::class, schema))
+    inline fun <reified T : Any> asBiDiMapping(
+        readSchema: CsvSchema = defaultReadSchema(),
+        writeSchema: CsvSchema = defaultWriteSchema<T>()
+    ) =
+        BiDiMapping<String, List<T>>(readerFor(T::class, readSchema), writerFor(T::class, writeSchema))
 
     inline fun <reified T : Any> Body.Companion.auto(
         description: String? = null,
@@ -68,10 +72,11 @@ open class ConfigurableJacksonCsv(val mapper: CsvMapper, val defaultContentType:
         description: String? = null,
         contentNegotiation: ContentNegotiation = ContentNegotiation.None,
         contentType: ContentType = defaultContentType,
-        schema: CsvSchema = defaultSchema<T>()
+        readSchema: CsvSchema = defaultReadSchema(),
+        writeSchema: CsvSchema = defaultWriteSchema<T>()
     ): BiDiBodyLensSpec<List<T>> {
-        val reader = readerFor(T::class, schema)
-        val writer = writerFor(T::class, schema)
+        val reader = readerFor(T::class, readSchema)
+        val writer = writerFor(T::class, writeSchema)
 
         return httpBodyRoot(
             listOf(Meta(true, "body", ObjectParam, "body", description, emptyMap())),

--- a/core/format/jackson-csv/src/test/kotlin/org/http4k/format/jacksonCsvTests.kt
+++ b/core/format/jackson-csv/src/test/kotlin/org/http4k/format/jacksonCsvTests.kt
@@ -6,6 +6,8 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.has
 import org.http4k.core.Body
+import org.http4k.core.Method
+import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.Uri
@@ -47,16 +49,21 @@ class JacksonCsvBodyTest {
     }
 
     @Test
-    fun `default schema is set to use headers`() {
+    fun `default schemas are set to use headers`() {
         assertThat(
-            JacksonCsv.defaultSchema<CsvArbObject>(),
+            JacksonCsv.defaultWriteSchema<CsvArbObject>(),
+            has(CsvSchema::usesHeader, equalTo(true))
+        )
+
+        assertThat(
+            JacksonCsv.defaultReadSchema(),
             has(CsvSchema::usesHeader, equalTo(true))
         )
     }
 
     @Test
     fun `empty list of objects with schema headers results in output with only headers`() {
-        val writer = JacksonCsv.writerFor(CsvArbObject::class, JacksonCsv.defaultSchema<CsvArbObject>())
+        val writer = JacksonCsv.writerFor(CsvArbObject::class, JacksonCsv.defaultWriteSchema<CsvArbObject>())
 
         assertThat(
             writer(emptyList()),
@@ -115,6 +122,79 @@ PT1S,1970-01-01T00:00:00Z,2000-01-01,2000-01-01T01:01:01,01:01:01,2000-01-01T01:
         assertThat(
             Response(OK).with(lens of listOf(obj)).bodyString(),
             equalTo(csv)
+        )
+    }
+
+    @Test
+    fun `roundtrip list of rows with unknown column from and to body`() {
+        val inputCsv = """
+            string,unknown,numbers,bool
+            hello,foo,,false
+            goodbye,bar,1;2;3,true
+
+        """.trimIndent()
+
+        val outputCsv = """
+            string,numbers,bool
+            hello,,false
+            goodbye,1;2;3,true
+
+        """.trimIndent()
+
+        val lens = JacksonCsv.autoBody<CsvArbObject>().toLens()
+
+        assertThat(
+            Response(OK).with(lens of lens(Request(Method.POST, "").body(inputCsv)))
+                .bodyString(),
+            equalTo(outputCsv)
+        )
+    }
+
+    @Test
+    fun `roundtrip list of rows with unordered columns from and to with BiDi lens`() {
+        val inputCsv = """
+            numbers,string,bool
+            ,hello,false
+            1;2;3,goodbye,true
+
+        """.trimIndent()
+
+        val outputCsv = """
+            string,numbers,bool
+            hello,,false
+            goodbye,1;2;3,true
+
+        """.trimIndent()
+
+        val lens = JacksonCsv.asBiDiMapping<CsvArbObject>()
+
+        assertThat(
+            lens(lens(inputCsv)),
+            equalTo(outputCsv)
+        )
+    }
+
+    @Test
+    fun `roundtrip list of rows with unknown column from and to with BiDi lens`() {
+        val inputCsv = """
+            string,unknown,numbers,bool
+            hello,foo,,false
+            goodbye,bar,1;2;3,true
+
+        """.trimIndent()
+
+        val outputCsv = """
+            string,numbers,bool
+            hello,,false
+            goodbye,1;2;3,true
+
+        """.trimIndent()
+
+        val lens = JacksonCsv.asBiDiMapping<CsvArbObject>()
+
+        assertThat(
+            lens(lens(inputCsv)),
+            equalTo(outputCsv)
         )
     }
 


### PR DESCRIPTION
<!-- Love http4k? Please consider sponsoring the project: 👉  https://github.com/sponsors/http4k -->

- [x] I have signed off all my commits (`git commit -s`) - see [CONTRIBUTING.md](../CONTRIBUTING.md#developer-certificate-of-origin-dco)

This PR resolves two deserialization issues when parsing CSV files using `http4k-format-jackson-csv`:

1. Column Ordering Mismatch: Fixes an issue where CSV files with columns ordered differently from the order defined by `@JsonPropertyOrder` failed to deserialize correctly.
2. Unknown Columns Handling: Fixes deserialization failures when a CSV file contains additional/unknown columns not explicitly declared on the target data class.

Changes Included

- ConfigurableJacksonCsv: Replaced defaultSchema with defaultReadSchema (header-driven) and defaultWriteSchema (property-order-driven).
- Tests: Added unit tests covering:
    - Deserializing CSV files where column order differs from model definition.
    - Deserializing CSV files with unknown/extra header columns.
