### PR TITLE
ResponseKey: Add optional ResponseLens and align ResponseKey naming conventions with RequestKey

### DIFF
--- a/core/core/src/main/kotlin/org/http4k/lens/response.kt
+++ b/core/core/src/main/kotlin/org/http4k/lens/response.kt
@@ -29,7 +29,6 @@ object ResponseKey {
         return BiDiLens(meta, get, setter)
     }
 
-
     @Deprecated("use ResponseKey.required", replaceWith = ReplaceWith("ResponseKey.required"))
     fun <T : Any> of(name: String): ResponseLens<T> = required(name)
 
@@ -54,5 +53,4 @@ object ResponseKey {
         }
         return BiDiLens(meta, get, setter)
     }
-
 }

--- a/core/core/src/main/kotlin/org/http4k/lens/response.kt
+++ b/core/core/src/main/kotlin/org/http4k/lens/response.kt
@@ -47,7 +47,7 @@ object ResponseKey {
         val setter = { value: T?, target: Response ->
             val wrappedValue = if (value == null) emptyMap() else mapOf(name to value)
             when (target) {
-                is ResponseWithContext -> ResponseWithContext(target.delegate, target.context + wrappedValue)
+                is ResponseWithContext -> ResponseWithContext(target.delegate, target.context - name + wrappedValue)
                 else -> ResponseWithContext(target, wrappedValue)
             }
         }

--- a/core/core/src/main/kotlin/org/http4k/lens/response.kt
+++ b/core/core/src/main/kotlin/org/http4k/lens/response.kt
@@ -7,7 +7,11 @@ import org.http4k.routing.ResponseWithContext
 typealias ResponseLens<T> = BiDiLens<Response, T>
 
 object ResponseKey {
-    fun <T : Any> of(name: String): ResponseLens<T> {
+
+    /**
+     * Represents a mandatory value in the context of a Response.
+     */
+    fun <T : Any> required(name: String): ResponseLens<T> {
         val meta = Meta(true, "context", ObjectParam, name, null, emptyMap())
         val get: (Response) -> T = { target ->
             @Suppress("UNCHECKED_CAST")
@@ -24,4 +28,31 @@ object ResponseKey {
         }
         return BiDiLens(meta, get, setter)
     }
+
+
+    @Deprecated("use ResponseKey.required", replaceWith = ReplaceWith("ResponseKey.required"))
+    fun <T : Any> of(name: String): ResponseLens<T> = required(name)
+
+    /**
+     * Represents a nullable value in the context of a Response.
+     */
+    fun <T : Any> optional(name: String): ResponseLens<T?> {
+        val meta = Meta(true, "context", ObjectParam, name, null, emptyMap())
+        val get: (Response) -> T? = { target ->
+            @Suppress("UNCHECKED_CAST")
+            when (target) {
+                is ResponseWithContext -> target.context[name] as? T
+                else -> null
+            }
+        }
+        val setter = { value: T?, target: Response ->
+            val wrappedValue = if (value == null) emptyMap() else mapOf(name to value)
+            when (target) {
+                is ResponseWithContext -> ResponseWithContext(target.delegate, target.context + wrappedValue)
+                else -> ResponseWithContext(target, wrappedValue)
+            }
+        }
+        return BiDiLens(meta, get, setter)
+    }
+
 }

--- a/core/core/src/test/kotlin/org/http4k/lens/RequestKeyTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/lens/RequestKeyTest.kt
@@ -47,7 +47,7 @@ class RequestKeyTest {
         val requiredKey = RequestKey.required<String>("bob")
         assertThat(requiredKey(request.with(requiredKey of "hello")), equalTo("hello"))
 
-        val optionalKey = RequestKey.required<String>("bob")
+        val optionalKey = RequestKey.optional<String>("bob")
         assertThat(optionalKey(request.with(optionalKey of "hello")), equalTo("hello"))
     }
 

--- a/core/core/src/test/kotlin/org/http4k/lens/ResponseKeyTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/lens/ResponseKeyTest.kt
@@ -23,13 +23,13 @@ class ResponseKeyTest {
 
     @Test
     fun `value present`() {
-        assertThat(ResponseKey.required<String>("hello")(response), equalTo("world"))
+        assertThat(ResponseKey.of<String>("hello")(response), equalTo("world"))
         assertThat(ResponseKey.optional<String>("hello")(response), equalTo("world"))
     }
 
     @Test
     fun `required value missing`() {
-        val requiredResponseKey = ResponseKey.required<String>("world")
+        val requiredResponseKey = ResponseKey.of<String>("world")
         assertThat(
             { requiredResponseKey(response) },
             throws(lensFailureWith<Response>(Missing(requiredResponseKey.meta), overallType = Failure.Type.Missing))
@@ -39,25 +39,46 @@ class ResponseKeyTest {
     @Test
     fun `optional value missing`() {
         val optionalResponseKey = ResponseKey.optional<String>("world")
+        assertThat(optionalResponseKey(Response(OK)), absent())
+    }
+
+    @Test
+    fun `required value missing - plain response`() {
+        val requiredResponseKey = ResponseKey.of<String>("world")
+        assertThat(
+            { requiredResponseKey(Response(OK)) },
+            throws(lensFailureWith<Response>(Missing(requiredResponseKey.meta), overallType = Failure.Type.Missing))
+        )
+    }
+
+    @Test
+    fun `optional value missing - plain response`() {
+        val optionalResponseKey = ResponseKey.optional<String>("world")
         assertThat(optionalResponseKey(response), absent())
     }
 
     @Test
     fun `sets value on response`() {
-        val requiredKey = ResponseKey.required<String>("bob")
+        val requiredKey = ResponseKey.of<String>("bob")
         assertThat(requiredKey(response.with(requiredKey of "hello")), equalTo("hello"))
 
         val optionalKey = ResponseKey.optional<String>("bob")
-        assertThat(optionalKey(response.with(requiredKey of "hello")), equalTo("hello"))
+        assertThat(optionalKey(response.with(optionalKey of "hello")), equalTo("hello"))
+    }
+
+    @Test
+    fun `sets null value on response`() {
+        val optionalKey = ResponseKey.optional<String>("hello")
+        assertThat(optionalKey(response.with(optionalKey of null)), equalTo(null))
     }
 
     @Test
     fun `required context value makes it through routing`() {
         val app: HttpHandler =
-            routes("" bind GET to { req: Request -> Response(OK).with(ResponseKey.required<String>("foo") of "bar") })
+            routes("" bind GET to { req: Request -> Response(OK).with(ResponseKey.of<String>("foo") of "bar") })
         val resp = Filter { next ->
             {
-                next(it).let { it.body(ResponseKey.required<String>("foo")(it)) }
+                next(it).let { it.body(ResponseKey.of<String>("foo")(it)) }
             }
         }.then(app)(Request(GET, ""))
 

--- a/core/core/src/test/kotlin/org/http4k/lens/ResponseKeyTest.kt
+++ b/core/core/src/test/kotlin/org/http4k/lens/ResponseKeyTest.kt
@@ -1,5 +1,6 @@
 package org.http4k.lens
 
+import com.natpryce.hamkrest.absent
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import com.natpryce.hamkrest.throws
@@ -22,12 +23,13 @@ class ResponseKeyTest {
 
     @Test
     fun `value present`() {
-        assertThat(ResponseKey.of<String>("hello")(response), equalTo("world"))
+        assertThat(ResponseKey.required<String>("hello")(response), equalTo("world"))
+        assertThat(ResponseKey.optional<String>("hello")(response), equalTo("world"))
     }
 
     @Test
-    fun `value missing`() {
-        val requiredResponseKey = ResponseKey.of<String>("world")
+    fun `required value missing`() {
+        val requiredResponseKey = ResponseKey.required<String>("world")
         assertThat(
             { requiredResponseKey(response) },
             throws(lensFailureWith<Response>(Missing(requiredResponseKey.meta), overallType = Failure.Type.Missing))
@@ -35,19 +37,40 @@ class ResponseKeyTest {
     }
 
     @Test
-    fun `sets value on response`() {
-        val key = ResponseKey.of<String>("bob")
-        val withResponseKey = response.with(key of "hello")
-        assertThat(key(withResponseKey), equalTo("hello"))
+    fun `optional value missing`() {
+        val optionalResponseKey = ResponseKey.optional<String>("world")
+        assertThat(optionalResponseKey(response), absent())
     }
 
     @Test
-    fun `context value makes it through routing`() {
+    fun `sets value on response`() {
+        val requiredKey = ResponseKey.required<String>("bob")
+        assertThat(requiredKey(response.with(requiredKey of "hello")), equalTo("hello"))
+
+        val optionalKey = ResponseKey.optional<String>("bob")
+        assertThat(optionalKey(response.with(requiredKey of "hello")), equalTo("hello"))
+    }
+
+    @Test
+    fun `required context value makes it through routing`() {
         val app: HttpHandler =
-            routes("" bind GET to { req: Request -> Response(OK).with(ResponseKey.of<String>("foo") of "bar") })
+            routes("" bind GET to { req: Request -> Response(OK).with(ResponseKey.required<String>("foo") of "bar") })
         val resp = Filter { next ->
             {
-                next(it).let { it.body(ResponseKey.of<String>("foo")(it)) }
+                next(it).let { it.body(ResponseKey.required<String>("foo")(it)) }
+            }
+        }.then(app)(Request(GET, ""))
+
+        assertThat(resp.bodyString(), equalTo("bar"))
+    }
+
+    @Test
+    fun `optional context value makes it through routing`() {
+        val app: HttpHandler =
+            routes("" bind GET to { req: Request -> Response(OK).with(ResponseKey.optional<String>("foo") of "bar") })
+        val resp = Filter { next ->
+            {
+                next(it).let { it.body(ResponseKey.optional<String>("foo")(it)!!) }
             }
         }.then(app)(Request(GET, ""))
 


### PR DESCRIPTION
<!-- Love http4k? Please consider sponsoring the project: 👉  https://github.com/sponsors/http4k -->

- [x] I have signed off all my commits (`git commit -s`) - see [CONTRIBUTING.md](../CONTRIBUTING.md#developer-certificate-of-origin-dco)


Introduces support for optional response lenses, while updating ResponseKey naming conventions to align with RequestKey.

Key Changes:

- Added ResponseKey.optional<T>(name): Enables creation of optional ResponseLens, returning null when a key is missing instead of throwing a LensFailure.

- Renamed ResponseKey.of to ResponseKey.required: Aligned mandatory ResponseLens<T> creation with RequestKey naming conventions.

- Deprecated ResponseKey.of: Preserved for backward compatibility by delegating directly to ResponseKey.required

Example Use Case: 

```
val lensFailureLens = ResponseKey.optional<LensFailure>("lens-failure")


class CustomErrorResponseRenderer : ErrorResponseRenderer {
    override fun badRequest(lensFailure: LensFailure): Response =
        Response(BAD_REQUEST).with(lensFailureLens of lensFailure)
}

val reportFilter = ResponseFilters.ReportHttpTransaction { transaction ->
    val lensFailure = lensFailureLens(transaction.response)
    if (lensFailure != null) {
        println("Request failed due to lens failure: $lensFailure")
    }
}
```